### PR TITLE
feat: add reporting mechanism

### DIFF
--- a/docs/Components/13-reporting.md
+++ b/docs/Components/13-reporting.md
@@ -1,0 +1,303 @@
+# Reporting
+
+Stove provides a comprehensive reporting system that tracks all actions and assertions during test execution. When a test fails, you get detailed information about what happened, making debugging easier.
+
+## Features
+
+- **Automatic tracking** of all system interactions (HTTP, Kafka, database, etc.)
+- **Test failure enrichment** with detailed execution reports
+- **Multiple output formats** (console, JSON)
+- **Framework integration** with Kotest and JUnit
+
+## Quick Start
+
+### Kotest Integration
+
+Add the `StoveKotestExtension` to your project configuration:
+
+```kotlin
+class TestConfig : AbstractProjectConfig() {
+    override val extensions: List<Extension> = listOf(StoveKotestExtension())
+    
+    override suspend fun beforeProject() {
+        TestSystem()
+            .with {
+                // your configuration
+            }
+            .run()
+    }
+    
+    override suspend fun afterProject() {
+        TestSystem.stop()
+    }
+}
+```
+
+### JUnit Integration
+
+Add the `StoveJUnitExtension` to your test classes:
+
+```kotlin
+@ExtendWith(StoveJUnitExtension::class)
+class MyE2ETest {
+    // your tests
+}
+```
+
+## Configuration
+
+Configure reporting options in your `TestSystem` setup:
+
+```kotlin
+TestSystem {
+    reporting {
+        enabled()           // Enable reporting (default: true)
+        dumpOnFailure()     // Dump report when tests fail (default: true)
+        failureRenderer(PrettyConsoleRenderer)  // Set the renderer
+    }
+}.with {
+    // your configuration
+}.run()
+```
+
+Or use the direct methods:
+
+```kotlin
+TestSystem {
+    reportingEnabled(true)
+    dumpReportOnTestFailure(true)
+    failureRenderer(PrettyConsoleRenderer)
+}.with {
+    // your configuration
+}.run()
+```
+
+## What Gets Reported
+
+### Actions
+
+Every interaction with a Stove system is recorded:
+
+- **HTTP**: All requests and responses (GET, POST, PUT, DELETE, etc.)
+- **Kafka**: Message publishing, consumption, and failure assertions
+- **Database**: Queries, saves, deletes (Couchbase, PostgreSQL, MongoDB, etc.)
+- **WireMock**: Stub registrations and verifications
+- **gRPC**: Client connections and calls
+
+### Assertions
+
+Both successful and failed assertions are tracked:
+
+- Expected vs. actual values
+- Assertion descriptions
+- Error messages
+
+## Example Output
+
+When a test fails, you'll see output like this:
+
+```
+expected:<2> but was:<1>
+
+═══════════════════════════════════════════════════════════════════════════════
+                         STOVE EXECUTION REPORT
+═══════════════════════════════════════════════════════════════════════════════
+
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                           STOVE TEST REPORT                                  ║
+║ Test: ExampleTest::should save the product                                   ║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║ 14:47:38.215 ✓ PASSED [HTTP] POST /api/products                              ║
+║     Input: {"id":1234,"name":"Test Product"}                                 ║
+║     Output: 201 Created                                                      ║
+║                                                                              ║
+║ 14:47:38.341 ✗ FAILED [PostgreSQL] Query                                     ║
+║     Input: SELECT * FROM Products WHERE id=1234                              ║
+║     Output: 1 row(s) returned                                                ║
+║     Expected: 2                                                              ║
+║     Actual: 1                                                                ║
+║     Error: expected:<2> but was:<1>                                          ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Renderers
+
+Stove provides two built-in renderers:
+
+### PrettyConsoleRenderer (Default)
+
+Human-readable format with:
+
+- Colorized output (when terminal supports ANSI)
+- Box-drawing characters for structure
+- Timestamps for each action
+- Clear pass/fail indicators
+
+### JsonReportRenderer
+
+Machine-readable JSON format, useful for:
+
+- CI/CD integration
+- Log aggregation systems
+- Custom report processing
+
+```kotlin
+TestSystem {
+    failureRenderer(JsonReportRenderer)
+}
+```
+
+Example JSON output:
+
+```json
+{
+  "testId": "ExampleTest::should save the product",
+  "testName": "should save the product",
+  "entries": [
+    {
+      "type": "action",
+      "system": "HTTP",
+      "action": "POST /api/products",
+      "timestamp": "2025-01-05T14:47:38.215",
+      "result": "PASSED",
+      "input": {"id": 1234, "name": "Test Product"},
+      "output": "201 Created"
+    },
+    {
+      "type": "action_with_result",
+      "system": "PostgreSQL",
+      "action": "Query",
+      "timestamp": "2025-01-05T14:47:38.341",
+      "result": "FAILED",
+      "expected": 2,
+      "actual": 1,
+      "error": "expected:<2> but was:<1>"
+    }
+  ],
+  "summary": {
+    "totalActions": 2,
+    "totalAssertions": 0,
+    "passedAssertions": 0,
+    "failedAssertions": 1
+  }
+}
+```
+
+## System Snapshots
+
+Some systems provide state snapshots when tests fail, giving you visibility into the system's internal state:
+
+### Kafka Snapshot
+
+Shows all messages in the message store:
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║ ┌─ KAFKA ────────────────────────────────────────────────────────────────────║
+║                                                                              ║
+║   Consumed: 1                                                                ║
+║   Produced: 1                                                                ║
+║   Failed: 0                                                                  ║
+║                                                                              ║
+║   State Details:                                                             ║
+║     produced: 1 item(s)                                                      ║
+║       [0]                                                                    ║
+║         topic: product-events                                                ║
+║         key: 1234                                                            ║
+║         value: {"id":1234,"name":"Test Product"}                             ║
+║     consumed: 1 item(s)                                                      ║
+║       [0]                                                                    ║
+║         topic: product-events                                                ║
+║         value: {"id":1234,"name":"Test Product"}                             ║
+║     failed: 0 item(s)                                                        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### WireMock Snapshot
+
+Shows registered stubs and unmatched requests:
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║ ┌─ WIREMOCK ─────────────────────────────────────────────────────────────────║
+║                                                                              ║
+║   Registered stubs: 2                                                        ║
+║   Served requests: 1 (matched: 1)                                            ║
+║   Unmatched requests: 0                                                      ║
+║                                                                              ║
+║   State Details:                                                             ║
+║     registeredStubs: 2 item(s)                                               ║
+║     servedRequests: 1 item(s)                                                ║
+║     unmatchedRequests: 0 item(s)                                             ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Disabling Reporting
+
+If you need to disable reporting (e.g., for performance-sensitive test runs):
+
+```kotlin
+TestSystem {
+    reporting {
+        disabled()
+    }
+}
+```
+
+Or:
+
+```kotlin
+TestSystem {
+    reportingEnabled(false)
+}
+```
+
+## Best Practices
+
+### 1. Always Use the Extension
+
+Register `StoveKotestExtension` or `StoveJUnitExtension` in your test configuration to get automatic test context tracking and failure enrichment.
+
+### 2. Use Descriptive Actions
+
+When writing custom assertions, provide meaningful descriptions:
+
+```kotlin
+shouldQuery<Product>("SELECT * FROM products WHERE active = true") { products ->
+    products.size shouldBe expectedCount
+}
+```
+
+### 3. Review Reports on CI
+
+The JSON renderer is particularly useful for CI/CD pipelines. You can:
+
+- Parse the JSON output for custom reporting
+- Store reports as build artifacts
+- Integrate with test management tools
+
+## Troubleshooting
+
+### Reports Not Showing
+
+1. Ensure the extension is registered:
+   - Kotest: `override val extensions = listOf(StoveKotestExtension())`
+   - JUnit: `@ExtendWith(StoveJUnitExtension::class)`
+
+2. Check that reporting is enabled:
+   ```kotlin
+   TestSystem {
+       reportingEnabled(true)
+       dumpReportOnTestFailure(true)
+   }
+   ```
+
+3. Verify `TestSystem` is initialized before tests run
+
+### Truncated Output
+
+If output appears truncated in your console, try:
+
+- Using a wider terminal window
+- Switching to `JsonReportRenderer` for full output
+- Checking your logging configuration

--- a/docs/Components/index.md
+++ b/docs/Components/index.md
@@ -104,6 +104,7 @@ TestSystem.validate {
 | Component | Use Case |
 |-----------|----------|
 | [Bridge](10-bridge.md) | Access application beans and services directly |
+| [Reporting](13-reporting.md) | Detailed execution reports and failure diagnostics |
 
 ## Common Configuration Pattern
 
@@ -264,3 +265,4 @@ test("should process order end-to-end") {
 - [Redis](09-redis.md) - In-memory data store for caching
 - [Bridge](10-bridge.md) - Direct access to application beans
 - [Provided Instances](11-provided-instances.md) - Use external infrastructure
+- [Reporting](13-reporting.md) - Detailed execution reports and failure diagnostics

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,6 +148,8 @@ Set up Stove once for your entire test suite. We recommend using a dedicated `sr
     ```kotlin
     // src/test-e2e/kotlin/e2e/TestConfig.kt
     class TestConfig : AbstractProjectConfig() {
+        // Register StoveKotestExtension for detailed failure reports
+        override val extensions: List<Extension> = listOf(StoveKotestExtension())
         
         override suspend fun beforeProject() {
             TestSystem()
@@ -412,6 +414,7 @@ Or run specific test classes:
 ## Next Steps
 
 - Explore [Components](Components/index.md) documentation for each available component
+- Set up [Reporting](Components/13-reporting.md) for detailed failure diagnostics
 - Learn about [Best Practices](best-practices.md) for writing effective e2e tests
 - Check [Troubleshooting](troubleshooting.md) if you encounter issues
 - Browse [Examples](https://github.com/Trendyol/stove/tree/main/examples) for complete working projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -493,7 +493,10 @@ it is time to run your application for the first time from the test-context with
     wide operation and executes **only one time**, as the name implies `beforeProject`.
     
     ```kotlin
