### PR TITLE
breaking: move baseUrl to httpClient system options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ kotlin-ide/
 
 # Ignore Gradle build output directory
 build
+.kotlin

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Frameworks:
 ### Setting-up all the physical dependencies with application
 
 ```kotlin
-TestSystem(baseUrl = "http://localhost:8001") {
+TestSystem() {
     if (isRunningLocally()) {
         enableReuseForTestContainers()
         keepDendenciesRunning() // this will keep the dependencies running after the tests are finished, so next run will be blazing fast :)
@@ -50,7 +50,11 @@ TestSystem(baseUrl = "http://localhost:8001") {
     // Enables http client 
     // to make real http calls 
     // against the application under test
-    http()
+    httpClient {
+        HttpClientSystemOptions(
+          baseUrl = "http://localhost:8001",
+        )
+    }
 
     // Enables Couchbase physically 
     // and exposes the configuration 

--- a/docs/how-to-write-tests/1.Application-Aware/1.Spring-Boot/0002-initial-configuration.md
+++ b/docs/how-to-write-tests/1.Application-Aware/1.Spring-Boot/0002-initial-configuration.md
@@ -17,9 +17,13 @@ it is time to run your application for the first time from the test-context with
     class TestSystemConfig : AbstractProjectConfig() {
     
         override suspend fun beforeProject(): Unit = 
-            TestSystem(baseUrl = "http://localhost:8001")
+            TestSystem()
                 .with {
-                    httpClient()
+                    httpClient {
+                        HttpClientSystemOptions {
+                            baseUrl = "http://localhost:8001"
+                        }
+                    }
                     springBoot(
                         runner = { parameters ->
                             /* 
@@ -49,9 +53,13 @@ it is time to run your application for the first time from the test-context with
     
         @BeforeAll
         fun beforeProject() = runBlocking {
-             TestSystem(baseUrl = "http://localhost:8001")
+             TestSystem()
                 .with {
-                    httpClient()
+                    httpClient {
+                        HttpClientSystemOptions {
+                            baseUrl = "http://localhost:8001"
+                        }
+                    }
                     springBoot(
                         runner = { parameters ->
                             /* 

--- a/docs/how-to-write-tests/1.Application-Aware/2.Ktor/index.md
+++ b/docs/how-to-write-tests/1.Application-Aware/2.Ktor/index.md
@@ -25,9 +25,13 @@
 ## Example Setup
 
 ```kotlin
