### PR TITLE
fix :: stove setup example syntax err

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -472,9 +472,9 @@ it is time to run your application for the first time from the test-context with
             TestSystem()
                 .with {
                     httpClient {
-                        HttpClientSystemOptions {
+                        HttpClientSystemOptions (
                             baseUrl = "http://localhost:8001"
-                        }
+                        )
                     }
                     springBoot(
                         runner = { parameters ->
@@ -508,9 +508,9 @@ it is time to run your application for the first time from the test-context with
              TestSystem()
                 .with {
                     httpClient {
-                        HttpClientSystemOptions {
+                        HttpClientSystemOptions (
                             baseUrl = "http://localhost:8001"
-                        }
+                        )
                     }
                     springBoot(
                         runner = { parameters ->


### PR DESCRIPTION
there is a syntax error at ["setting up stove for the runner"](https://trendyol.github.io/stove/#setting-up-stove-for-the-runner) part in docs 