-    class Stove : AbstractProjectConfig() {    
+    class Stove : AbstractProjectConfig() {
+        // Register StoveKotestExtension for detailed failure reports
+        override val extensions: List<Extension> = listOf(StoveKotestExtension())
+            
         override suspend fun beforeProject(): Unit = 
             TestSystem()
                 .with {

--- a/docs/release-notes/0.20.0.md
+++ b/docs/release-notes/0.20.0.md
@@ -4,6 +4,7 @@
 
 This release introduces:
 
+- **Test Reporting System**: Comprehensive reporting that tracks all actions and assertions during test execution
 - **Spring Boot 4.x Support**: Full support for Spring Boot 4.x and Spring Kafka 4.x
 - **Unified Spring Modules**: Single modules that work across Spring Boot 2.x, 3.x, and 4.x
 - **New Bean Registration DSL**: `stoveSpring4xRegistrar` for Spring Boot 4.x (since `BeanDefinitionDsl` is deprecated)
@@ -14,6 +15,95 @@ This release introduces:
 ---
 
 ## New Features
+
+### Test Reporting System
+
+Stove now includes a built-in reporting system that captures everything that happens during your tests. When a test fails, you get a detailed report showing exactly what happened, making debugging much easier.
+
+**Key capabilities:**
+
+- **Automatic tracking** of all system interactions (HTTP, Kafka, database, WireMock, gRPC)
+- **Test failure enrichment** with detailed execution reports embedded in test output
+- **System snapshots** showing internal state (Kafka messages, WireMock stubs) at the time of failure
+- **Multiple renderers** - human-readable console output or machine-readable JSON
+- **Framework integration** with both Kotest and JUnit
+- **Stack trace preservation** - original stack traces are preserved in test failures
+
+#### Quick Start - Kotest
+
+```kotlin
+class TestConfig : AbstractProjectConfig() {
+    override val extensions: List<Extension> = listOf(StoveKotestExtension())
+    
+    override suspend fun beforeProject() {
+        TestSystem()
+            .with { /* your configuration */ }
+            .run()
+    }
+    
+    override suspend fun afterProject() {
+        TestSystem.stop()
+    }
+}
+```
+
+#### Quick Start - JUnit
+
+```kotlin
+@ExtendWith(StoveJUnitExtension::class)
+class MyE2ETest {
+    // your tests
+}
+```
+
+#### Configuration
+
+```kotlin
+TestSystem {
+    reporting {
+        enabled()           // Enable reporting (default: true)
+        dumpOnFailure()     // Dump report when tests fail (default: true)
+        failureRenderer(PrettyConsoleRenderer)  // Set the renderer
+    }
+}
+```
+
+#### Example Output
+
+When a test fails, you'll see output like:
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                           STOVE TEST EXECUTION REPORT                        ║
+║ Test: should save the product                                                ║
+║ Status: FAILED                                                               ║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║ 14:47:38.215 ✓ PASSED [HTTP] POST /api/products                              ║
+║     Input: {"id":1234,"name":"Test Product"}                                 ║
+║                                                                              ║
+║ 14:47:38.341 ✗ FAILED [Kafka] shouldBePublished<ProductCreatedEvent>         ║
+║     Expected: Message matching condition within 5s                           ║
+║     Actual: No matching message found                                        ║
+║     Error: GOT A TIMEOUT: While expecting the publish of 'ProductCreatedEvent'║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║ SYSTEM SNAPSHOTS                                                             ║
+║ ┌─ KAFKA ────────────────────────────────────────────────────────────────────║
+║   Consumed: 0                                                                ║
+║   Produced: 1                                                                ║
+║   State Details:                                                             ║
+║     produced: 1 item(s)                                                      ║
+║       [0] topic: product-events, value: {"id":1234,"name":"Test Product"}    ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+#### Available Renderers
+
+- **PrettyConsoleRenderer** (default) - Colorized, box-drawing output for terminals
+- **JsonReportRenderer** - Machine-readable JSON for CI/CD integration
+
+See the [Reporting documentation](../Components/13-reporting.md) for full details.
+
+---
 
 ### Spring Boot 4.x Support
 
@@ -234,9 +324,26 @@ When Spring Boot, Spring Kafka, or Ktor DI is missing from the classpath, Stove 
 
 ### From 0.19.x
 
+#### Add the Test Extension for Reporting
+
+To get the full benefit of the new reporting system, add the appropriate extension:
+
+**Kotest:**
+```kotlin
+class TestConfig : AbstractProjectConfig() {
+    override val extensions = listOf(StoveKotestExtension())
+}
+```
+
+**JUnit:**
+```kotlin
+@ExtendWith(StoveJUnitExtension::class)
+class MyE2ETest { }
+```
+
 #### For Spring Boot 2.x and 3.x Users
 
-**If using `BaseApplicationContextInitializer`:** Migrate to `addTestDependencies` (see Breaking Changes above).
+**If using `BaseApplicationContextInitializer`:** Migrate to `addTestDependencies` (see Breaking Changes below).
 
 **If using `beans { }` directly:** Your existing code continues to work. Optionally, use the new cleaner API:
 
@@ -271,9 +378,9 @@ Note: The `beans { }` DSL from Spring is deprecated in 4.x, which is why Stove p
 
 ---
 
-### Breaking Changes
+## Breaking Changes
 
-#### `BaseApplicationContextInitializer` Removed
+### `BaseApplicationContextInitializer` Removed
 
 `BaseApplicationContextInitializer` has been removed. Migrate to `addTestDependencies`:
 
@@ -308,9 +415,33 @@ This is simpler - no need to create a separate class.
 
 ---
 
-### Notes
+### HttpSystem: `getResponse` renamed to `getResponseBodiless`
 
-#### BridgeSystem API Enhancement
+The `getResponse` method in `HttpSystem` has been renamed to `getResponseBodiless` to better reflect its purpose - it returns a response without parsing the body.
+
+**Before:**
+```kotlin
+http {
+    getResponse("/api/endpoint") { response ->
+        response.status shouldBe 200
+    }
+}
+```
+
+**After:**
+```kotlin
+http {
+    getResponseBodiless("/api/endpoint") { response ->
+        response.status shouldBe 200
+    }
+}
+```
+
+---
+
+## Notes
+
+### BridgeSystem API Enhancement
 
 The `BridgeSystem` abstract class now has a new method `getByType(type: KType)` which is used by `resolve()` to support generic types. If you have a custom `BridgeSystem` implementation:
 
@@ -326,7 +457,7 @@ override fun <D : Any> getByType(type: KType): D {
 }
 ```
 
-#### Dead Letter Topic Naming Convention (Spring Kafka)
+### Dead Letter Topic Naming Convention (Spring Kafka)
 
 Be aware that Spring Kafka changed the default DLT (Dead Letter Topic) naming convention between versions:
 
@@ -336,6 +467,16 @@ Be aware that Spring Kafka changed the default DLT (Dead Letter Topic) naming co
 | 3.x, 4.x | `-dlt` | `my-topic-dlt` |
 
 This is not a Stove change, but something to be aware of when writing Kafka tests across different Spring Kafka versions.
+
+### Optional: Disable Reporting
+
+If you don't want the new reporting feature (not recommended), you can disable it:
+
+```kotlin
+TestSystem {
+    reportingEnabled(false)
+}
+```
 
 ---
 

--- a/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/ExampleTest.kt
+++ b/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/ExampleTest.kt
@@ -60,7 +60,7 @@ class ExampleTest :
         }
 
         kafka {
-          shouldBePublished<DomainEvents.ProductUpdated>(20.seconds) {
+          shouldBePublished<DomainEvents.ProductUpdated>(5.seconds) {
             actual.id == givenId && actual.name == givenName
           }
           shouldBeConsumed<DomainEvents.ProductUpdated>(20.seconds) {

--- a/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/Stove.kt
+++ b/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/Stove.kt
@@ -3,10 +3,12 @@ package com.stove.ktor.example.e2e
 import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.rdbms.postgres.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.serialization.StoveSerde
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.system.*
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import stove.ktor.example.app.objectMapperRef
 
 class Stove : AbstractProjectConfig() {
@@ -16,6 +18,8 @@ class Stove : AbstractProjectConfig() {
       System.setProperty(STOVE_KAFKA_BRIDGE_PORT, stoveKafkaBridgePortDefault)
     }
   }
+
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
 
   override suspend fun beforeProject() = TestSystem()
     .with {

--- a/examples/micronaut-example/src/test/kotlin/com/stove/micronaut/example/e2e/Stove.kt
+++ b/examples/micronaut-example/src/test/kotlin/com/stove/micronaut/example/e2e/Stove.kt
@@ -3,12 +3,16 @@ package com.stove.micronaut.example.e2e
 import com.trendyol.stove.testing.*
 import com.trendyol.stove.testing.e2e.couchbase.*
 import com.trendyol.stove.testing.e2e.http.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
   @Suppress("LongMethod")

--- a/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/Stove.kt
+++ b/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/Stove.kt
@@ -3,13 +3,17 @@ package com.stove.spring.example4x.e2e
 import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.kafka.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 import tools.jackson.databind.json.JsonMapper
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
   override suspend fun beforeProject(): Unit =

--- a/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/Stove.kt
+++ b/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/Stove.kt
@@ -4,12 +4,16 @@ import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.couchbase.*
 import com.trendyol.stove.testing.e2e.http.*
 import com.trendyol.stove.testing.e2e.kafka.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val logger: Logger = LoggerFactory.getLogger("WireMockMonitor")
 
   @Suppress("LongMethod")

--- a/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/ReportingIntegrationTest.kt
+++ b/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/ReportingIntegrationTest.kt
@@ -1,0 +1,199 @@
+package com.stove.spring.standalone.example.e2e
+
+import arrow.core.some
+import com.trendyol.stove.testing.e2e.couchbase.couchbase
+import com.trendyol.stove.testing.e2e.http.http
+import com.trendyol.stove.testing.e2e.reporting.*
+import com.trendyol.stove.testing.e2e.standalone.kafka.*
+import com.trendyol.stove.testing.e2e.system.TestSystem
+import com.trendyol.stove.testing.e2e.wiremock.wiremock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.*
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.string.shouldContain
+import stove.spring.standalone.example.application.handlers.*
+import stove.spring.standalone.example.application.services.SupplierPermission
+import kotlin.time.Duration.Companion.seconds
+
+class ReportingIntegrationTest :
+  FunSpec({
+    test("report should capture HTTP and Kafka operations") {
+      TestSystem.validate {
+        val request = ProductCreateRequest(100L, "test product", 1L)
+        val permission = SupplierPermission(request.supplierId, isAllowed = true)
+
+        wiremock {
+          mockGet("/suppliers/${permission.id}/allowed", 200, permission.some())
+        }
+
+        http {
+          postAndExpectBodilessResponse("/api/product/create", request.some()) {
+            it.status shouldBe 200
+          }
+        }
+
+        kafka {
+          shouldBePublished<ProductCreatedEvent> {
+            actual.id == request.id
+          }
+        }
+      }
+
+      // Validate the report contents
+      val report = TestSystem.reporter().currentTest()
+
+      // Should have WireMock stub action
+      report
+        .entries()
+        .filterIsInstance<ActionEntry>()
+        .any { it.system == "WireMock" && it.action.contains("GET /suppliers") } shouldBe true
+
+      // Should have HTTP action
+      report
+        .entries()
+        .filterIsInstance<ActionEntry>()
+        .any { it.system == "HTTP" && it.action.contains("POST /api/product") } shouldBe true
+
+      // Should have Kafka assertion
+      report
+        .entries()
+        .filterIsInstance<AssertionEntry>()
+        .any { it.system == "Kafka" && it.description.contains("shouldBePublished") } shouldBe true
+    }
+
+    test("report should include Kafka MessageStore snapshot on failure") {
+      try {
+        TestSystem.validate {
+          kafka {
+            publish("orders.test", mapOf("id" to 1))
+
+            // This will fail - no consumer for this topic
+            shouldBePublished<Map<String, Any>>(atLeastIn = 1.seconds) {
+              actual["nonexistent"] == true
+            }
+          }
+        }
+      } catch (_: Throwable) {
+        // Expected - can be TimeoutCancellationException, AssertionError, or wrapped exception
+      }
+
+      // Get the snapshot
+      val snapshot = TestSystem.getSystem<KafkaSystem>(KafkaSystem::class).snapshot()
+      snapshot shouldNotBe null
+      snapshot.system shouldBe "Kafka"
+      (snapshot.state["published"] as? List<*>)?.size?.shouldBeGreaterThan(0)
+    }
+
+    test("report should capture Couchbase operations") {
+      TestSystem.validate {
+        val request = ProductCreateRequest(200L, "couchbase test", 1L)
+        val permission = SupplierPermission(request.supplierId, isAllowed = true)
+
+        wiremock {
+          mockGet("/suppliers/${permission.id}/allowed", 200, permission.some())
+        }
+
+        http {
+          postAndExpectBodilessResponse("/api/product/create", request.some()) {
+            it.status shouldBe 200
+          }
+        }
+
+        couchbase {
+          shouldGet<ProductCreateRequest>("product:${request.id}") {
+            it.id shouldBe request.id
+          }
+        }
+      }
+
+      val report = TestSystem.reporter().currentTest()
+
+      // Should have Couchbase combined action with result
+      report
+        .entries()
+        .filterIsInstance<ActionEntry>()
+        .any { it.system == "Couchbase" && it.action.contains("Get document") && it.result != null } shouldBe true
+    }
+
+    test("report should capture multiple system interactions") {
+      TestSystem.validate {
+        val request = ProductCreateRequest(300L, "multi-system test", 1L)
+        val permission = SupplierPermission(request.supplierId, isAllowed = true)
+
+        // WireMock
+        wiremock {
+          mockGet("/suppliers/${permission.id}/allowed", 200, permission.some())
+        }
+
+        // HTTP
+        http {
+          postAndExpectBodilessResponse("/api/product/create", request.some()) {
+            it.status shouldBe 200
+          }
+        }
+
+        // Kafka
+        kafka {
+          shouldBePublished<ProductCreatedEvent> {
+            actual.id == request.id
+          }
+        }
+
+        // Couchbase
+        couchbase {
+          shouldGet<ProductCreateRequest>("product:${request.id}") {
+            it.id shouldBe request.id
+          }
+        }
+      }
+
+      val report = TestSystem.reporter().currentTest()
+      // Use entriesForThisTest() to filter only entries for this specific test
+      val entries = report.entriesForThisTest()
+
+      // Should have entries from all systems
+      // Note: Systems using recordActionWithResult create a single combined entry
+      entries.filter { it.system == "WireMock" } shouldHaveSize 1
+      entries.filter { it.system == "HTTP" } shouldHaveSize 1 // Combined action with result
+      entries.filter { it.system == "Kafka" } shouldHaveSize 1
+      entries.filter { it.system == "Couchbase" } shouldHaveSize 1 // Combined action with result
+    }
+
+    test("report should be renderable as JSON") {
+      TestSystem.validate {
+        http {
+          get<String>("/api/index") {
+            it shouldContain "Hi from Stove framework"
+          }
+        }
+      }
+
+      val report = TestSystem.reporter().currentTest()
+      val json = JsonReportRenderer.render(report, emptyList())
+
+      json shouldContain "testId"
+      json shouldContain "testName"
+      json shouldContain "entries"
+      json shouldContain "summary"
+      json shouldContain "HTTP"
+    }
+
+    test("report should be renderable as pretty console") {
+      TestSystem.validate {
+        http {
+          get<String>("/api/index") {
+            it shouldContain "Hi from Stove framework"
+          }
+        }
+      }
+
+      val report = TestSystem.reporter().currentTest()
+      val pretty = PrettyConsoleRenderer.render(report, emptyList())
+
+      pretty shouldContain "STOVE TEST EXECUTION REPORT"
+      pretty shouldContain "[HTTP]"
+      pretty shouldContain "╔"
+      pretty shouldContain "╚"
+    }
+  })

--- a/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/Stove.kt
+++ b/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/Stove.kt
@@ -3,11 +3,13 @@ package com.stove.spring.standalone.example.e2e
 import com.trendyol.stove.testing.e2e.*
 import com.trendyol.stove.testing.e2e.couchbase.*
 import com.trendyol.stove.testing.e2e.http.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.serialization.StoveSerde
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.system.*
 import com.trendyol.stove.testing.e2e.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 import stove.spring.standalone.example.infrastructure.ObjectMapperConfig
 
@@ -17,6 +19,8 @@ class Stove : AbstractProjectConfig() {
   init {
     stoveKafkaBridgePortDefault = PortFinder.findAvailablePortAsString()
   }
+
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
 
   @Suppress("LongMethod")
   override suspend fun beforeProject(): Unit =

--- a/examples/spring-streams-example/src/test/kotlin/com/stove/spring/streams/example/e2e/Stove.kt
+++ b/examples/spring-streams-example/src/test/kotlin/com/stove/spring/streams/example/e2e/Stove.kt
@@ -4,13 +4,17 @@ import com.stove.spring.streams.example.e2e.ExampleTest.Companion.INPUT_TOPIC
 import com.stove.spring.streams.example.e2e.ExampleTest.Companion.INPUT_TOPIC2
 import com.stove.spring.streams.example.e2e.ExampleTest.Companion.OUTPUT_TOPIC
 import com.trendyol.stove.testing.e2e.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.system.*
 import com.trendyol.stove.testing.e2e.system.TestSystem.Companion.validate
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.apache.kafka.clients.admin.NewTopic
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   @Suppress("LongMethod")
   override suspend fun beforeProject(): Unit = TestSystem()
     .also {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ io-grpc = "1.78.0"
 io-grpc-kotlin = "1.5.0"
 google-protobuf = "4.33.2"
 hoplite = "2.9.0"
+junit-jupiter = "5.10.0"
 kotest = "6.0.7"
 mockito = "6.1.0"
 kotlinx-serialization = "1.9.0"
@@ -189,9 +190,10 @@ ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint
 # testing
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
-kotest-framework-engine = { module = "io.kotest:kotest-property", version.ref = "kotest" }
+kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 kotest-arrow = { module = "io.kotest.extensions:kotest-assertions-arrow", version = "2.0.0" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 
 [plugins]
 allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }

--- a/lib/stove-testing-e2e-couchbase/api/stove-testing-e2e-couchbase.api
+++ b/lib/stove-testing-e2e-couchbase/api/stove-testing-e2e-couchbase.api
@@ -57,7 +57,7 @@ public final class com/trendyol/stove/testing/e2e/couchbase/CouchbaseExposedConf
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem$Companion;
 	public field cluster Lcom/couchbase/client/kotlin/Cluster;
 	public field collection Lcom/couchbase/client/kotlin/Collection;
@@ -67,8 +67,14 @@ public final class com/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem : co
 	public final fun getCluster ()Lcom/couchbase/client/kotlin/Cluster;
 	public final fun getCollection ()Lcom/couchbase/client/kotlin/Collection;
 	public final fun getContext ()Lcom/trendyol/stove/testing/e2e/couchbase/CouchbaseContext;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setCluster (Lcom/couchbase/client/kotlin/Cluster;)V
 	public final fun setCollection (Lcom/couchbase/client/kotlin/Collection;)V
@@ -76,6 +82,7 @@ public final class com/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem : co
 	public final fun shouldDelete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldNotExist (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldNotExist (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/couchbase/CouchbaseSystem;

--- a/lib/stove-testing-e2e-couchbase/src/test/kotlin/com/trendyol/stove/testing/e2e/couchbase/TestSystemConfig.kt
+++ b/lib/stove-testing-e2e-couchbase/src/test/kotlin/com/trendyol/stove/testing/e2e/couchbase/TestSystemConfig.kt
@@ -3,9 +3,11 @@ package com.trendyol.stove.testing.e2e.couchbase
 import com.couchbase.client.kotlin.Cluster
 import com.trendyol.stove.testing.e2e.couchbase.CouchbaseSystem.Companion.bucket
 import com.trendyol.stove.testing.e2e.database.migrations.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 import org.testcontainers.couchbase.*
 import org.testcontainers.utility.DockerImageName
@@ -180,6 +182,8 @@ class ProvidedCouchbaseStrategy : CouchbaseTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = CouchbaseTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-elasticsearch/api/stove-testing-e2e-elasticsearch.api
+++ b/lib/stove-testing-e2e-elasticsearch/api/stove-testing-e2e-elasticsearch.api
@@ -99,7 +99,7 @@ public final class com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchExp
 	public final fun create ([B)Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchExposedCertificate;
 }
 
-public final class com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem : com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAware, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAware, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem$Companion;
 	public field esClient Lco/elastic/clients/elasticsearch/ElasticsearchClient;
 	public fun afterRun (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -107,13 +107,20 @@ public final class com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSys
 	public fun configuration ()Ljava/util/List;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getEsClient ()Lco/elastic/clients/elasticsearch/ElasticsearchClient;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun save (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem;
 	public final fun setEsClient (Lco/elastic/clients/elasticsearch/ElasticsearchClient;)V
 	public final fun shouldDelete (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem;
-	public final fun shouldNotExist (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem;
+	public final fun shouldNotExist (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchSystem;

--- a/lib/stove-testing-e2e-elasticsearch/src/test/kotlin/com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchTestSystemTests.kt
+++ b/lib/stove-testing-e2e-elasticsearch/src/test/kotlin/com/trendyol/stove/testing/e2e/elasticsearch/ElasticsearchTestSystemTests.kt
@@ -6,9 +6,11 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.trendyol.stove.testing.e2e.database.migrations.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.apache.http.HttpHost
@@ -176,6 +178,8 @@ class ProvidedElasticsearchStrategy : ElasticsearchTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = ElasticsearchTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-grpc/api/stove-testing-e2e-grpc.api
+++ b/lib/stove-testing-e2e-grpc/api/stove-testing-e2e-grpc.api
@@ -1,7 +1,7 @@
 public abstract interface annotation class com/trendyol/stove/testing/e2e/grpc/GrpcDsl : java/lang/annotation/Annotation {
 }
 
-public final class com/trendyol/stove/testing/e2e/grpc/GrpcSystem : com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
+public final class com/trendyol/stove/testing/e2e/grpc/GrpcSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystem$Companion;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystemOptions;)V
 	public final fun channelWithMetadata (Ljava/util/Map;)Lio/grpc/Channel;
@@ -9,12 +9,19 @@ public final class com/trendyol/stove/testing/e2e/grpc/GrpcSystem : com/trendyol
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGrpcChannel ()Lio/grpc/ManagedChannel;
 	public final fun getOptions ()Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystemOptions;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun getWireClientResources ()Lcom/trendyol/stove/testing/e2e/grpc/WireClientResources;
 	public final fun grpcClient ()Lcom/squareup/wire/GrpcClient;
 	public final fun managedChannel ()Lio/grpc/ManagedChannel;
 	public final fun rawChannel (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystem;
 	public final fun rawWireClient (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun withEndpoint (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/grpc/GrpcSystem;
 }

--- a/lib/stove-testing-e2e-grpc/src/test/kotlin/com/trendyol/stove/testing/e2e/grpc/Stove.kt
+++ b/lib/stove-testing-e2e-grpc/src/test/kotlin/com/trendyol/stove/testing/e2e/grpc/Stove.kt
@@ -1,8 +1,10 @@
 package com.trendyol.stove.testing.e2e.grpc
 
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 
 /**
  * Test application that wraps the [TestGrpcServer].
@@ -26,6 +28,8 @@ class TestGrpcApp(
 }
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject() {
     TestSystem()
       .with {

--- a/lib/stove-testing-e2e-http/api/stove-testing-e2e-http.api
+++ b/lib/stove-testing-e2e-http/api/stove-testing-e2e-http.api
@@ -27,7 +27,7 @@ public final class com/trendyol/stove/testing/e2e/http/HttpClientSystemOptions :
 public abstract interface annotation class com/trendyol/stove/testing/e2e/http/HttpDsl : java/lang/annotation/Annotation {
 }
 
-public final class com/trendyol/stove/testing/e2e/http/HttpSystem : com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
+public final class com/trendyol/stove/testing/e2e/http/HttpSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/http/HttpSystem$Companion;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/http/HttpClientSystemOptions;)V
 	public fun close ()V
@@ -37,17 +37,26 @@ public final class com/trendyol/stove/testing/e2e/http/HttpSystem : com/trendyol
 	public final fun executeWithBody (Lio/ktor/http/HttpMethod;Ljava/lang/String;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun get (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBodilessResponse (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getBodilessResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getKtorHttpClient ()Lio/ktor/client/HttpClient;
 	public final fun getOptions ()Lcom/trendyol/stove/testing/e2e/http/HttpClientSystemOptions;
-	public final fun getResponse (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Larrow/core/Option;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
+	public final fun headAndExpectBodilessResponse (Ljava/lang/String;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun headAndExpectBodilessResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun patchAndExpectBodilessResponse (Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun patchAndExpectBodilessResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun postAndExpectBodilessResponse (Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun postAndExpectBodilessResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun putAndExpectBodilessResponse (Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun putAndExpectBodilessResponse$default (Lcom/trendyol/stove/testing/e2e/http/HttpSystem;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun toBodilessResponse (Lio/ktor/client/statement/HttpResponse;)Lcom/trendyol/stove/testing/e2e/http/StoveHttpResponse$Bodiless;
 	public final fun toFormData (Ljava/util/List;)Ljava/util/List;

--- a/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
+++ b/lib/stove-testing-e2e-http/src/test/kotlin/com/trendyol/stove/testing/e2e/http/HttpSystemTests.kt
@@ -6,11 +6,13 @@ import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.matching.MultipartValuePattern
 import com.trendyol.stove.ConsoleSpec
 import com.trendyol.stove.testing.e2e.http.HttpSystem.Companion.client
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import com.trendyol.stove.testing.e2e.wiremock.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.*
 import io.kotest.matchers.string.shouldContain
@@ -31,6 +33,8 @@ class NoApplication : ApplicationUnderTest<Unit> {
 }
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {
@@ -176,7 +180,7 @@ class HttpSystemTests :
         }
 
         http {
-          getResponse("/get") { actual ->
+          getBodilessResponse("/get") { actual ->
             actual.status shouldBe 200
             actual::class shouldBe StoveHttpResponse.Bodiless::class
           }
@@ -348,7 +352,7 @@ class HttpSystemTests :
         }
 
         http {
-          this.getResponse("/get-behaviour") { actual ->
+          this.getResponse<Any>("/get-behaviour") { actual ->
             actual.status shouldBe 503
           }
 

--- a/lib/stove-testing-e2e-kafka/api/stove-testing-e2e-kafka.api
+++ b/lib/stove-testing-e2e-kafka/api/stove-testing-e2e-kafka.api
@@ -250,18 +250,21 @@ public final class com/trendyol/stove/testing/e2e/standalone/kafka/KafkaMigratio
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem : com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAware, com/trendyol/stove/testing/e2e/system/abstractions/BeforeRunAware, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAware, com/trendyol/stove/testing/e2e/system/abstractions/BeforeRunAware, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem$Companion;
 	public field sink Lcom/trendyol/stove/testing/e2e/standalone/kafka/intercepting/TestSystemMessageSink;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaContext;)V
 	public final fun adminOperations (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterRun (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun assertKafkaMessage-WPi__2c (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun beforeRun (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
 	public fun configuration ()Ljava/util/List;
 	public final fun consumer-IY8X1Ik (Ljava/lang/String;ZLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lorg/apache/kafka/common/serialization/Deserializer;Lorg/apache/kafka/common/serialization/Deserializer;JJLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun consumer-IY8X1Ik$default (Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem;Ljava/lang/String;ZLjava/lang/String;ZLkotlin/jvm/functions/Function1;Lorg/apache/kafka/common/serialization/Deserializer;Lorg/apache/kafka/common/serialization/Deserializer;JJLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public final fun getSink ()Lcom/trendyol/stove/testing/e2e/standalone/kafka/intercepting/TestSystemMessageSink;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun messageStore ()Lcom/trendyol/stove/testing/e2e/standalone/kafka/intercepting/MessageStore;
@@ -274,12 +277,17 @@ public final class com/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem :
 	public static synthetic fun peekPublishedMessages-rnQQ1Ag$default (Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun publish (Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun publish$default (Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setSink (Lcom/trendyol/stove/testing/e2e/standalone/kafka/intercepting/TestSystemMessageSink;)V
 	public final fun shouldBeConsumedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeFailedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBePublishedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeRetriedInternal-WPwdCS8 (Lkotlin/reflect/KClass;JILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/standalone/kafka/KafkaSystem;

--- a/lib/stove-testing-e2e-kafka/src/test/kotlin/com/trendyol/stove/testing/e2e/standalone/kafka/setup/TestSystemConfig.kt
+++ b/lib/stove-testing-e2e-kafka/src/test/kotlin/com/trendyol/stove/testing/e2e/standalone/kafka/setup/TestSystemConfig.kt
@@ -1,12 +1,14 @@
 package com.trendyol.stove.testing.e2e.standalone.kafka.setup
 
 import com.trendyol.stove.testing.e2e.database.migrations.DatabaseMigration
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.standalone.kafka.*
 import com.trendyol.stove.testing.e2e.standalone.kafka.setup.example.KafkaTestShared
 import com.trendyol.stove.testing.e2e.system.*
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.github.nomisRev.kafka.publisher.PublisherSettings
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.apache.kafka.clients.admin.*
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
@@ -276,6 +278,8 @@ private fun setupBridgePort() {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = KafkaTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-mongodb/api/stove-testing-e2e-mongodb.api
+++ b/lib/stove-testing-e2e-mongodb/api/stove-testing-e2e-mongodb.api
@@ -96,7 +96,7 @@ public final class com/trendyol/stove/testing/e2e/mongodb/MongodbMigrationContex
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/trendyol/stove/testing/e2e/mongodb/MongodbSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/mongodb/MongodbSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/mongodb/MongodbSystem$Companion;
 	public static final field RESERVED_ID Ljava/lang/String;
 	public field mongoClient Lcom/mongodb/kotlin/client/coroutine/MongoClient;
@@ -105,15 +105,22 @@ public final class com/trendyol/stove/testing/e2e/mongodb/MongodbSystem : com/tr
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getContext ()Lcom/trendyol/stove/testing/e2e/mongodb/MongodbContext;
 	public final fun getMongoClient ()Lcom/mongodb/kotlin/client/coroutine/MongoClient;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun inspect ()Lcom/trendyol/stove/testing/e2e/containers/StoveContainerInspectInformation;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/mongodb/MongodbSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setMongoClient (Lcom/mongodb/kotlin/client/coroutine/MongoClient;)V
 	public final fun shouldDelete (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun shouldDelete$default (Lcom/trendyol/stove/testing/e2e/mongodb/MongodbSystem;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun shouldNotExist (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun shouldNotExist$default (Lcom/trendyol/stove/testing/e2e/mongodb/MongodbSystem;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/mongodb/MongodbSystem;

--- a/lib/stove-testing-e2e-mongodb/src/test/kotlin/com/trendyol/stove/testing/e2e/mongodb/MongodbTestSystemTests.kt
+++ b/lib/stove-testing-e2e-mongodb/src/test/kotlin/com/trendyol/stove/testing/e2e/mongodb/MongodbTestSystemTests.kt
@@ -1,10 +1,12 @@
 package com.trendyol.stove.testing.e2e.mongodb
 
 import com.fasterxml.jackson.annotation.JsonAlias
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.TestSystem.Companion.validate
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAny
 import io.kotest.matchers.shouldBe
@@ -143,6 +145,8 @@ class ProvidedMongodbStrategy : MongodbTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = MongodbTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-rdbms-mssql/api/stove-testing-e2e-rdbms-mssql.api
+++ b/lib/stove-testing-e2e-rdbms-mssql/api/stove-testing-e2e-rdbms-mssql.api
@@ -37,19 +37,26 @@ public final class com/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlOptionsKt {
 	public static final fun mssql-PmNtuJU (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 }
 
-public final class com/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem$Companion;
 	public field sqlOperations Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;
 	public fun close ()V
 	public fun configuration ()Ljava/util/List;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public final fun getSqlOperations ()Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun ops (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setSqlOperations (Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;)V
 	public final fun shouldExecute (Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/rdbms/mssql/MsSqlSystem;

--- a/lib/stove-testing-e2e-rdbms-mssql/src/test/kotlin/com/trendyol/stove/testing/e2e/rdbms/mssql/MssqlSystemTest.kt
+++ b/lib/stove-testing-e2e-rdbms-mssql/src/test/kotlin/com/trendyol/stove/testing/e2e/rdbms/mssql/MssqlSystemTest.kt
@@ -2,10 +2,12 @@ package com.trendyol.stove.testing.e2e.rdbms.mssql
 
 import com.trendyol.stove.functional.*
 import com.trendyol.stove.testing.e2e.database.migrations.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.TestSystem.Companion.validate
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import org.slf4j.*
@@ -179,6 +181,8 @@ class ProvidedMsSqlStrategy : MsSqlTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = MsSqlTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-rdbms-postgres/api/stove-testing-e2e-rdbms-postgres.api
+++ b/lib/stove-testing-e2e-rdbms-postgres/api/stove-testing-e2e-rdbms-postgres.api
@@ -63,18 +63,25 @@ public final class com/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlOptio
 	public static synthetic fun provided$default (Lcom/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlOptions$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/rdbms/postgres/ProvidedPostgresqlOptions;
 }
 
-public final class com/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem$Companion;
 	public field sqlOperations Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;
 	public fun close ()V
 	public fun configuration ()Ljava/util/List;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public final fun getSqlOperations ()Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setSqlOperations (Lcom/trendyol/stove/testing/e2e/rdbms/NativeSqlOperations;)V
 	public final fun shouldExecute (Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/rdbms/postgres/PostgresqlSystem;

--- a/lib/stove-testing-e2e-rdbms-postgres/src/test/kotlin/com/trendyol/stove/testing/e2e/rdbms/postgres/TestSystemConfig.kt
+++ b/lib/stove-testing-e2e-rdbms-postgres/src/test/kotlin/com/trendyol/stove/testing/e2e/rdbms/postgres/TestSystemConfig.kt
@@ -1,9 +1,11 @@
 package com.trendyol.stove.testing.e2e.rdbms.postgres
 
 import com.trendyol.stove.testing.e2e.database.migrations.DatabaseMigration
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.slf4j.*
 import org.testcontainers.postgresql.PostgreSQLContainer
 
@@ -149,6 +151,8 @@ class ProvidedPostgresStrategy : PostgresTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = PostgresTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-redis/api/stove-testing-e2e-redis.api
+++ b/lib/stove-testing-e2e-redis/api/stove-testing-e2e-redis.api
@@ -101,15 +101,22 @@ public final class com/trendyol/stove/testing/e2e/redis/RedisOptionsKt {
 	public static final fun redis-PmNtuJU (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 }
 
-public final class com/trendyol/stove/testing/e2e/redis/RedisSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
+public final class com/trendyol/stove/testing/e2e/redis/RedisSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/redis/RedisSystem$Companion;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/redis/RedisContext;)V
 	public fun close ()V
 	public fun configuration ()Ljava/util/List;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/redis/RedisSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/redis/RedisSystem;

--- a/lib/stove-testing-e2e-redis/src/main/kotlin/com/trendyol/stove/testing/e2e/redis/RedisSystem.kt
+++ b/lib/stove-testing-e2e-redis/src/main/kotlin/com/trendyol/stove/testing/e2e/redis/RedisSystem.kt
@@ -3,6 +3,7 @@
 package com.trendyol.stove.testing.e2e.redis
 
 import com.trendyol.stove.functional.*
+import com.trendyol.stove.testing.e2e.reporting.*
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.*
 import com.trendyol.stove.testing.e2e.system.annotations.StoveDsl
@@ -127,8 +128,10 @@ class RedisSystem(
   private val context: RedisContext
 ) : PluggedSystem,
   RunAware,
-  ExposesConfiguration {
+  ExposesConfiguration,
+  Reports {
   private lateinit var client: RedisClient
+
   private lateinit var exposedConfiguration: RedisExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<RedisExposedConfiguration> =
@@ -159,14 +162,25 @@ class RedisSystem(
    * This operation is not supported when using a provided instance.
    * @return RedisSystem
    */
-  fun pause(): RedisSystem = withContainerOrWarn("pause") { it.pause() }
+  fun pause(): RedisSystem {
+    recordAction(
+      action = "Pause container",
+      metadata = mapOf("operation" to "fault-injection")
+    )
+    return withContainerOrWarn("pause") { it.pause() }
+  }
 
   /**
    * Unpauses the container. Use with care, as it will unpause the container which might affect other tests.
    * This operation is not supported when using a provided instance.
    * @return RedisSystem
    */
-  fun unpause(): RedisSystem = withContainerOrWarn("unpause") { it.unpause() }
+  fun unpause(): RedisSystem {
+    recordAction(
+      action = "Unpause container"
+    )
+    return withContainerOrWarn("unpause") { it.unpause() }
+  }
 
   private suspend fun obtainExposedConfiguration(): RedisExposedConfiguration =
     when {

--- a/lib/stove-testing-e2e-redis/src/test/kotlin/com/trendyol/stove/testing/e2e/redis/RedisSystemTests.kt
+++ b/lib/stove-testing-e2e-redis/src/test/kotlin/com/trendyol/stove/testing/e2e/redis/RedisSystemTests.kt
@@ -1,9 +1,11 @@
 package com.trendyol.stove.testing.e2e.redis
 
 import com.trendyol.stove.testing.e2e.redis.RedisSystem.Companion.client
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.future.await
@@ -123,6 +125,8 @@ class ProvidedRedisStrategy : RedisTestStrategy {
 // ============================================================================
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   private val strategy = RedisTestStrategy.select()
 
   override suspend fun beforeProject() = strategy.start()

--- a/lib/stove-testing-e2e-wiremock/api/stove-testing-e2e-wiremock.api
+++ b/lib/stove-testing-e2e-wiremock/api/stove-testing-e2e-wiremock.api
@@ -40,12 +40,14 @@ public final class com/trendyol/stove/testing/e2e/wiremock/WireMockRequestListen
 	public fun getName ()Ljava/lang/String;
 }
 
-public final class com/trendyol/stove/testing/e2e/wiremock/WireMockSystem : com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware, com/trendyol/stove/testing/e2e/system/abstractions/ValidatedSystem {
+public final class com/trendyol/stove/testing/e2e/wiremock/WireMockSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunAware, com/trendyol/stove/testing/e2e/system/abstractions/ValidatedSystem {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem$Companion;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/wiremock/WireMockContext;)V
 	public final fun behaviourFor (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 	public fun close ()V
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun mockDelete (Ljava/lang/String;ILjava/util/Map;)Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;
 	public static synthetic fun mockDelete$default (Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;Ljava/lang/String;ILjava/util/Map;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;
@@ -77,7 +79,12 @@ public final class com/trendyol/stove/testing/e2e/wiremock/WireMockSystem : com/
 	public static synthetic fun mockPutConfigure$default (Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;
 	public final fun mockPutContaining (Ljava/lang/String;Ljava/util/Map;ILarrow/core/Option;Ljava/util/Map;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;
 	public static synthetic fun mockPutContaining$default (Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;Ljava/lang/String;Ljava/util/Map;ILarrow/core/Option;Ljava/util/Map;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/wiremock/WireMockSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public fun validate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/lib/stove-testing-e2e-wiremock/src/test/kotlin/com/trendyol/stove/testing/e2e/wiremock/Stove.kt
+++ b/lib/stove-testing-e2e-wiremock/src/test/kotlin/com/trendyol/stove/testing/e2e/wiremock/Stove.kt
@@ -1,10 +1,14 @@
 package com.trendyol.stove.testing.e2e.wiremock
 
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import com.trendyol.stove.testing.e2e.system.abstractions.ApplicationUnderTest
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {

--- a/lib/stove-testing-e2e/api/stove-testing-e2e.api
+++ b/lib/stove-testing-e2e/api/stove-testing-e2e.api
@@ -314,6 +314,330 @@ public final class com/trendyol/stove/testing/e2e/messaging/SuccessfulParsedMess
 	public fun getMetadata ()Lcom/trendyol/stove/testing/e2e/messaging/MessageMetadata;
 }
 
+public final class com/trendyol/stove/testing/e2e/reporting/ActionEntry : com/trendyol/stove/testing/e2e/reporting/ReportEntry {
+	public fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/time/Instant;
+	public final fun component10 ()Ljava/lang/Object;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Object;
+	public final fun component6 ()Ljava/lang/Object;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public final fun component9 ()Ljava/lang/Object;
+	public final fun copy (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getActual ()Ljava/lang/Object;
+	public final fun getError ()Ljava/lang/String;
+	public final fun getExpected ()Ljava/lang/Object;
+	public final fun getInput ()Ljava/lang/Object;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun getResult ()Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public fun getSummary ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getTestId ()Ljava/lang/String;
+	public fun getTimestamp ()Ljava/time/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/AssertionEntry : com/trendyol/stove/testing/e2e/reporting/ReportEntry {
+	public fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/time/Instant;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Object;
+	public final fun component6 ()Ljava/lang/Object;
+	public final fun component7 ()Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public final fun component8 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Throwable;)Lcom/trendyol/stove/testing/e2e/reporting/AssertionEntry;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/AssertionEntry;Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/AssertionEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActual ()Ljava/lang/Object;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getExpected ()Ljava/lang/Object;
+	public final fun getFailure ()Ljava/lang/Throwable;
+	public fun getResult ()Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public fun getSummary ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getTestId ()Ljava/lang/String;
+	public fun getTimestamp ()Ljava/time/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/AssertionResult : java/lang/Enum {
+	public static final field Companion Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult$Companion;
+	public static final field FAILED Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public static final field PASSED Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public static fun values ()[Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/AssertionResult$Companion {
+	public final fun of (Z)Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/JsonReportEntry {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Object;
+	public final fun component11 ()Ljava/lang/Object;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Object;
+	public final fun component7 ()Ljava/lang/Object;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/JsonReportEntry;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/JsonReportEntry;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/JsonReportEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getActual ()Ljava/lang/Object;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getError ()Ljava/lang/String;
+	public final fun getExpected ()Ljava/lang/Object;
+	public final fun getInput ()Ljava/lang/Object;
+	public final fun getMetadata ()Ljava/util/Map;
+	public final fun getOutput ()Ljava/lang/Object;
+	public final fun getResult ()Ljava/lang/String;
+	public final fun getSystem ()Ljava/lang/String;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/JsonReportRenderer : com/trendyol/stove/testing/e2e/reporting/ReportRenderer {
+	public static final field INSTANCE Lcom/trendyol/stove/testing/e2e/reporting/JsonReportRenderer;
+	public fun render (Lcom/trendyol/stove/testing/e2e/reporting/TestReport;Ljava/util/List;)Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/JsonSummary {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;IIIIILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailedAssertions ()I
+	public final fun getPassedAssertions ()I
+	public final fun getTotalActions ()I
+	public final fun getTotalAssertions ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/JsonTestReport {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;)Lcom/trendyol/stove/testing/e2e/reporting/JsonTestReport;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/JsonTestReport;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/JsonTestReport;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getSummary ()Lcom/trendyol/stove/testing/e2e/reporting/JsonSummary;
+	public final fun getSystemSnapshots ()Ljava/util/Map;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTestName ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/PrettyConsoleRenderer : com/trendyol/stove/testing/e2e/reporting/ReportRenderer {
+	public static final field INSTANCE Lcom/trendyol/stove/testing/e2e/reporting/PrettyConsoleRenderer;
+	public fun render (Lcom/trendyol/stove/testing/e2e/reporting/TestReport;Ljava/util/List;)Ljava/lang/String;
+}
+
+public abstract class com/trendyol/stove/testing/e2e/reporting/ReportEntry {
+	public abstract fun getResult ()Lcom/trendyol/stove/testing/e2e/reporting/AssertionResult;
+	public abstract fun getSummary ()Ljava/lang/String;
+	public abstract fun getSystem ()Ljava/lang/String;
+	public abstract fun getTestId ()Ljava/lang/String;
+	public abstract fun getTimestamp ()Ljava/time/Instant;
+	public final fun isFailed ()Z
+	public final fun isPassed ()Z
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/ReportEntryFactory {
+	public static final field INSTANCE Lcom/trendyol/stove/testing/e2e/reporting/ReportEntryFactory;
+	public final fun action (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public static synthetic fun action$default (Lcom/trendyol/stove/testing/e2e/reporting/ReportEntryFactory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public final fun actionWithResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public static synthetic fun actionWithResult$default (Lcom/trendyol/stove/testing/e2e/reporting/ReportEntryFactory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/ActionEntry;
+	public final fun assertion (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/trendyol/stove/testing/e2e/reporting/AssertionEntry;
+	public static synthetic fun assertion$default (Lcom/trendyol/stove/testing/e2e/reporting/ReportEntryFactory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/AssertionEntry;
+}
+
+public abstract interface class com/trendyol/stove/testing/e2e/reporting/ReportRenderer {
+	public abstract fun render (Lcom/trendyol/stove/testing/e2e/reporting/TestReport;Ljava/util/List;)Ljava/lang/String;
+}
+
+public abstract interface class com/trendyol/stove/testing/e2e/reporting/Reports {
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public static synthetic fun recordAction$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun recordAndExecute$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun recordAndExecuteSuspend$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
+	public static synthetic fun recordAssertion$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/Reports$DefaultImpls {
+	public static fun getReportSystemName (Lcom/trendyol/stove/testing/e2e/reporting/Reports;)Ljava/lang/String;
+	public static fun getReporter (Lcom/trendyol/stove/testing/e2e/reporting/Reports;)Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
+	public static fun recordAction (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public static synthetic fun recordAction$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)V
+	public static fun recordAndExecute (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun recordAndExecute$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun recordAndExecuteSuspend (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun recordAndExecuteSuspend$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun recordAssertion (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
+	public static synthetic fun recordAssertion$default (Lcom/trendyol/stove/testing/e2e/reporting/Reports;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+	public static fun snapshot (Lcom/trendyol/stove/testing/e2e/reporting/Reports;)Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveJUnitExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/TestExecutionExceptionHandler {
+	public fun <init> ()V
+	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun handleTestExecutionException (Lorg/junit/jupiter/api/extension/ExtensionContext;Ljava/lang/Throwable;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveKotestExtension : io/kotest/core/extensions/TestCaseExtension {
+	public fun <init> ()V
+	public fun intercept (Lio/kotest/core/test/TestCase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveReporter {
+	public static final field Companion Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clear ()V
+	public final fun collectSnapshots ()Ljava/util/List;
+	public final fun currentTest ()Lcom/trendyol/stove/testing/e2e/reporting/TestReport;
+	public final fun currentTestId ()Ljava/lang/String;
+	public final fun currentTestOrNull ()Lcom/trendyol/stove/testing/e2e/reporting/TestReport;
+	public final fun dump (Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;)Ljava/lang/String;
+	public final fun dumpIfFailed (Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;)Ljava/lang/String;
+	public static synthetic fun dumpIfFailed$default (Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun endTest ()V
+	public final fun hasFailures ()Z
+	public final fun isEnabled ()Z
+	public final fun printIfFailed (Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;)V
+	public static synthetic fun printIfFailed$default (Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ILjava/lang/Object;)V
+	public final fun record (Lcom/trendyol/stove/testing/e2e/reporting/ReportEntry;)V
+	public final fun startTest (Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveReporter$Companion {
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestContext : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext$Key;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSpecName ()Ljava/lang/String;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTestName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestContext$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestContextHolder {
+	public static final field INSTANCE Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContextHolder;
+	public final fun clear ()V
+	public final fun get ()Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;
+	public final fun set (Lcom/trendyol/stove/testing/e2e/reporting/StoveTestContext;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestContextKt {
+	public static final fun currentStoveTestContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestErrorException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/StoveTestFailureException : java/lang/AssertionError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/SystemSnapshot {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/util/Map;
+	public final fun getSummary ()Ljava/lang/String;
+	public final fun getSystem ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/TestReport {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun clear ()V
+	public final fun entries ()Ljava/util/List;
+	public final fun entriesForThisTest ()Ljava/util/List;
+	public final fun failures ()Ljava/util/List;
+	public final fun failuresForThisTest ()Ljava/util/List;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTestName ()Ljava/lang/String;
+	public final fun hasFailures ()Z
+	public final fun record (Lcom/trendyol/stove/testing/e2e/reporting/ReportEntry;)V
+}
+
+public final class com/trendyol/stove/testing/e2e/reporting/TestReportKt {
+	public static final fun actions (Ljava/util/List;)Ljava/util/List;
+	public static final fun assertions (Ljava/util/List;)Ljava/util/List;
+	public static final fun failures (Ljava/util/List;)Ljava/util/List;
+	public static final fun forSystem (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
+	public static final fun forTest (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
+	public static final fun passed (Ljava/util/List;)Ljava/util/List;
+	public static final fun withResults (Ljava/util/List;)Ljava/util/List;
+}
+
 public final class com/trendyol/stove/testing/e2e/serialization/E2eObjectMapperConfig {
 	public static final field INSTANCE Lcom/trendyol/stove/testing/e2e/serialization/E2eObjectMapperConfig;
 	public final fun createObjectMapperWithDefaults ()Lcom/fasterxml/jackson/databind/ObjectMapper;
@@ -458,7 +782,7 @@ public final class com/trendyol/stove/testing/e2e/serialization/StoveSerde$Stove
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public abstract class com/trendyol/stove/testing/e2e/system/BridgeSystem : com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAwareWithContext, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
+public abstract class com/trendyol/stove/testing/e2e/system/BridgeSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/AfterRunAwareWithContext, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem {
 	protected field ctx Ljava/lang/Object;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;)V
 	public fun afterRun (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -467,8 +791,15 @@ public abstract class com/trendyol/stove/testing/e2e/system/BridgeSystem : com/t
 	public abstract fun get (Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public fun getByType (Lkotlin/reflect/KType;)Ljava/lang/Object;
 	protected final fun getCtx ()Ljava/lang/Object;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	protected final fun setCtx (Ljava/lang/Object;)V
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 }
 
@@ -498,6 +829,16 @@ public final class com/trendyol/stove/testing/e2e/system/PropertiesFile {
 public final class com/trendyol/stove/testing/e2e/system/PropertiesFile$Companion {
 }
 
+public final class com/trendyol/stove/testing/e2e/system/ReportingDsl {
+	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;)V
+	public final fun disabled ()Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public final fun dumpOnFailure (Z)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public static synthetic fun dumpOnFailure$default (Lcom/trendyol/stove/testing/e2e/system/ReportingDsl;ZILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public final fun enabled (Z)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public static synthetic fun enabled$default (Lcom/trendyol/stove/testing/e2e/system/ReportingDsl;ZILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public final fun failureRenderer (Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+}
+
 public final class com/trendyol/stove/testing/e2e/system/TestSystem : com/trendyol/stove/testing/e2e/system/abstractions/ReadyTestSystem, java/lang/AutoCloseable {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/system/TestSystem$Companion;
 	public fun <init> ()V
@@ -508,27 +849,49 @@ public final class com/trendyol/stove/testing/e2e/system/TestSystem : com/trendy
 	public fun close ()V
 	public final fun getActiveSystems ()Ljava/util/Map;
 	public final fun getOptions ()Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;
+	public final fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public final fun registerForDispose (Ljava/lang/AutoCloseable;)Ljava/lang/AutoCloseable;
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun with (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 }
 
 public final class com/trendyol/stove/testing/e2e/system/TestSystem$Companion {
+	public final fun getSystem (Lkotlin/reflect/KClass;)Lcom/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem;
+	public final fun instanceInitialized ()Z
+	public final fun reporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public final fun stop ()V
 	public final fun validate (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/trendyol/stove/testing/e2e/system/TestSystemOptions {
 	public fun <init> ()V
-	public fun <init> (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;Z)V
-	public synthetic fun <init> (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZZZZLcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ZZLjava/lang/String;)V
+	public synthetic fun <init> (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZZZZLcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;
 	public final fun component3 ()Z
-	public final fun copy (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;Z)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
+	public final fun component8 ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
+	public final fun component9 ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
+	public final fun copy (ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZZZZLcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ZZLjava/lang/String;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;ZLcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;ZZZZLcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;ZZLjava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptions;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultRenderer ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
+	public final fun getDumpReportOnStop ()Z
+	public final fun getDumpReportOnTestFailure ()Z
+	public final fun getFailureRenderer ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
+	public final fun getFileRenderer ()Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;
 	public final fun getKeepDependenciesRunning ()Z
+	public final fun getReportFilePath ()Ljava/lang/String;
+	public final fun getReportToConsole ()Z
+	public final fun getReportToFile ()Z
+	public final fun getReportingEnabled ()Z
 	public final fun getRunMigrationsAlways ()Z
 	public final fun getStateStorageFactory ()Lcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;
 	public fun hashCode ()I
@@ -536,12 +899,22 @@ public final class com/trendyol/stove/testing/e2e/system/TestSystemOptions {
 }
 
 public final class com/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl {
+	public static final field Companion Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl$Companion;
 	public fun <init> ()V
+	public final fun dumpReportOnTestFailure (Z)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public static synthetic fun dumpReportOnTestFailure$default (Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;ZILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
 	public final fun enableReuseForTestContainers ()V
+	public final fun failureRenderer (Lcom/trendyol/stove/testing/e2e/reporting/ReportRenderer;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
 	public final fun isRunningLocally ()Z
 	public final fun keepDependenciesRunning ()Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public final fun reporting (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public final fun reportingEnabled (Z)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+	public static synthetic fun reportingEnabled$default (Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;ZILjava/lang/Object;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
 	public final fun runMigrationsAlways ()Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
 	public final fun stateStorage (Lcom/trendyol/stove/testing/e2e/system/abstractions/StateStorageFactory;)Lcom/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl;
+}
+
+public final class com/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl$Companion {
 }
 
 public final class com/trendyol/stove/testing/e2e/system/ValidationDsl {

--- a/lib/stove-testing-e2e/build.gradle.kts
+++ b/lib/stove-testing-e2e/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   api(libs.arrow.core)
   api(libs.kotlinx.core)
   api(libs.jackson.kotlin)
+  api(libs.jackson.databind)
   api(libs.google.gson)
   api(libs.kotlinx.serialization.json)
   api(libs.testcontainers) {
@@ -15,7 +16,15 @@ dependencies {
     }
   }
 
+  // Compile-time dependencies for extensions (compileOnly since they're only needed for extension classes)
+  // kotest-framework-engine contains TestCase, TestResult, and listener interfaces
+  compileOnly(libs.kotest.framework.engine) // For Kotest extension (TestCase, TestResult, BeforeTestListener, AfterTestListener)
+  compileOnly(libs.junit.jupiter.api) // For JUnit extension
+
   testImplementation(libs.kotest.arrow)
+  testImplementation(libs.kotest.runner.junit5)
+  testImplementation(libs.kotest.framework.engine)
+  testImplementation(libs.kotest.assertions.core)
   testFixturesImplementation(libs.kotest.runner.junit5)
 }
 

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/JsonReportRenderer.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/JsonReportRenderer.kt
@@ -1,0 +1,112 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.fasterxml.jackson.databind.*
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+/**
+ * JSON renderer for machine-parseable test reports.
+ * Useful for CI integration, log aggregation, and programmatic analysis.
+ */
+object JsonReportRenderer : ReportRenderer {
+  private val mapper = ObjectMapper().apply {
+    enable(SerializationFeature.INDENT_OUTPUT)
+  }
+
+  private val timestampFormatter = DateTimeFormatter.ISO_INSTANT
+
+  override fun render(report: TestReport, snapshots: List<SystemSnapshot>): String {
+    val jsonReport = JsonTestReport(
+      testId = report.testId,
+      testName = report.testName,
+      timestamp = timestampFormatter.format(Instant.now()),
+      entries = report.entries().map { it.toJsonEntry() },
+      systemSnapshots = snapshots.associate { it.system to it.state },
+      summary = JsonSummary(
+        totalActions = report.entries().filterIsInstance<ActionEntry>().size,
+        totalAssertions = report.entries().filterIsInstance<AssertionEntry>().size,
+        passedAssertions = report
+          .entries()
+          .filterIsInstance<AssertionEntry>()
+          .count { it.result == AssertionResult.PASSED },
+        failedAssertions = report.failures().size
+      )
+    )
+    return mapper.writeValueAsString(jsonReport)
+  }
+
+  private fun ReportEntry.toJsonEntry(): JsonReportEntry = when (this) {
+    is ActionEntry -> JsonReportEntry(
+      type = if (result != null) "action_with_result" else "action",
+      timestamp = timestampFormatter.format(timestamp),
+      system = system,
+      testId = testId,
+      action = action,
+      input = input,
+      output = output,
+      metadata = metadata,
+      description = null,
+      expected = expected,
+      actual = actual,
+      result = result?.name,
+      error = error
+    )
+
+    is AssertionEntry -> JsonReportEntry(
+      type = "assertion",
+      timestamp = timestampFormatter.format(timestamp),
+      system = system,
+      testId = testId,
+      action = null,
+      input = null,
+      output = null,
+      metadata = emptyMap(),
+      description = description,
+      expected = expected,
+      actual = actual,
+      result = result.name,
+      error = failure?.message
+    )
+  }
+}
+
+/**
+ * JSON representation of a test report.
+ */
+data class JsonTestReport(
+  val testId: String,
+  val testName: String,
+  val timestamp: String,
+  val entries: List<JsonReportEntry>,
+  val systemSnapshots: Map<String, Any>,
+  val summary: JsonSummary
+)
+
+/**
+ * JSON representation of a report entry.
+ */
+data class JsonReportEntry(
+  val type: String,
+  val timestamp: String,
+  val system: String,
+  val testId: String,
+  val action: String?,
+  val input: Any?,
+  val output: Any?,
+  val metadata: Map<String, Any>,
+  val description: String?,
+  val expected: Any?,
+  val actual: Any?,
+  val result: String?,
+  val error: String?
+)
+
+/**
+ * JSON representation of report summary.
+ */
+data class JsonSummary(
+  val totalActions: Int,
+  val totalAssertions: Int,
+  val passedAssertions: Int,
+  val failedAssertions: Int
+)

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/PrettyConsoleRenderer.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/PrettyConsoleRenderer.kt
@@ -1,0 +1,487 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Pretty console renderer for human-readable test reports.
+ * Uses box drawing characters, colors, and clear formatting for easy reading.
+ * Automatically wraps long lines to maintain the box frame.
+ */
+@Suppress("MagicNumber", "TooManyFunctions")
+object PrettyConsoleRenderer : ReportRenderer {
+  private const val BOX_WIDTH = 100
+  private const val CONTENT_WIDTH = BOX_WIDTH - 4 // Account for "║ " and " ║"
+  private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+
+  // ANSI Color codes
+  private object Colors {
+    const val RESET = "\u001B[0m"
+    const val BOLD = "\u001B[1m"
+    const val DIM = "\u001B[2m"
+
+    // Foreground colors
+    const val RED = "\u001B[31m"
+    const val GREEN = "\u001B[32m"
+    const val YELLOW = "\u001B[33m"
+    const val BLUE = "\u001B[34m"
+    const val MAGENTA = "\u001B[35m"
+    const val CYAN = "\u001B[36m"
+    const val WHITE = "\u001B[37m"
+
+    // Bright foreground colors
+    const val BRIGHT_RED = "\u001B[91m"
+    const val BRIGHT_GREEN = "\u001B[92m"
+    const val BRIGHT_YELLOW = "\u001B[93m"
+    const val BRIGHT_BLUE = "\u001B[94m"
+    const val BRIGHT_CYAN = "\u001B[96m"
+  }
+
+  override fun render(report: TestReport, snapshots: List<SystemSnapshot>): String = buildString {
+    val hasFailures = report.hasFailures()
+
+    // Header
+    topBorder(if (hasFailures) Colors.RED else Colors.CYAN)
+    centeredLine("STOVE TEST EXECUTION REPORT", Colors.BOLD + Colors.WHITE)
+    emptyLine()
+    contentLine("Test: ${colorize(report.testName, Colors.BRIGHT_YELLOW)}")
+    contentLine("ID: ${colorize(report.testId, Colors.DIM)}")
+
+    if (hasFailures) {
+      contentLine("Status: ${colorize("FAILED", Colors.BOLD + Colors.BRIGHT_RED)}")
+    } else {
+      contentLine("Status: ${colorize("IN PROGRESS", Colors.BRIGHT_BLUE)}")
+    }
+
+    divider(if (hasFailures) Colors.RED else Colors.CYAN)
+
+    // Timeline
+    emptyLine()
+    contentLine(colorize("TIMELINE", Colors.BOLD + Colors.WHITE))
+    contentLine(colorize("─".repeat(8), Colors.DIM))
+    emptyLine()
+
+    report.entries().forEach { entry ->
+      when (entry) {
+        is ActionEntry -> renderAction(entry)
+        is AssertionEntry -> renderAssertion(entry)
+      }
+    }
+
+    // Snapshots
+    if (snapshots.isNotEmpty()) {
+      divider(Colors.CYAN)
+      emptyLine()
+      contentLine(colorize("SYSTEM SNAPSHOTS", Colors.BOLD + Colors.WHITE))
+      contentLine(colorize("─".repeat(16), Colors.DIM))
+      emptyLine()
+
+      snapshots.forEach { snapshot ->
+        renderSnapshot(snapshot)
+      }
+    }
+
+    // Footer
+    emptyLine()
+    bottomBorder(if (hasFailures) Colors.RED else Colors.CYAN)
+  }
+
+  private fun colorize(text: String, color: String): String = "$color$text${Colors.RESET}"
+
+  private fun StringBuilder.topBorder(color: String = Colors.CYAN) {
+    appendLine("$color╔${"═".repeat(BOX_WIDTH - 2)}╗${Colors.RESET}")
+  }
+
+  private fun StringBuilder.bottomBorder(color: String = Colors.CYAN) {
+    appendLine("$color╚${"═".repeat(BOX_WIDTH - 2)}╝${Colors.RESET}")
+  }
+
+  private fun StringBuilder.divider(color: String = Colors.CYAN) {
+    appendLine("$color╠${"═".repeat(BOX_WIDTH - 2)}╣${Colors.RESET}")
+  }
+
+  private fun StringBuilder.emptyLine() {
+    appendLine("${Colors.CYAN}║${Colors.RESET}${" ".repeat(BOX_WIDTH - 2)}${Colors.CYAN}║${Colors.RESET}")
+  }
+
+  private fun StringBuilder.centeredLine(text: String, color: String = "") {
+    val plainText = stripAnsi(text)
+    val truncated = if (plainText.length > CONTENT_WIDTH) plainText.take(CONTENT_WIDTH) else text
+    val plainTruncated = stripAnsi(truncated)
+    val padding = (CONTENT_WIDTH - plainTruncated.length) / 2
+    val rightPadding = CONTENT_WIDTH - padding - plainTruncated.length
+
+    val coloredText = if (color.isNotEmpty()) colorize(plainTruncated, color) else truncated
+    appendLine(
+      "${Colors.CYAN}║${Colors.RESET} ${" ".repeat(padding)}$coloredText${" ".repeat(rightPadding)} ${Colors.CYAN}║${Colors.RESET}"
+    )
+  }
+
+  private fun StringBuilder.contentLine(text: String, indent: Int = 0) {
+    val indentStr = " ".repeat(indent)
+    val availableWidth = CONTENT_WIDTH - indent
+
+    // First split by actual newlines, then wrap each line
+    text.split('\n').forEach { rawLine ->
+      // Wrap each line to fit within the available width
+      wrapText(rawLine.replace("\r", ""), availableWidth).forEach { wrappedLine ->
+        val plainLine = stripAnsi(wrappedLine)
+
+        // Safety: truncate if still too long (shouldn't happen, but ensures border integrity)
+        val (finalLine, finalPlainLength) = if (plainLine.length > availableWidth) {
+          val truncated = truncateWithAnsi(wrappedLine, availableWidth - 3) + "..."
+          truncated to (availableWidth)
+        } else {
+          wrappedLine to plainLine.length
+        }
+
+        val padding = availableWidth - finalPlainLength
+        appendLine(
+          "${Colors.CYAN}║${Colors.RESET} $indentStr$finalLine${" ".repeat(padding.coerceAtLeast(0))} ${Colors.CYAN}║${Colors.RESET}"
+        )
+      }
+    }
+  }
+
+  /**
+   * Truncates a string with ANSI codes to a target plain-text length.
+   */
+  @Suppress("NestedBlockDepth")
+  private fun truncateWithAnsi(text: String, targetLength: Int): String {
+    if (targetLength <= 0) return ""
+    val result = StringBuilder()
+    var plainLength = 0
+    var i = 0
+
+    while (i < text.length && plainLength < targetLength) {
+      if (text[i] == '\u001B') {
+        // Copy entire ANSI sequence
+        while (i < text.length) {
+          result.append(text[i])
+          if (text[i] == 'm') {
+            i++
+            break
+          }
+          i++
+        }
+      } else {
+        result.append(text[i])
+        plainLength++
+        i++
+      }
+    }
+
+    // Append reset code to ensure colors don't bleed
+    result.append(Colors.RESET)
+    return result.toString()
+  }
+
+  private fun StringBuilder.renderAction(entry: ActionEntry) {
+    val formattedTime = colorize(
+      entry.timestamp.atZone(ZoneId.systemDefault()).format(timeFormatter),
+      Colors.DIM
+    )
+
+    // Determine icon and color based on result
+    val (icon, statusText) = when (entry.result) {
+      AssertionResult.PASSED -> colorize("✓", Colors.BRIGHT_GREEN) to colorize("PASSED", Colors.BRIGHT_GREEN)
+      AssertionResult.FAILED -> colorize("✗", Colors.BRIGHT_RED) to colorize("FAILED", Colors.BRIGHT_RED)
+      null -> colorize("●", Colors.BRIGHT_BLUE) to null
+    }
+
+    val system = colorize("[${entry.system}]", Colors.BRIGHT_CYAN)
+
+    // Show status if present
+    val statusPart = statusText?.let { " $it" } ?: ""
+    contentLine("$formattedTime $icon$statusPart $system ${entry.action}")
+
+    entry.input?.let {
+      contentLine("${colorize("Input:", Colors.YELLOW)} ${formatValue(it)}", indent = 4)
+    }
+    entry.output?.let {
+      contentLine("${colorize("Output:", Colors.YELLOW)} ${formatValue(it)}", indent = 4)
+    }
+    if (entry.metadata.isNotEmpty()) {
+      contentLine("${colorize("Metadata:", Colors.DIM)} ${formatValue(entry.metadata)}", indent = 4)
+    }
+
+    // Show assertion details if failed
+    if (entry.isFailed) {
+      entry.expected?.let {
+        renderLabeledContent("Expected:", formatValue(it), Colors.GREEN, indent = 4)
+      }
+      entry.actual?.let {
+        renderLabeledContent("Actual:", formatValue(it), Colors.RED, indent = 4)
+      }
+      entry.error?.let {
+        renderLabeledContent("Error:", it, Colors.BRIGHT_RED, indent = 4)
+      }
+    }
+
+    emptyLine()
+  }
+
+  private fun StringBuilder.renderAssertion(entry: AssertionEntry) {
+    val formattedTime = colorize(
+      entry.timestamp.atZone(ZoneId.systemDefault()).format(timeFormatter),
+      Colors.DIM
+    )
+
+    val (icon, statusColor) = if (entry.result == AssertionResult.PASSED) {
+      colorize("✓", Colors.BRIGHT_GREEN) to Colors.BRIGHT_GREEN
+    } else {
+      colorize("✗", Colors.BRIGHT_RED) to Colors.BRIGHT_RED
+    }
+
+    val status = colorize(entry.result.name, Colors.BOLD + statusColor)
+    val system = colorize("[${entry.system}]", Colors.BRIGHT_CYAN)
+
+    contentLine("$formattedTime $icon $status $system ${entry.description}")
+
+    if (entry.result == AssertionResult.FAILED) {
+      entry.expected?.let {
+        renderLabeledContent("Expected:", formatValue(it), Colors.GREEN, indent = 4)
+      }
+      entry.actual?.let {
+        renderLabeledContent("Actual:", formatValue(it), Colors.RED, indent = 4)
+      }
+      entry.failure?.let {
+        renderLabeledContent("Error:", it.message ?: "Unknown error", Colors.BRIGHT_RED, indent = 4)
+      }
+    }
+    emptyLine()
+  }
+
+  /**
+   * Renders a labeled content block where the label and content may be on separate lines
+   * if the content is multi-line or too long.
+   */
+  private fun StringBuilder.renderLabeledContent(label: String, content: String, labelColor: String, indent: Int) {
+    val coloredLabel = colorize(label, labelColor)
+    val lines = content.split('\n').map { it.replace("\r", "").trim() }.filter { it.isNotEmpty() }
+
+    if (lines.size == 1 && stripAnsi("$label $content").length <= CONTENT_WIDTH - indent) {
+      // Single line that fits - render inline
+      contentLine("$coloredLabel $content", indent = indent)
+    } else {
+      // Multi-line or long content - render label separately
+      contentLine(coloredLabel, indent = indent)
+      lines.forEach { line ->
+        contentLine(line, indent = indent + 2)
+      }
+    }
+  }
+
+  private fun StringBuilder.renderSnapshot(snapshot: SystemSnapshot) {
+    val header = "┌─ ${snapshot.system.uppercase()} "
+    val headerLine = header + "─".repeat((CONTENT_WIDTH - header.length).coerceAtLeast(0))
+    contentLine(colorize(headerLine, Colors.MAGENTA))
+    emptyLine()
+
+    // Render summary
+    snapshot.summary.lines().forEach { line ->
+      if (line.isNotBlank()) {
+        contentLine(colorize(line, Colors.WHITE), indent = 2)
+      }
+    }
+
+    // Render state if available
+    if (snapshot.state.isNotEmpty()) {
+      emptyLine()
+      contentLine(colorize("State Details:", Colors.BOLD + Colors.WHITE), indent = 2)
+      renderSnapshotState(snapshot.state, indent = 4)
+    }
+
+    emptyLine()
+  }
+
+  private fun StringBuilder.renderSnapshotState(state: Map<String, Any>, indent: Int) {
+    state.forEach { (key, value) ->
+      val coloredKey = colorize(key, Colors.YELLOW)
+      when (value) {
+        is Collection<*> -> {
+          contentLine("$coloredKey: ${colorize("${value.size} item(s)", Colors.DIM)}", indent = indent)
+          value.forEachIndexed { index, item ->
+            renderSnapshotItem(index, item, indent + 2)
+          }
+        }
+
+        else -> {
+          contentLine("$coloredKey: ${formatValue(value)}", indent = indent)
+        }
+      }
+    }
+  }
+
+  private fun StringBuilder.renderSnapshotItem(index: Int, item: Any?, indent: Int) {
+    val indexLabel = colorize("[$index]", Colors.DIM)
+    when (item) {
+      is Map<*, *> -> {
+        contentLine(indexLabel, indent = indent)
+        item.forEach { (k, v) ->
+          contentLine("${colorize(k.toString(), Colors.CYAN)}: $v", indent = indent + 2)
+        }
+      }
+
+      else -> {
+        contentLine("$indexLabel ${formatValue(item)}", indent = indent)
+      }
+    }
+  }
+
+  /**
+   * Wraps text to fit within the specified width.
+   * Tries to break at word boundaries when possible.
+   * Accounts for ANSI escape codes in width calculation.
+   */
+  @Suppress("LoopWithTooManyJumpStatements")
+  private fun wrapText(text: String, maxWidth: Int): List<String> {
+    if (maxWidth <= 0) return listOf(text)
+
+    val plainText = stripAnsi(text)
+    if (plainText.length <= maxWidth) return listOf(text)
+
+    val lines = mutableListOf<String>()
+    var remaining = text
+    var plainRemaining = plainText
+
+    var iterations = 0
+    val maxIterations = 100 // Safety limit
+
+    while (plainRemaining.isNotEmpty() && iterations < maxIterations) {
+      iterations++
+
+      if (plainRemaining.length <= maxWidth) {
+        lines.add(remaining)
+        break
+      }
+
+      // Find the best break point in plain text
+      var breakPoint = maxWidth
+
+      // Try to find a space to break at (prefer word boundaries)
+      var foundSpace = -1
+      for (i in maxWidth downTo maxWidth / 2) {
+        if (plainRemaining[i] == ' ') {
+          foundSpace = i
+          break
+        }
+      }
+
+      if (foundSpace > 0) {
+        breakPoint = foundSpace
+      }
+
+      // Find corresponding position in original text (with ANSI codes)
+      val originalBreakPoint = findOriginalPosition(remaining, breakPoint)
+
+      // Ensure we make progress
+      if (originalBreakPoint == 0) {
+        // Can't find a break point, force break at maxWidth
+        val forcedBreak = findOriginalPosition(remaining, maxWidth.coerceAtMost(plainRemaining.length))
+        if (forcedBreak > 0) {
+          lines.add(remaining.substring(0, forcedBreak))
+          remaining = remaining.substring(forcedBreak)
+        } else {
+          // Fallback: just add remaining and break
+          lines.add(remaining)
+          break
+        }
+      } else {
+        lines.add(remaining.substring(0, originalBreakPoint).trimEnd())
+        remaining = remaining.substring(originalBreakPoint).trimStart()
+      }
+
+      plainRemaining = stripAnsi(remaining)
+    }
+
+    return lines.ifEmpty { listOf(text) }
+  }
+
+  /**
+   * Finds the position in the original string (with ANSI codes) that corresponds
+   * to a position in the plain string (without ANSI codes).
+   */
+  private fun findOriginalPosition(original: String, plainPosition: Int): Int {
+    var plainIndex = 0
+    var originalIndex = 0
+    var inEscape = false
+
+    while (originalIndex < original.length && plainIndex < plainPosition) {
+      val char = original[originalIndex]
+      if (char == '\u001B') {
+        inEscape = true
+      } else if (inEscape) {
+        if (char == 'm') {
+          inEscape = false
+        }
+      } else {
+        plainIndex++
+      }
+      originalIndex++
+    }
+
+    // Skip any trailing ANSI codes
+    while (originalIndex < original.length && original[originalIndex] == '\u001B') {
+      while (originalIndex < original.length && original[originalIndex] != 'm') {
+        originalIndex++
+      }
+      if (originalIndex < original.length) originalIndex++ // skip 'm'
+    }
+
+    return originalIndex
+  }
+
+  /**
+   * Strips ANSI escape codes from a string.
+   */
+  private fun stripAnsi(text: String): String = text.replace(Regex("\u001B\\[[0-9;]*m"), "")
+
+  /**
+   * Formats a value for display, handling different types appropriately.
+   */
+  private fun formatValue(obj: Any?): String {
+    if (obj == null) return colorize("null", Colors.DIM)
+
+    val str = when (obj) {
+      is String -> {
+        obj
+      }
+
+      is Number -> {
+        colorize(obj.toString(), Colors.BRIGHT_YELLOW)
+      }
+
+      is Boolean -> {
+        colorize(obj.toString(), if (obj) Colors.GREEN else Colors.RED)
+      }
+
+      is Collection<*> -> {
+        if (obj.isEmpty()) {
+          colorize("[]", Colors.DIM)
+        } else {
+          colorize("[${obj.size} items]", Colors.DIM)
+        }
+      }
+
+      is Map<*, *> -> {
+        if (obj.isEmpty()) {
+          colorize("{}", Colors.DIM)
+        } else {
+          obj.entries.joinToString(", ", "{", "}") {
+            "${colorize(it.key.toString(), Colors.CYAN)}=${it.value}"
+          }
+        }
+      }
+
+      else -> {
+        obj.toString()
+      }
+    }
+
+    // Clean up newlines for inline display, but don't truncate
+    return str
+      .replace("\n", " ")
+      .replace("\r", "")
+  }
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportEntry.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportEntry.kt
@@ -1,0 +1,141 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import java.time.Instant
+
+/**
+ * Base sealed class for all report entries.
+ * Immutable by design - all properties are val and data classes ensure proper equals/hashCode.
+ */
+sealed class ReportEntry {
+  abstract val timestamp: Instant
+  abstract val system: String
+  abstract val testId: String
+
+  /** Display summary for this entry */
+  abstract val summary: String
+
+  /** True if this entry represents a failure */
+  val isFailed: Boolean get() = result == AssertionResult.FAILED
+
+  /** True if this entry represents a success */
+  val isPassed: Boolean get() = result == AssertionResult.PASSED
+
+  /** Optional result - null means action only without assertion */
+  abstract val result: AssertionResult?
+}
+
+/**
+ * Represents an action performed by a system (HTTP request, Kafka publish, SQL query, etc.).
+ * May optionally include an assertion result.
+ */
+data class ActionEntry(
+  override val timestamp: Instant,
+  override val system: String,
+  override val testId: String,
+  val action: String,
+  val input: Any? = null,
+  val output: Any? = null,
+  val metadata: Map<String, Any> = emptyMap(),
+  override val result: AssertionResult? = null,
+  val expected: Any? = null,
+  val actual: Any? = null,
+  val error: String? = null
+) : ReportEntry() {
+  override val summary: String get() = "[$system] $action"
+}
+
+/**
+ * Represents a standalone assertion during test execution.
+ */
+data class AssertionEntry(
+  override val timestamp: Instant,
+  override val system: String,
+  override val testId: String,
+  val description: String,
+  val expected: Any? = null,
+  val actual: Any? = null,
+  override val result: AssertionResult,
+  val failure: Throwable? = null
+) : ReportEntry() {
+  override val summary: String get() = "[$system] $description: ${result.name}"
+}
+
+/**
+ * Result of an assertion.
+ */
+enum class AssertionResult {
+  PASSED,
+  FAILED;
+
+  companion object {
+    fun of(passed: Boolean): AssertionResult = if (passed) PASSED else FAILED
+  }
+}
+
+/**
+ * Factory for creating report entries with consistent timestamping.
+ */
+object ReportEntryFactory {
+  private fun now(): Instant = Instant.now()
+
+  fun action(
+    system: String,
+    testId: String,
+    action: String,
+    input: Any? = null,
+    output: Any? = null,
+    metadata: Map<String, Any> = emptyMap()
+  ): ActionEntry = ActionEntry(
+    timestamp = now(),
+    system = system,
+    testId = testId,
+    action = action,
+    input = input,
+    output = output,
+    metadata = metadata
+  )
+
+  fun actionWithResult(
+    system: String,
+    testId: String,
+    action: String,
+    passed: Boolean,
+    input: Any? = null,
+    output: Any? = null,
+    metadata: Map<String, Any> = emptyMap(),
+    expected: Any? = null,
+    actual: Any? = null,
+    error: String? = null
+  ): ActionEntry = ActionEntry(
+    timestamp = now(),
+    system = system,
+    testId = testId,
+    action = action,
+    input = input,
+    output = output,
+    metadata = metadata,
+    result = AssertionResult.of(passed),
+    expected = expected,
+    actual = actual,
+    error = error
+  )
+
+  fun assertion(
+    system: String,
+    testId: String,
+    description: String,
+    passed: Boolean,
+    expected: Any? = null,
+    actual: Any? = null,
+    failure: Throwable? = null
+  ): AssertionEntry = AssertionEntry(
+    timestamp = now(),
+    system = system,
+    testId = testId,
+    description = description,
+    expected = expected,
+    actual = actual,
+    result = AssertionResult.of(passed),
+    failure = failure
+  )
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportRenderer.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportRenderer.kt
@@ -1,0 +1,11 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+/**
+ * Interface for rendering test reports in different formats.
+ */
+interface ReportRenderer {
+  /**
+   * Render a test report with optional system snapshots.
+   */
+  fun render(report: TestReport, snapshots: List<SystemSnapshot>): String
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/Reports.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/Reports.kt
@@ -1,0 +1,184 @@
+@file:Suppress("TooGenericExceptionCaught")
+
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.trendyol.stove.testing.e2e.system.abstractions.PluggedSystem
+
+/**
+ * Interface for systems that participate in test reporting.
+ *
+ * Provides recording capabilities for actions and assertions during test execution,
+ * following the Single Responsibility Principle - this interface only handles reporting.
+ *
+ * ## Design Principles
+ * - **Functional**: Recording functions return unit, using callbacks for results
+ * - **Immutable**: All recorded entries are immutable data classes
+ * - **Composable**: `recordAndExecute` combines action recording with assertion execution
+ */
+interface Reports {
+  /**
+   * System identifier for reports. Defaults to class name without "System" suffix.
+   * Override only when custom naming is needed (e.g., "HTTP" instead of "Http").
+   */
+  val reportSystemName: String
+    get() = this::class.simpleName?.removeSuffix("System") ?: "Unknown"
+
+  /**
+   * Access to the reporter. Requires implementing class to be a [PluggedSystem].
+   */
+  val reporter: StoveReporter
+    get() = (this as? PluggedSystem)?.testSystem?.reporter
+      ?: error("Reports must be implemented by a PluggedSystem")
+
+  /**
+   * Capture current system state for failure reports.
+   * Override to provide system-specific snapshots (e.g., Kafka messages, WireMock stubs).
+   */
+  fun snapshot(): SystemSnapshot = SystemSnapshot(
+    system = reportSystemName,
+    state = emptyMap(),
+    summary = "No detailed state available"
+  )
+
+  /**
+   * Record an action without assertion.
+   *
+   * @param action Description of the action performed
+   * @param input Optional input data (request body, query params, etc.)
+   * @param output Optional output data (response body, result, etc.)
+   * @param metadata Additional key-value metadata
+   */
+  fun recordAction(
+    action: String,
+    input: Any? = null,
+    output: Any? = null,
+    metadata: Map<String, Any> = emptyMap()
+  ) {
+    if (!reporter.isEnabled) return
+    reporter.record(
+      ReportEntryFactory.action(
+        system = reportSystemName,
+        testId = reporter.currentTestId(),
+        action = action,
+        input = input,
+        output = output,
+        metadata = metadata
+      )
+    )
+  }
+
+  /**
+   * Execute an assertion and record the combined action with result.
+   *
+   * This is the preferred method for actions that include assertions.
+   * It handles success/failure recording automatically and re-throws on failure.
+   *
+   * Example:
+   * ```kotlin
+   * recordAndExecute(
+   *   action = "GET /users/123",
+   *   input = queryParams,
+   *   expected = "200 OK"
+   * ) {
+   *   response.status shouldBe 200
+   * }
+   * ```
+   */
+  suspend fun <T> recordAndExecute(
+    action: String,
+    input: Any? = null,
+    output: Any? = null,
+    metadata: Map<String, Any> = emptyMap(),
+    expected: Any? = null,
+    actual: Any? = null,
+    assertion: suspend () -> T
+  ): T = executeWithRecording(action, input, output, metadata, expected, actual, assertion)
+
+  /**
+   * Alias for [recordAndExecute] - maintained for API compatibility.
+   */
+  suspend fun <T> recordAndExecuteSuspend(
+    action: String,
+    input: Any? = null,
+    output: Any? = null,
+    metadata: Map<String, Any> = emptyMap(),
+    expected: Any? = null,
+    actual: Any? = null,
+    assertion: suspend () -> T
+  ): T = recordAndExecute(action, input, output, metadata, expected, actual, assertion)
+
+  /**
+   * Record a standalone assertion result.
+   * Use when you need to record an assertion separate from an action.
+   */
+  fun recordAssertion(
+    description: String,
+    expected: Any? = null,
+    actual: Any? = null,
+    passed: Boolean,
+    failure: Throwable? = null,
+    metadata: Map<String, Any> = emptyMap()
+  ) {
+    if (!reporter.isEnabled) return
+
+    reporter.record(
+      ReportEntryFactory.assertion(
+        system = reportSystemName,
+        testId = reporter.currentTestId(),
+        description = description,
+        expected = expected,
+        actual = actual,
+        passed = passed,
+        failure = failure
+      )
+    )
+  }
+
+  // Private implementation - single place for recording logic
+  private suspend fun <T> executeWithRecording(
+    action: String,
+    input: Any?,
+    output: Any?,
+    metadata: Map<String, Any>,
+    expected: Any?,
+    actual: Any?,
+    assertion: suspend () -> T
+  ): T {
+    if (!reporter.isEnabled) return assertion()
+
+    return try {
+      val result = assertion()
+      recordActionResult(action, input, output, metadata, expected, actual, true, null)
+      result
+    } catch (e: Throwable) {
+      recordActionResult(action, input, output, metadata, expected, actual, false, e)
+      throw e
+    }
+  }
+
+  private fun recordActionResult(
+    action: String,
+    input: Any?,
+    output: Any?,
+    metadata: Map<String, Any>,
+    expected: Any?,
+    actual: Any?,
+    passed: Boolean,
+    error: Throwable?
+  ) {
+    reporter.record(
+      ReportEntryFactory.actionWithResult(
+        system = reportSystemName,
+        testId = reporter.currentTestId(),
+        action = action,
+        input = input,
+        output = output,
+        metadata = metadata,
+        passed = passed,
+        expected = expected,
+        actual = actual,
+        error = error?.message
+      )
+    )
+  }
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveJUnitExtension.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveJUnitExtension.kt
@@ -1,0 +1,79 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.trendyol.stove.testing.e2e.system.TestSystem
+import org.junit.jupiter.api.extension.*
+
+/**
+ * JUnit 5 extension that automatically manages test context and enriches test failures
+ * with Stove's execution report.
+ *
+ * When a test fails, the report is included in the exception message so that JUnit's
+ * test engine displays what happened during the test execution.
+ *
+ * Register this extension on your test class:
+ * ```kotlin
+ * @ExtendWith(StoveJUnitExtension::class)
+ * class MyE2ETests { ... }
+ * ```
+ *
+ * Or globally via @RegisterExtension:
+ * ```kotlin
+ * companion object {
+ *     @JvmField
+ *     @RegisterExtension
+ *     val stove = StoveJUnitExtension()
+ * }
+ * ```
+ */
+class StoveJUnitExtension :
+  BeforeEachCallback,
+  AfterEachCallback,
+  TestExecutionExceptionHandler {
+  override fun beforeEach(context: ExtensionContext) {
+    if (!TestSystem.instanceInitialized()) return
+
+    val ctx = StoveTestContext(
+      testId = "${context.requiredTestClass.simpleName}::${context.requiredTestMethod.name}",
+      testName = context.displayName,
+      specName = context.requiredTestClass.simpleName
+    )
+
+    StoveTestContextHolder.set(ctx)
+    TestSystem.reporter().startTest(ctx)
+  }
+
+  override fun handleTestExecutionException(context: ExtensionContext, throwable: Throwable) {
+    if (!TestSystem.instanceInitialized()) {
+      throw throwable
+    }
+
+    val reporter = TestSystem.reporter()
+    val options = TestSystem.instance.options
+
+    // Enrich the exception with Stove report if enabled
+    if (options.dumpReportOnTestFailure && options.reportingEnabled) {
+      val report = reporter.dumpIfFailed(options.failureRenderer)
+      if (report.isNotEmpty()) {
+        throw StoveTestFailureException(
+          originalMessage = throwable.message ?: "Test failed",
+          stoveReport = report,
+          cause = throwable
+        )
+      }
+    }
+
+    // Re-throw original exception if no report or reporting disabled
+    throw throwable
+  }
+
+  override fun afterEach(context: ExtensionContext) {
+    if (!TestSystem.instanceInitialized()) return
+
+    val reporter = TestSystem.reporter()
+
+    // Clear report for next test
+    reporter.endTest()
+    reporter.clear()
+    StoveTestContextHolder.clear()
+  }
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveKotestExtension.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveKotestExtension.kt
@@ -1,0 +1,149 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.trendyol.stove.testing.e2e.system.TestSystem
+import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.test.TestCase
+import io.kotest.engine.test.TestResult
+
+/**
+ * Kotest extension that automatically manages test context and enriches test failures
+ * with Stove's execution report.
+ *
+ * When a test fails, the report is included in the exception message so that Kotest's
+ * test engine displays what happened during the test execution.
+ *
+ * Register this extension in your Kotest project config:
+ * ```kotlin
+ * class TestConfig : AbstractProjectConfig() {
+ *     override fun extensions() = listOf(StoveKotestExtension())
+ * }
+ * ```
+ */
+class StoveKotestExtension : TestCaseExtension {
+  override suspend fun intercept(
+    testCase: TestCase,
+    execute: suspend (TestCase) -> TestResult
+  ): TestResult {
+    if (!TestSystem.instanceInitialized()) {
+      return execute(testCase)
+    }
+
+    val reporter = TestSystem.reporter()
+    val options = TestSystem.instance.options
+
+    return reporter.withTestContext(testCase.toStoveContext()) {
+      execute(testCase).enrichIfFailed(options, reporter)
+    }
+  }
+
+  private fun TestCase.toStoveContext() = StoveTestContext(
+    testId = "${spec::class.simpleName}::${name.name}",
+    testName = name.name,
+    specName = spec::class.simpleName
+  )
+
+  private fun TestResult.enrichIfFailed(
+    options: com.trendyol.stove.testing.e2e.system.TestSystemOptions,
+    reporter: StoveReporter
+  ): TestResult {
+    if (!options.shouldEnrichFailures()) return this
+
+    return when (this) {
+      is TestResult.Failure -> enrichFailure(reporter, options)
+      is TestResult.Error -> enrichError(reporter, options)
+      else -> this
+    }
+  }
+
+  private fun TestResult.Failure.enrichFailure(
+    reporter: StoveReporter,
+    options: com.trendyol.stove.testing.e2e.system.TestSystemOptions
+  ): TestResult = reporter
+    .dumpIfFailed(options.failureRenderer)
+    .takeIf { it.isNotEmpty() }
+    ?.let { report ->
+      TestResult.Failure(
+        duration,
+        StoveTestFailureException(cause.message ?: "Test failed", report, cause)
+      )
+    } ?: this
+
+  private fun TestResult.Error.enrichError(
+    reporter: StoveReporter,
+    options: com.trendyol.stove.testing.e2e.system.TestSystemOptions
+  ): TestResult = reporter
+    .dumpIfFailed(options.failureRenderer)
+    .takeIf { it.isNotEmpty() }
+    ?.let { report ->
+      TestResult.Error(
+        duration,
+        StoveTestErrorException(cause.message ?: "Test error", report, cause)
+      )
+    } ?: this
+}
+
+private fun com.trendyol.stove.testing.e2e.system.TestSystemOptions.shouldEnrichFailures() =
+  dumpReportOnTestFailure && reportingEnabled
+
+/**
+ * Executes the block within a test context, ensuring proper setup and cleanup.
+ */
+private inline fun <T> StoveReporter.withTestContext(
+  ctx: StoveTestContext,
+  block: () -> T
+): T {
+  startTest(ctx)
+  return try {
+    block()
+  } finally {
+    endTest()
+    clear()
+  }
+}
+
+/**
+ * Exception that wraps test assertion failures with Stove's execution report.
+ * The report is included in the exception message for display by test engines.
+ *
+ * Preserves the original exception's stack trace so test frameworks show the actual failure location.
+ */
+class StoveTestFailureException(
+  originalMessage: String,
+  stoveReport: String,
+  cause: Throwable? = null
+) : AssertionError(buildStoveReportMessage(originalMessage, stoveReport), cause) {
+  init {
+    // Copy the original stack trace to show the actual failure location
+    cause?.let { stackTrace = it.stackTrace }
+  }
+}
+
+/**
+ * Exception that wraps test errors with Stove's execution report.
+ * The report is included in the exception message for display by test engines.
+ *
+ * Preserves the original exception's stack trace so test frameworks show the actual failure location.
+ */
+class StoveTestErrorException(
+  originalMessage: String,
+  stoveReport: String,
+  cause: Throwable? = null
+) : Exception(buildStoveReportMessage(originalMessage, stoveReport), cause) {
+  init {
+    // Copy the original stack trace to show the actual failure location
+    cause?.let { stackTrace = it.stackTrace }
+  }
+}
+
+private fun buildStoveReportMessage(
+  originalMessage: String,
+  stoveReport: String
+): String = """
+  |$originalMessage
+  |
+  |═══════════════════════════════════════════════════════════════════════════════
+  |                         STOVE EXECUTION REPORT
+  |═══════════════════════════════════════════════════════════════════════════════
+  |
+  |$stoveReport
+  """.trimMargin()

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveReporter.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveReporter.kt
@@ -1,0 +1,88 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.trendyol.stove.testing.e2e.system.TestSystem
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Central reporter that manages test reports and context.
+ * Thread-safe for concurrent test execution.
+ *
+ * ## Design
+ * - Each test gets its own [TestReport] container
+ * - Test context is resolved from [StoveTestContextHolder] (ThreadLocal) or internal context
+ * - Snapshots are collected from all systems implementing [Reports]
+ */
+class StoveReporter(
+  val isEnabled: Boolean = true
+) {
+  private val reports = ConcurrentHashMap<String, TestReport>()
+  private val contextThreadLocal = ThreadLocal<String>()
+
+  /** Start tracking a new test */
+  fun startTest(ctx: StoveTestContext) {
+    contextThreadLocal.set(ctx.testId)
+    reports.computeIfAbsent(ctx.testId) { TestReport(ctx.testId, ctx.testName) }
+  }
+
+  /** End tracking the current test */
+  fun endTest(): Unit = contextThreadLocal.remove()
+
+  /** Record an entry in the current test's report */
+  fun record(entry: ReportEntry) {
+    if (!isEnabled) return
+    currentTest().record(entry)
+  }
+
+  /** Get report for current test, creating if needed */
+  fun currentTest(): TestReport =
+    reports.computeIfAbsent(currentTestId()) { TestReport(it, it) }
+
+  /** Get report for current test if it exists */
+  fun currentTestOrNull(): TestReport? =
+    resolveTestId()?.let { reports[it] }
+
+  /** Get current test ID */
+  fun currentTestId(): String =
+    resolveTestId() ?: DEFAULT_TEST_ID
+
+  /** Check if current test has failures */
+  fun hasFailures(): Boolean =
+    currentTestOrNull()?.hasFailures() == true
+
+  /** Clear current test report */
+  fun clear(): Unit = currentTestOrNull()?.clear() ?: Unit
+
+  /** Render report using specified renderer */
+  fun dump(renderer: ReportRenderer): String =
+    currentTestOrNull()?.let { renderer.render(it, collectSnapshots()) } ?: ""
+
+  /** Render report only if there are failures */
+  fun dumpIfFailed(renderer: ReportRenderer = PrettyConsoleRenderer): String =
+    currentTestOrNull()
+      ?.takeIf { it.hasFailures() }
+      ?.let { renderer.render(it, collectSnapshots()) }
+      ?: ""
+
+  /** Print report to console only if there are failures */
+  fun printIfFailed(renderer: ReportRenderer = PrettyConsoleRenderer): Unit =
+    dumpIfFailed(renderer).takeIf { it.isNotEmpty() }?.let(::println) ?: Unit
+
+  /** Collect snapshots from all reporting systems */
+  fun collectSnapshots(): List<SystemSnapshot> =
+    runCatching {
+      if (TestSystem.instanceInitialized()) {
+        TestSystem.instance.activeSystems.values
+          .filterIsInstance<Reports>()
+          .map { it.snapshot() }
+      } else {
+        emptyList()
+      }
+    }.getOrDefault(emptyList())
+
+  private fun resolveTestId(): String? =
+    StoveTestContextHolder.get()?.testId ?: contextThreadLocal.get()
+
+  companion object {
+    private const val DEFAULT_TEST_ID = "default"
+  }
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContext.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContext.kt
@@ -1,0 +1,23 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Coroutine context element that identifies the current test.
+ * Used by Kotest to correlate report entries with the test that generated them.
+ */
+data class StoveTestContext(
+    val testId: String,
+    val testName: String,
+    val specName: String? = null
+) : AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<StoveTestContext>
+}
+
+/**
+ * Extension function to get the current test context from the coroutine context.
+ */
+suspend fun currentStoveTestContext(): StoveTestContext? =
+    currentCoroutineContext()[StoveTestContext]

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContextHolder.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContextHolder.kt
@@ -1,0 +1,24 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+/**
+ * Thread-local holder for test context.
+ * Used by JUnit 5 (which uses threads) to correlate report entries with tests.
+ */
+object StoveTestContextHolder {
+  private val threadLocalContext = ThreadLocal<StoveTestContext>()
+
+  /**
+   * Set the current test context for this thread.
+   */
+  fun set(context: StoveTestContext) = threadLocalContext.set(context)
+
+  /**
+   * Get the current test context for this thread, if any.
+   */
+  fun get(): StoveTestContext? = threadLocalContext.get()
+
+  /**
+   * Clear the test context for this thread.
+   */
+  fun clear() = threadLocalContext.remove()
+}

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/SystemSnapshot.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/SystemSnapshot.kt
@@ -1,0 +1,14 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+/**
+ * Snapshot of a system's state at a point in time.
+ * Used for debugging test failures by providing context about what the system was doing.
+ *
+ * Systems with rich internal state (like Kafka's MessageStore or WireMock's stubs)
+ * should override [Reports.snapshot] to provide detailed state information.
+ */
+data class SystemSnapshot(
+  val system: String,
+  val state: Map<String, Any>,
+  val summary: String
+)

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/TestReport.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/reporting/TestReport.kt
@@ -1,0 +1,70 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Container for report entries belonging to a single test.
+ * Thread-safe for concurrent recording during test execution.
+ *
+ * Exposes only immutable views of data through public APIs.
+ */
+class TestReport(
+  val testId: String,
+  val testName: String
+) {
+  private val queue: ConcurrentLinkedQueue<ReportEntry> = ConcurrentLinkedQueue()
+
+  /** Record a new entry. Thread-safe. */
+  fun record(entry: ReportEntry): Unit = queue.add(entry).let { }
+
+  /** All entries as immutable list */
+  fun entries(): List<ReportEntry> = queue.toList()
+
+  /** Entries for this test only */
+  fun entriesForThisTest(): List<ReportEntry> = queue.filter { it.testId == testId }
+
+  /** All failed entries */
+  fun failures(): List<ReportEntry> = queue.filter { it.isFailed }
+
+  /** Failed entries for this test */
+  fun failuresForThisTest(): List<ReportEntry> = entriesForThisTest().filter { it.isFailed }
+
+  /** True if any failures exist */
+  fun hasFailures(): Boolean = queue.any { it.isFailed }
+
+  /** Clear all entries */
+  fun clear(): Unit = queue.clear()
+}
+
+// ============================================================================
+// Extension Functions for List<ReportEntry>
+// Functional-style filtering operations
+// ============================================================================
+
+/** Filter entries by system name */
+fun List<ReportEntry>.forSystem(system: String): List<ReportEntry> =
+  filter { it.system == system }
+
+/** Filter entries by test ID */
+fun List<ReportEntry>.forTest(testId: String): List<ReportEntry> =
+  filter { it.testId == testId }
+
+/** Get only failed entries */
+fun List<ReportEntry>.failures(): List<ReportEntry> =
+  filter { it.isFailed }
+
+/** Get only passed entries */
+fun List<ReportEntry>.passed(): List<ReportEntry> =
+  filter { it.isPassed }
+
+/** Get only action entries */
+fun List<ReportEntry>.actions(): List<ActionEntry> =
+  filterIsInstance<ActionEntry>()
+
+/** Get only assertion entries */
+fun List<ReportEntry>.assertions(): List<AssertionEntry> =
+  filterIsInstance<AssertionEntry>()
+
+/** Get entries with assertion results (passed or failed) */
+fun List<ReportEntry>.withResults(): List<ReportEntry> =
+  filter { it.result != null }

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/system/TestSystemOptions.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/system/TestSystemOptions.kt
@@ -1,11 +1,23 @@
 package com.trendyol.stove.testing.e2e.system
 
+import com.trendyol.stove.testing.e2e.reporting.JsonReportRenderer
+import com.trendyol.stove.testing.e2e.reporting.PrettyConsoleRenderer
+import com.trendyol.stove.testing.e2e.reporting.ReportRenderer
 import com.trendyol.stove.testing.e2e.system.abstractions.*
 
 data class TestSystemOptions(
   val keepDependenciesRunning: Boolean = false,
   val stateStorageFactory: StateStorageFactory = StateStorageFactory.Default(),
-  val runMigrationsAlways: Boolean = false
+  val runMigrationsAlways: Boolean = false,
+  val reportingEnabled: Boolean = true,
+  val dumpReportOnTestFailure: Boolean = true,
+  val dumpReportOnStop: Boolean = false,
+  val defaultRenderer: ReportRenderer = PrettyConsoleRenderer,
+  val failureRenderer: ReportRenderer = PrettyConsoleRenderer,
+  val fileRenderer: ReportRenderer = JsonReportRenderer,
+  val reportToConsole: Boolean = true,
+  val reportToFile: Boolean = false,
+  val reportFilePath: String = "build/stove-reports"
 ) {
   inline fun <reified TState : ExposedConfiguration, reified TSystem : PluggedSystem> createStateStorage(): StateStorage<TState> =
     (this.stateStorageFactory(this, TSystem::class, TState::class))

--- a/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl.kt
+++ b/lib/stove-testing-e2e/src/main/kotlin/com/trendyol/stove/testing/e2e/system/TestSystemOptionsDsl.kt
@@ -1,50 +1,136 @@
 package com.trendyol.stove.testing.e2e.system
 
+import com.trendyol.stove.testing.e2e.reporting.ReportRenderer
 import com.trendyol.stove.testing.e2e.system.abstractions.StateStorageFactory
 import com.trendyol.stove.testing.e2e.system.annotations.StoveDsl
-import org.slf4j.*
+import org.slf4j.LoggerFactory
 
+/**
+ * DSL for configuring [TestSystemOptions].
+ *
+ * Example:
+ * ```kotlin
+ * TestSystem {
+ *   if (isRunningLocally()) {
+ *     enableReuseForTestContainers()
+ *     keepDependenciesRunning()
+ *   }
+ *   reporting {
+ *     enabled()
+ *     dumpOnFailure()
+ *   }
+ * }
+ * ```
+ */
 @StoveDsl
 class TestSystemOptionsDsl {
-  private val l: Logger = LoggerFactory.getLogger(javaClass)
+  private val logger = LoggerFactory.getLogger(javaClass)
   private val propertiesFile = PropertiesFile()
 
   internal var options = TestSystemOptions()
+    private set
 
-  @StoveDsl
-  fun keepDependenciesRunning(): TestSystemOptionsDsl {
-    l.info(
-      """You have chosen to keep dependencies running. 
-                | For that Stove needs '.testcontainers.properties' file under your user(~/).
-                | To add that call '${TestSystemOptionsDsl::enableReuseForTestContainers.name}' method
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Container & Environment
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Keep dependencies (containers) running after tests complete.
+   * Requires `.testcontainers.properties` file - call [enableReuseForTestContainers] first.
+   */
+  fun keepDependenciesRunning(): TestSystemOptionsDsl = apply {
+    logger.info(
+      """
+      |You have chosen to keep dependencies running.
+      |For that Stove needs '.testcontainers.properties' file under your user(~/).
+      |To add that call 'enableReuseForTestContainers()' method
       """.trimMargin()
     )
-
     propertiesFile.detectAndLogStatus()
     options = options.copy(keepDependenciesRunning = true)
-    return this
   }
 
-  @StoveDsl
+  /**
+   * Check if tests are running locally (not on CI).
+   */
   fun isRunningLocally(): Boolean = !isRunningOnCI()
 
-  @StoveDsl
+  /**
+   * Enable container reuse in TestContainers by creating the required properties file.
+   */
   fun enableReuseForTestContainers(): Unit = propertiesFile.enable()
 
-  @StoveDsl
-  fun stateStorage(factory: StateStorageFactory): TestSystemOptionsDsl {
+  /**
+   * Configure custom state storage factory.
+   */
+  fun stateStorage(factory: StateStorageFactory): TestSystemOptionsDsl = apply {
     options = options.copy(stateStorageFactory = factory)
-    return this
   }
 
-  @StoveDsl
-  fun runMigrationsAlways(): TestSystemOptionsDsl {
+  /**
+   * Always run migrations, even if the database state hasn't changed.
+   */
+  fun runMigrationsAlways(): TestSystemOptionsDsl = apply {
     options = options.copy(runMigrationsAlways = true)
-    return this
   }
 
-  private fun isRunningOnCI(): Boolean =
-    System.getenv("CI") == "true" ||
-      System.getenv("GITLAB_CI") == "true" ||
-      System.getenv("GITHUB_ACTIONS") == "true"
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Reporting Configuration
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Configure reporting options using the [ReportingDsl].
+   *
+   * Example:
+   * ```kotlin
+   * reporting {
+   *   enabled()
+   *   dumpOnFailure()
+   * }
+   * ```
+   */
+  fun reporting(configure: ReportingDsl.() -> Unit): TestSystemOptionsDsl = apply {
+    ReportingDsl(this).configure()
+  }
+
+  /** Enable reporting. */
+  fun reportingEnabled(enabled: Boolean = true): TestSystemOptionsDsl = apply {
+    options = options.copy(reportingEnabled = enabled)
+  }
+
+  /** Dump report on test failure. */
+  fun dumpReportOnTestFailure(enabled: Boolean = true): TestSystemOptionsDsl = apply {
+    options = options.copy(dumpReportOnTestFailure = enabled)
+  }
+
+  /** Set the renderer used for test failure reports. */
+  fun failureRenderer(renderer: ReportRenderer): TestSystemOptionsDsl = apply {
+    options = options.copy(failureRenderer = renderer)
+  }
+
+  private fun isRunningOnCI(): Boolean = CI_ENV_VARS.any { System.getenv(it) == "true" }
+
+  companion object {
+    private val CI_ENV_VARS = listOf("CI", "GITLAB_CI", "GITHUB_ACTIONS")
+  }
+}
+
+/**
+ * DSL for configuring reporting options in a grouped, fluent manner.
+ */
+@StoveDsl
+class ReportingDsl(
+  private val parent: TestSystemOptionsDsl
+) {
+  /** Enable reporting. */
+  fun enabled(value: Boolean = true) = parent.reportingEnabled(value)
+
+  /** Disable reporting. */
+  fun disabled() = enabled(false)
+
+  /** Dump report on test failure. */
+  fun dumpOnFailure(value: Boolean = true) = parent.dumpReportOnTestFailure(value)
+
+  /** Set the failure renderer. */
+  fun failureRenderer(renderer: ReportRenderer) = parent.failureRenderer(renderer)
 }

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/JsonReportRendererTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/JsonReportRendererTest.kt
@@ -1,0 +1,41 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class JsonReportRendererTest :
+  FunSpec({
+
+    test("generates valid JSON with entries and summary") {
+      val report = TestReport("test-1", "should process order")
+      report.record(ActionEntry(Instant.now(), "HTTP", "test-1", "POST /api"))
+      report.record(AssertionEntry(Instant.now(), "HTTP", "test-1", "status", result = AssertionResult.PASSED))
+
+      val json = JsonReportRenderer.render(report, emptyList())
+      val parsed = ObjectMapper().readTree(json)
+
+      parsed["testId"].asText() shouldBe "test-1"
+      parsed["testName"].asText() shouldBe "should process order"
+      parsed["entries"].size() shouldBe 2
+      parsed["summary"]["totalActions"].asInt() shouldBe 1
+      parsed["summary"]["totalAssertions"].asInt() shouldBe 1
+      parsed["summary"]["passedAssertions"].asInt() shouldBe 1
+    }
+
+    test("includes system snapshots") {
+      val report = TestReport("test-1", "test")
+      val snapshot = SystemSnapshot(
+        system = "Kafka",
+        state = mapOf("consumed" to listOf(mapOf("topic" to "orders"))),
+        summary = "1 message"
+      )
+
+      val json = JsonReportRenderer.render(report, listOf(snapshot))
+      val parsed = ObjectMapper().readTree(json)
+
+      parsed["systemSnapshots"]["Kafka"]["consumed"].size() shouldBe 1
+      parsed["systemSnapshots"]["Kafka"]["consumed"][0]["topic"].asText() shouldBe "orders"
+    }
+  })

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/PrettyConsoleRendererTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/PrettyConsoleRendererTest.kt
@@ -1,0 +1,99 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import com.trendyol.stove.ConsoleSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.Instant
+
+class PrettyConsoleRendererTest :
+  ConsoleSpec({ output ->
+
+    fun String.stripAnsi(): String = replace(Regex("\u001B\\[[0-9;]*m"), "")
+
+    test("renders timeline with box drawing") {
+      val report = TestReport("test-1", "should process order")
+      report.record(
+        ActionEntry(
+          timestamp = Instant.parse("2025-01-05T10:15:23.001Z"),
+          system = "HTTP",
+          testId = "test-1",
+          action = "POST /api/orders"
+        )
+      )
+
+      val rendered = PrettyConsoleRenderer.render(report, emptyList())
+      println(rendered)
+
+      val plainOutput = output.out.stripAnsi()
+      plainOutput shouldContain "STOVE TEST EXECUTION REPORT"
+      plainOutput shouldContain "should process order"
+      plainOutput shouldContain "[HTTP] POST /api/orders"
+      output.out shouldContain "╔"
+      output.out shouldContain "╚"
+    }
+
+    test("highlights failed assertions") {
+      val report = TestReport("test-1", "should fail")
+      report.record(
+        AssertionEntry(
+          timestamp = Instant.now(),
+          system = "Kafka",
+          testId = "test-1",
+          description = "shouldBePublished<OrderEvent>",
+          result = AssertionResult.FAILED,
+          failure = AssertionError("Timed out")
+        )
+      )
+
+      val rendered = PrettyConsoleRenderer.render(report, emptyList())
+      println(rendered)
+
+      val plainOutput = output.out.stripAnsi()
+      plainOutput shouldContain "✗"
+      plainOutput shouldContain "FAILED"
+      plainOutput shouldContain "Timed out"
+    }
+
+    test("renders system snapshots") {
+      val report = TestReport("test-1", "test")
+      val snapshot = SystemSnapshot(
+        system = "Kafka",
+        state = mapOf("consumed" to listOf(mapOf("topic" to "orders"))),
+        summary = "Consumed: 1\nPublished: 0"
+      )
+
+      val rendered = PrettyConsoleRenderer.render(report, listOf(snapshot))
+      println(rendered)
+
+      val plainOutput = output.out.stripAnsi()
+      plainOutput shouldContain "KAFKA"
+      plainOutput shouldContain "Consumed: 1"
+    }
+
+    test("maintains frame integrity with long text") {
+      val report = TestReport("test-long", "long test name")
+      val longInput = "This is a very long input that exceeds the box width and should be wrapped properly"
+
+      report.record(
+        ActionEntry(
+          timestamp = Instant.now(),
+          system = "HTTP",
+          testId = "test-long",
+          action = "POST /api/endpoint",
+          input = longInput
+        )
+      )
+
+      val rendered = PrettyConsoleRenderer.render(report, emptyList())
+      println(rendered)
+
+      // Verify all content lines end with the closing border
+      val plainRendered = rendered.stripAnsi()
+      plainRendered
+        .lines()
+        .filter { it.startsWith("║") }
+        .forEach { line ->
+          line.endsWith("║") shouldBe true
+        }
+    }
+  })

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportEntryTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/ReportEntryTest.kt
@@ -1,0 +1,57 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class ReportEntryTest :
+  FunSpec({
+
+    test("ActionEntry generates correct summary") {
+      val entry = ActionEntry(
+        timestamp = Instant.now(),
+        system = "HTTP",
+        testId = "test-1",
+        action = "POST /api/users"
+      )
+
+      entry.summary shouldBe "[HTTP] POST /api/users"
+    }
+
+    test("ActionEntry with failed result is detected as failure") {
+      val entry = ActionEntry(
+        timestamp = Instant.now(),
+        system = "PostgreSQL",
+        testId = "test-1",
+        action = "Query",
+        result = AssertionResult.FAILED,
+        error = "Row count mismatch"
+      )
+
+      entry.isFailed shouldBe true
+      entry.isPassed shouldBe false
+    }
+
+    test("AssertionEntry captures failure details") {
+      val error = AssertionError("Expected 200 but got 500")
+      val entry = AssertionEntry(
+        timestamp = Instant.now(),
+        system = "HTTP",
+        testId = "test-1",
+        description = "Response status check",
+        expected = 200,
+        actual = 500,
+        result = AssertionResult.FAILED,
+        failure = error
+      )
+
+      entry.isFailed shouldBe true
+      entry.failure?.message shouldBe "Expected 200 but got 500"
+      entry.summary shouldBe "[HTTP] Response status check: FAILED"
+    }
+
+    test("AssertionResult.of converts boolean correctly") {
+      AssertionResult.of(true) shouldBe AssertionResult.PASSED
+      AssertionResult.of(false) shouldBe AssertionResult.FAILED
+    }
+  })

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveReporterTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveReporterTest.kt
@@ -1,0 +1,74 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class StoveReporterTest :
+  FunSpec({
+
+    test("starts test and creates report") {
+      val reporter = StoveReporter()
+      val ctx = StoveTestContext("TestSpec::test1", "test1", "TestSpec")
+
+      reporter.startTest(ctx)
+      val report = reporter.currentTest()
+
+      report.testId shouldBe "TestSpec::test1"
+      report.testName shouldBe "test1"
+    }
+
+    test("records entries when enabled") {
+      val reporter = StoveReporter()
+      reporter.startTest(StoveTestContext("test-1", "test1"))
+
+      reporter.record(ActionEntry(Instant.now(), "HTTP", "test-1", "GET /api"))
+
+      reporter.currentTest().entries() shouldHaveSize 1
+    }
+
+    test("ignores entries when disabled") {
+      val reporter = StoveReporter(isEnabled = false)
+      reporter.startTest(StoveTestContext("test-1", "test1"))
+
+      reporter.record(ActionEntry(Instant.now(), "HTTP", "test-1", "GET /api"))
+
+      reporter.currentTest().entries() shouldHaveSize 0
+    }
+
+    test("uses default test ID when no context") {
+      val reporter = StoveReporter()
+
+      reporter.currentTestId() shouldBe "default"
+      reporter.currentTest().testId shouldBe "default"
+    }
+
+    test("clears context after endTest") {
+      val reporter = StoveReporter()
+      reporter.startTest(StoveTestContext("test-1", "test1"))
+
+      reporter.endTest()
+
+      reporter.currentTestId() shouldBe "default"
+    }
+
+    test("detects failures correctly") {
+      val reporter = StoveReporter()
+      reporter.startTest(StoveTestContext("test-1", "test1"))
+
+      reporter.hasFailures() shouldBe false
+
+      reporter.record(
+        AssertionEntry(
+          Instant.now(),
+          "HTTP",
+          "test-1",
+          "check",
+          result = AssertionResult.FAILED
+        )
+      )
+
+      reporter.hasFailures() shouldBe true
+    }
+  })

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContextTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/StoveTestContextTest.kt
@@ -1,0 +1,38 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+
+class StoveTestContextTest :
+  FunSpec({
+
+    test("StoveTestContext is a CoroutineContext element") {
+      val ctx = StoveTestContext("TestSpec::test1", "test1", "TestSpec")
+
+      ctx.testId shouldBe "TestSpec::test1"
+      ctx.testName shouldBe "test1"
+      ctx.specName shouldBe "TestSpec"
+      ctx.key shouldBe StoveTestContext.Key
+    }
+
+    test("currentStoveTestContext retrieves context from coroutine") {
+      val ctx = StoveTestContext("test-1", "test1")
+      val contextWithStove = currentCoroutineContext() + ctx
+
+      withContext(contextWithStove) {
+        currentStoveTestContext() shouldBe ctx
+      }
+    }
+
+    test("StoveTestContextHolder stores context in ThreadLocal") {
+      val ctx = StoveTestContext("test-1", "test1")
+
+      StoveTestContextHolder.set(ctx)
+      StoveTestContextHolder.get() shouldBe ctx
+
+      StoveTestContextHolder.clear()
+      StoveTestContextHolder.get() shouldBe null
+    }
+  })

--- a/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/TestReportTest.kt
+++ b/lib/stove-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/reporting/TestReportTest.kt
@@ -1,0 +1,78 @@
+package com.trendyol.stove.testing.e2e.reporting
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.Instant
+
+class TestReportTest :
+  FunSpec({
+
+    test("records entries in chronological order") {
+      val report = TestReport("test-1", "test")
+
+      val entry1 = ActionEntry(Instant.now().minusSeconds(2), "HTTP", "test-1", "GET /api")
+      val entry2 = ActionEntry(Instant.now().minusSeconds(1), "Kafka", "test-1", "Publish")
+      val entry3 = AssertionEntry(Instant.now(), "Kafka", "test-1", "consumed", result = AssertionResult.PASSED)
+
+      report.record(entry1)
+      report.record(entry2)
+      report.record(entry3)
+
+      report.entries() shouldHaveSize 3
+      report.entries()[0] shouldBe entry1
+    }
+
+    test("filters failures correctly") {
+      val report = TestReport("test-1", "test")
+
+      report.record(AssertionEntry(Instant.now(), "HTTP", "test-1", "check", result = AssertionResult.PASSED))
+      report.record(AssertionEntry(Instant.now(), "Kafka", "test-1", "check", result = AssertionResult.FAILED))
+      report.record(
+        ActionEntry(
+          Instant.now(),
+          "PostgreSQL",
+          "test-1",
+          "Query",
+          result = AssertionResult.FAILED
+        )
+      )
+
+      report.failures() shouldHaveSize 2
+      report.hasFailures() shouldBe true
+    }
+
+    test("filters entries by testId") {
+      val report = TestReport("test-1", "test")
+
+      report.record(ActionEntry(Instant.now(), "HTTP", "test-1", "action"))
+      report.record(ActionEntry(Instant.now(), "HTTP", "test-2", "other test"))
+
+      report.entries() shouldHaveSize 2
+      report.entriesForThisTest() shouldHaveSize 1
+      report.entriesForThisTest().all { it.testId == "test-1" } shouldBe true
+    }
+
+    test("clear removes all entries") {
+      val report = TestReport("test-1", "test")
+      report.record(ActionEntry(Instant.now(), "HTTP", "test-1", "action"))
+
+      report.clear()
+
+      report.entries() shouldBe emptyList()
+    }
+
+    test("extension functions filter correctly") {
+      val entries = listOf(
+        ActionEntry(Instant.now(), "HTTP", "test-1", "action"),
+        AssertionEntry(Instant.now(), "Kafka", "test-1", "check", result = AssertionResult.PASSED),
+        AssertionEntry(Instant.now(), "HTTP", "test-1", "check", result = AssertionResult.FAILED)
+      )
+
+      entries.forSystem("HTTP") shouldHaveSize 2
+      entries.actions() shouldHaveSize 1
+      entries.assertions() shouldHaveSize 2
+      entries.failures() shouldHaveSize 1
+      entries.passed() shouldHaveSize 1
+    }
+  })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,10 +24,12 @@ nav:
     - Bridge: Components/10-bridge.md
     - Provided Instances: Components/11-provided-instances.md
     - gRPC: Components/12-grpc.md
+    - Reporting: Components/13-reporting.md
   - Writing Custom Systems: writing-custom-systems.md
   - Best Practices: best-practices.md
   - Troubleshooting: troubleshooting.md
   - Release Notes:
+      - 0.20.0: release-notes/0.20.0.md
       - 0.19.0: release-notes/0.19.0.md
       - 0.15.0: release-notes/0.15.0.md
 theme:

--- a/recipes/buildSrc/src/main/kotlin/TestFolders.kt
+++ b/recipes/buildSrc/src/main/kotlin/TestFolders.kt
@@ -3,3 +3,7 @@ object TestFolders {
     const val e2e = "test-e2e"
     const val shared = "test-shared"
 }
+
+val runningOnCI get() = System.getenv("CI") == "true"
+
+val runningLocally get() = !runningOnCI

--- a/recipes/java-recipes/quarkus-basic-recipe/build.gradle.kts
+++ b/recipes/java-recipes/quarkus-basic-recipe/build.gradle.kts
@@ -18,6 +18,10 @@ kotlin {
   }
 }
 
+tasks.e2eTest {
+  enabled = runningLocally
+}
+
 dependencies {
   implementation(enforcedPlatform(libs.quarkus))
   implementation(libs.quarkus.rest)

--- a/starters/ktor/tests/ktor-di-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/ktor/Stove.kt
+++ b/starters/ktor/tests/ktor-di-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/ktor/Stove.kt
@@ -2,10 +2,14 @@ package com.trendyol.stove.testing.e2e.ktor
 
 import com.trendyol.stove.testing.e2e.bridge
 import com.trendyol.stove.testing.e2e.ktor
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 
 class KtorDiStove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {

--- a/starters/ktor/tests/ktor-koin-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/ktor/Stove.kt
+++ b/starters/ktor/tests/ktor-koin-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/ktor/Stove.kt
@@ -2,10 +2,14 @@ package com.trendyol.stove.testing.e2e.ktor
 
 import com.trendyol.stove.testing.e2e.bridge
 import com.trendyol.stove.testing.e2e.ktor
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 
 class KoinStove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {

--- a/starters/micronaut/stove-micronaut-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/BridgeSystemTest.kt
+++ b/starters/micronaut/stove-micronaut-testing-e2e/src/test/kotlin/com/trendyol/stove/testing/e2e/BridgeSystemTest.kt
@@ -2,9 +2,11 @@ package com.trendyol.stove.testing.e2e
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trendyol.stove.testing.*
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.system.*
 import com.trendyol.stove.testing.e2e.system.TestSystem.Companion.validate
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.micronaut.context.ApplicationContext
@@ -60,6 +62,8 @@ object TestAppRunner {
 }
 
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject() = TestSystem()
     .with {
       bridge()

--- a/starters/spring/stove-spring-testing-e2e-kafka/api/stove-spring-testing-e2e-kafka.api
+++ b/starters/spring/stove-spring-testing-e2e-kafka/api/stove-spring-testing-e2e-kafka.api
@@ -93,25 +93,33 @@ public final class com/trendyol/stove/testing/e2e/kafka/KafkaOps {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/trendyol/stove/testing/e2e/kafka/KafkaSystem : com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunnableSystemWithContext {
+public final class com/trendyol/stove/testing/e2e/kafka/KafkaSystem : com/trendyol/stove/testing/e2e/reporting/Reports, com/trendyol/stove/testing/e2e/system/abstractions/ExposesConfiguration, com/trendyol/stove/testing/e2e/system/abstractions/PluggedSystem, com/trendyol/stove/testing/e2e/system/abstractions/RunnableSystemWithContext {
 	public static final field Companion Lcom/trendyol/stove/testing/e2e/kafka/KafkaSystem$Companion;
 	public fun <init> (Lcom/trendyol/stove/testing/e2e/system/TestSystem;Lcom/trendyol/stove/testing/e2e/kafka/KafkaContext;)V
 	public final fun adminOperations (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun afterRun (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterRun (Lorg/springframework/context/ApplicationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun assertKafkaMessage-WPi__2c (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun beforeRun (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
 	public fun configuration ()Ljava/util/List;
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGetInterceptor ()Lkotlin/jvm/functions/Function0;
+	public fun getReportSystemName ()Ljava/lang/String;
+	public fun getReporter ()Lcom/trendyol/stove/testing/e2e/reporting/StoveReporter;
 	public fun getTestSystem ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun pause ()Lcom/trendyol/stove/testing/e2e/kafka/KafkaSystem;
 	public final fun publish (Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun publish$default (Lcom/trendyol/stove/testing/e2e/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun recordAction (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;)V
+	public fun recordAndExecute (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAndExecuteSuspend (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun recordAssertion (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ZLjava/lang/Throwable;Ljava/util/Map;)V
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeConsumedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeFailedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBePublishedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshot ()Lcom/trendyol/stove/testing/e2e/reporting/SystemSnapshot;
 	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun then ()Lcom/trendyol/stove/testing/e2e/system/TestSystem;
 	public final fun unpause ()Lcom/trendyol/stove/testing/e2e/kafka/KafkaSystem;

--- a/starters/spring/stove-spring-testing-e2e-kafka/src/main/kotlin/com/trendyol/stove/testing/e2e/kafka/TestSystemInterceptor.kt
+++ b/starters/spring/stove-spring-testing-e2e-kafka/src/main/kotlin/com/trendyol/stove/testing/e2e/kafka/TestSystemInterceptor.kt
@@ -29,6 +29,11 @@ class TestSystemKafkaInterceptor<K : Any, V : Any>(
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val store = MessageStore()
 
+  /**
+   * Get access to the message store for reporting purposes.
+   */
+  internal fun getStore(): MessageStore = store
+
   override fun onSuccess(
     record: ProducerRecord<K, V>,
     recordMetadata: RecordMetadata

--- a/starters/spring/tests/spring-2x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
+++ b/starters/spring/tests/spring-2x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
@@ -1,9 +1,11 @@
 package com.trendyol.stove.testing.e2e
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.serialization.StoveSerde
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
@@ -15,6 +17,8 @@ open class TestSpringBootApp
  * Uses [stoveSpringRegistrar] with `bean<T>()` DSL.
  */
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {

--- a/starters/spring/tests/spring-3x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
+++ b/starters/spring/tests/spring-3x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
@@ -1,9 +1,11 @@
 package com.trendyol.stove.testing.e2e
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.serialization.StoveSerde
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
@@ -15,6 +17,8 @@ open class TestSpringBootApp
  * Uses [stoveSpringRegistrar] with `bean<T>()` DSL.
  */
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {

--- a/starters/spring/tests/spring-4x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
+++ b/starters/spring/tests/spring-4x-tests/src/test/kotlin/com/trendyol/stove/testing/e2e/Stove.kt
@@ -1,9 +1,11 @@
 package com.trendyol.stove.testing.e2e
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.trendyol.stove.testing.e2e.reporting.StoveKotestExtension
 import com.trendyol.stove.testing.e2e.serialization.StoveSerde
 import com.trendyol.stove.testing.e2e.system.TestSystem
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
@@ -15,6 +17,8 @@ open class TestSpringBootApp
  * Uses [stoveSpring4xRegistrar] with `registerBean<T>()` DSL.
  */
 class Stove : AbstractProjectConfig() {
+  override val extensions: List<Extension> = listOf(StoveKotestExtension())
+
   override suspend fun beforeProject(): Unit =
     TestSystem()
       .with {


### PR DESCRIPTION
```
## Example Output

When a test fails, you'll see output like this:

 
expected:<2> but was:<1>
═══════════════════════════════════════════════════════════════════════════════
                         STOVE EXECUTION REPORT
═══════════════════════════════════════════════════════════════════════════════
╔══════════════════════════════════════════════════════════════════════════════╗
║                           STOVE TEST REPORT                                  ║
║ Test: ExampleTest::should save the product                                   ║
╠══════════════════════════════════════════════════════════════════════════════╣
║ 14:47:38.215 ● [HTTP] POST /api/products                                     ║
║     Input: {"id":1234,"name":"Test Product"}                                 ║
║     Output: 201 Created                                                      ║
║     ✓ PASSED                                                                 ║
║                                                                              ║
║ 14:47:38.341 ● [PostgreSQL] Query                                            ║
║     Input: SELECT * FROM Products WHERE id=1234                              ║
║     Output: 1 row(s) returned                                                ║
║     ✗ FAILED                                                                 ║
║     Expected: 2                                                              ║
║     Actual: 1                                                                ║
║     Error: expected:<2> but was:<1>                                          ║
║                                                                              ║
║     📍 Location: ExampleTest.kt:45                                           ║
║     Class: ExampleTest                                                       ║
║     Code:                                                                    ║
║         result.size shouldBe 2                                               ║
╚══════════════════════════════════════════════════════════════════════════════╝
```

 

implements #960