### PR TITLE
 disable zookeeper, expose kafka options for configuration from client

### DIFF
--- a/lib/stove-testing-e2e-kafka/src/test/kotlin/com/trendyol/stove/testing/e2e/standalone/kafka/tests/KafkaSystemTests.kt
+++ b/lib/stove-testing-e2e-kafka/src/test/kotlin/com/trendyol/stove/testing/e2e/standalone/kafka/tests/KafkaSystemTests.kt
@@ -8,7 +8,7 @@ import io.kotest.core.spec.style.FunSpec
 
 class KafkaSystemTests : FunSpec({
 
-    xtest("When publish then it should work") {
+    test("When publish then it should work") {
         TestSystem.validate {
             kafka {
                 publish("product", ProductCreated("1"))
@@ -20,7 +20,7 @@ class KafkaSystemTests : FunSpec({
         // delay(5000)
     }
 
-    xtest("When publish to a failing consumer should end-up throwing exception") {
+    test("When publish to a failing consumer should end-up throwing exception") {
         TestSystem.validate {
             kafka {
                 publish("productFailing", ProductFailingCreated("1"))


### PR DESCRIPTION
- disable zookeeper by default
- expose kafka container options for configuration from client