-TestSystem(baseUrl = "http://localhost:8080")
+TestSystem()
     .with {
-        httpClient()
+        httpClient {
+          HttpClientSystemOptions {
+              baseUrl = "http://localhost:8080"
+          }
+        }
         bridge()
         postgresql {
             PostgresqlOptions(configureExposedConfiguration = { cfg ->

--- a/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/TestSystemConfig.kt
+++ b/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/TestSystemConfig.kt
@@ -2,7 +2,7 @@ package com.stove.ktor.example.e2e
 
 import com.trendol.stove.testing.e2e.rdbms.postgres.*
 import com.trendyol.stove.testing.e2e.*
-import com.trendyol.stove.testing.e2e.http.httpClient
+import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.system.*
 import com.trendyol.stove.testing.e2e.system.abstractions.*
@@ -31,57 +31,59 @@ class GitlabStateStorageFactory : StateStorageFactory {
 class TestSystemConfig : AbstractProjectConfig() {
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
-  override suspend fun beforeProject() =
-    TestSystem(baseUrl = "http://localhost:8080") {
-//      this.stateStorage(GitlabStateStorageFactory())
-      if (this.isRunningLocally()) {
-        enableReuseForTestContainers()
-        keepDependenciesRunning()
-      }
-    }.with {
-      httpClient()
-      bridge()
-      postgresql {
-        PostgresqlOptions(configureExposedConfiguration = { cfg ->
-          listOf(
-            "database.jdbcUrl=${cfg.jdbcUrl}",
-            "database.host=${cfg.host}",
-            "database.port=${cfg.port}",
-            "database.name=${cfg.database}",
-            "database.username=${cfg.username}",
-            "database.password=${cfg.password}"
-          )
-        })
-      }
-      kafka {
-        stoveKafkaObjectMapperRef = objectMapperRef
-        KafkaSystemOptions {
-          listOf(
-            "kafka.bootstrapServers=${it.bootstrapServers}",
-            "kafka.interceptorClasses=${it.interceptorClass}"
-          )
-        }
-      }
-      wiremock {
-        WireMockSystemOptions(
-          port = 9090,
-          removeStubAfterRequestMatched = true,
-          afterRequest = { e, _ ->
-            logger.info(e.request.toString())
-          }
+  override suspend fun beforeProject() = TestSystem {
+    if (this.isRunningLocally()) {
+      enableReuseForTestContainers()
+      keepDependenciesRunning()
+    }
+  }.with {
+    httpClient {
+      HttpClientSystemOptions(
+        baseUrl = "http://localhost:8080"
+      )
+    }
+    bridge()
+    postgresql {
+      PostgresqlOptions(configureExposedConfiguration = { cfg ->
+        listOf(
+          "database.jdbcUrl=${cfg.jdbcUrl}",
+          "database.host=${cfg.host}",
+          "database.port=${cfg.port}",
+          "database.name=${cfg.database}",
+          "database.username=${cfg.username}",
+          "database.password=${cfg.password}"
+        )
+      })
+    }
+    kafka {
+      stoveKafkaObjectMapperRef = objectMapperRef
+      KafkaSystemOptions {
+        listOf(
+          "kafka.bootstrapServers=${it.bootstrapServers}",
+          "kafka.interceptorClasses=${it.interceptorClass}"
         )
       }
-      ktor(
-        withParameters = listOf(
-          "port=8080"
-        ),
-        runner = { parameters ->
-          stove.ktor.example.run(parameters) {
-            addTestSystemDependencies()
-          }
+    }
+    wiremock {
+      WireMockSystemOptions(
+        port = 9090,
+        removeStubAfterRequestMatched = true,
+        afterRequest = { e, _ ->
+          logger.info(e.request.toString())
         }
       )
-    }.run()
+    }
+    ktor(
+      withParameters = listOf(
+        "port=8080"
+      ),
+      runner = { parameters ->
+        stove.ktor.example.run(parameters) {
+          addTestSystemDependencies()
+        }
+      }
+    )
+  }.run()
 
   override suspend fun afterProject() {
     TestSystem.stop()

--- a/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/TestSystemConfig.kt
+++ b/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/TestSystemConfig.kt
@@ -2,7 +2,7 @@ package com.stove.spring.example.e2e
 
 import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.couchbase.*
-import com.trendyol.stove.testing.e2e.http.httpClient
+import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.kafka.*
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.wiremock.*
@@ -12,10 +12,15 @@ import org.slf4j.*
 class TestSystemConfig : AbstractProjectConfig() {
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
+  @Suppress("LongMethod")
   override suspend fun beforeProject(): Unit =
-    TestSystem(baseUrl = "http://localhost:8001")
+    TestSystem()
       .with {
-        httpClient()
+        httpClient {
+          HttpClientSystemOptions(
+            baseUrl = "http://localhost:8001"
+          )
+        }
         couchbase {
           CouchbaseSystemOptions(
             "Stove",

--- a/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/TestSystemConfig.kt
+++ b/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/TestSystemConfig.kt
@@ -2,7 +2,7 @@ package com.stove.spring.standalone.example.e2e
 
 import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.couchbase.*
-import com.trendyol.stove.testing.e2e.http.httpClient
+import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.wiremock.*
@@ -13,10 +13,15 @@ import stove.spring.standalone.example.infrastructure.ObjectMapperConfig
 class TestSystemConfig : AbstractProjectConfig() {
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
+  @Suppress("LongMethod")
   override suspend fun beforeProject(): Unit =
-    TestSystem(baseUrl = "http://localhost:8001")
+    TestSystem()
       .with {
-        httpClient()
+        httpClient {
+          HttpClientSystemOptions(
+            baseUrl = "http://localhost:8001"
+          )
+        }
         couchbase {
           CouchbaseSystemOptions(
             "Stove",

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,5 @@ projectUrl=https://github.com/Trendyol/stove
 licenceUrl=https://github.com/Trendyol/stove/blob/master/LICENCE
 licence=Apache-2.0 license
 snapshot=1.0.0-SNAPSHOT
+kotlin.daemon.jvmargs=-Xmx1536m
 

--- a/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
+++ b/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
@@ -25,10 +25,11 @@ class NoApplication : ApplicationUnderTest<Unit> {
 
 class TestConfig : AbstractProjectConfig() {
   override suspend fun beforeProject(): Unit =
-    TestSystem("http://localhost:8086")
+    TestSystem()
       .with {
         httpClient {
           HttpClientSystemOptions(
+            baseUrl = "http://localhost:8086",
             objectMapper = StoveObjectMapper.byConfiguring {
               findAndRegisterModules()
             }


### PR DESCRIPTION
As it is not directly related with TestSytem, and main usage of base URL is scoped inside the `httpClient` validation dsl.