### PR TITLE
feat(wiremock): add partial body matching for POST/PUT/PATCH requests…

### DIFF
--- a/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
+++ b/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
@@ -285,6 +285,93 @@ class HttpSystemTests :
       }
     }
 
+    test("should match POST request with partial body containing specific fields") {
+      val aUniqueIdentifierForTest = 123
+      val aProductCategoryForTest = "food"
+      val expectedPostDtoName = UUID.randomUUID().toString()
+
+      TestSystem.validate {
+        wiremock {
+          mockPostRequestContaining(
+            url = "/post-with-request-containing",
+            requestContaining = mapOf("productId" to aUniqueIdentifierForTest),
+            statusCode = 200,
+            responseBody = TestDto(expectedPostDtoName).some()
+          )
+        }
+
+        http {
+          postAndExpectBody<TestDto>(
+            uri = "/post-with-request-containing",
+            body = mapOf(
+              "productId" to aUniqueIdentifierForTest,
+              "productCategory" to aProductCategoryForTest
+            ).some()
+          ) { actual ->
+            actual.body().name shouldBe expectedPostDtoName
+          }
+        }
+      }
+    }
+
+    test("should match PUT request with partial body containing specific fields") {
+      val aUniqueIdentifierForTest = 123
+      val aProductCategoryForTest = "food"
+      val expectedPutDtoName = UUID.randomUUID().toString()
+
+      TestSystem.validate {
+        wiremock {
+          mockPutRequestContaining(
+            url = "/put-with-request-containing",
+            requestContaining = mapOf("productId" to aUniqueIdentifierForTest),
+            statusCode = 200,
+            responseBody = TestDto(expectedPutDtoName).some()
+          )
+        }
+
+        http {
+          putAndExpectBody<TestDto>(
+            uri = "/put-with-request-containing",
+            body = mapOf(
+              "productId" to aUniqueIdentifierForTest,
+              "productCategory" to aProductCategoryForTest
+            ).some()
+          ) { actual ->
+            actual.body().name shouldBe expectedPutDtoName
+          }
+        }
+      }
+    }
+
+    test("should match PATCH request with partial body containing specific fields") {
+      val aUniqueIdentifierForTest = 123
+      val aProductCategoryForTest = "food"
+      val expectedPatchDtoName = UUID.randomUUID().toString()
+
+      TestSystem.validate {
+        wiremock {
+          mockPatchRequestContaining(
+            url = "/patch-with-request-containing",
+            requestContaining = mapOf("productId" to aUniqueIdentifierForTest),
+            statusCode = 200,
+            responseBody = TestDto(expectedPatchDtoName).some()
+          )
+        }
+
+        http {
+          patchAndExpectBody<TestDto>(
+            uri = "/patch-with-request-containing",
+            body = mapOf(
+              "productId" to aUniqueIdentifierForTest,
+              "productCategory" to aProductCategoryForTest
+            ).some()
+          ) { actual ->
+            actual.body().name shouldBe expectedPatchDtoName
+          }
+        }
+      }
+    }
+
     test("java time instant should work") {
       val expectedGetDtoName = UUID.randomUUID().toString()
       TestSystem.validate {

--- a/lib/stove-testing-e2e-wiremock/src/main/kotlin/com/trendyol/stove/testing/e2e/wiremock/WireMockSystem.kt
+++ b/lib/stove-testing-e2e-wiremock/src/main/kotlin/com/trendyol/stove/testing/e2e/wiremock/WireMockSystem.kt
@@ -219,6 +219,84 @@ class WireMockSystem(
   }
 
   @WiremockDsl
+  fun mockPostRequestContaining(
+    url: String,
+    requestContaining: Map<String, Any>,
+    statusCode: Int = 200,
+    responseBody: Option<Any> = None,
+    urlPatternFn: (url: String) -> UrlPattern = { urlEqualTo(it) }
+  ): WireMockSystem = mockPostConfigure(url, urlPatternFn) { builder, serde ->
+
+    requestContaining.forEach { (key, value) ->
+      builder.withRequestBody(
+        matchingJsonPath(
+          "$.$key",
+          equalToJson(String(serde.serialize(value)))
+        )
+      )
+    }
+
+    val response = aResponse()
+      .withStatus(statusCode)
+      .withHeader("Content-Type", "application/json; charset=UTF-8")
+      .also { rb -> responseBody.map { rb.withBody(serde.serialize(it)) } }
+
+    builder.willReturn(response)
+  }
+
+  @WiremockDsl
+  fun mockPutRequestContaining(
+    url: String,
+    requestContaining: Map<String, Any>,
+    statusCode: Int = 200,
+    responseBody: Option<Any> = None,
+    urlPatternFn: (url: String) -> UrlPattern = { urlEqualTo(it) }
+  ): WireMockSystem = mockPutConfigure(url, urlPatternFn) { builder, serde ->
+
+    requestContaining.forEach { (key, value) ->
+      builder.withRequestBody(
+        matchingJsonPath(
+          "$.$key",
+          equalToJson(String(serde.serialize(value)))
+        )
+      )
+    }
+
+    val response = aResponse()
+      .withStatus(statusCode)
+      .withHeader("Content-Type", "application/json; charset=UTF-8")
+      .also { rb -> responseBody.map { rb.withBody(serde.serialize(it)) } }
+
+    builder.willReturn(response)
+  }
+
+  @WiremockDsl
+  fun mockPatchRequestContaining(
+    url: String,
+    requestContaining: Map<String, Any>,
+    statusCode: Int = 200,
+    responseBody: Option<Any> = None,
+    urlPatternFn: (url: String) -> UrlPattern = { urlEqualTo(it) }
+  ): WireMockSystem = mockPatchConfigure(url, urlPatternFn) { builder, serde ->
+
+    requestContaining.forEach { (key, value) ->
+      builder.withRequestBody(
+        matchingJsonPath(
+          "$.$key",
+          equalToJson(String(serde.serialize(value)))
+        )
+      )
+    }
+
+    val response = aResponse()
+      .withStatus(statusCode)
+      .withHeader("Content-Type", "application/json; charset=UTF-8")
+      .also { rb -> responseBody.map { rb.withBody(serde.serialize(it)) } }
+
+    builder.willReturn(response)
+  }
+
+  @WiremockDsl
   fun behaviourFor(
     url: String,
     method: (String) -> MappingBuilder,


### PR DESCRIPTION
## Implementation Notes

**Approach difference from the original issue:**

Instead of using `containing()` with string manipulation (as suggested in #776), 
this implementation uses `matchingJsonPath` + `equalToJson` for better reliability.

**Why?**
- JSON-aware matching (structure, not strings)
- Handles nested objects and formatting variations
- Resilient to whitespace and key ordering
- String matching breaks with complex values

**Implementation:**
```kotlin
requestContaining.forEach { (key, value) ->
  builder.withRequestBody(
    matchingJsonPath("$.$key", equalToJson(String(serde.serialize(value))))
  )
}