### PR TITLE
feat(tracing): introduce stove-tracing to capture the journey of the code for an executed e2e test and enrich the Stove Execution Report with it.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,6 +129,7 @@ subprojects.of("lib", "spring", "examples", "ktor", "micronaut", "tests", "test-
 val publishedProjects = listOf(
   projects.lib.stoveBom.name,
   projects.lib.stove.name,
+  projects.lib.stoveTracing.name,
   projects.lib.stoveCouchbase.name,
   projects.lib.stoveElasticsearch.name,
   projects.lib.stoveGrpc.name,

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
-  `kotlin-dsl`
+    `kotlin-dsl`
 }
 
 repositories {
-  mavenCentral()
-  google()
-  gradlePluginPortal()
+    mavenCentral()
+    google()
+    gradlePluginPortal()
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,8 +1,9 @@
 rootProject.name = "buildSrc"
+
 dependencyResolutionManagement {
-  versionCatalogs {
-    create("libs").from(files("../gradle/libs.versions.toml"))
-  }
+    versionCatalogs {
+        create("libs").from(files("../gradle/libs.versions.toml"))
+    }
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/buildSrc/src/main/kotlin/com/trendyol/stove/gradle/StoveTracingConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/trendyol/stove/gradle/StoveTracingConfiguration.kt
@@ -1,0 +1,320 @@
+@file:Suppress("TooManyFunctions")
+
+package com.trendyol.stove.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.testing.Test
+import java.net.ServerSocket
+
+/*
+ * ════════════════════════════════════════════════════════════════════════════════
+ * STOVE TRACING CONFIGURATION
+ * ════════════════════════════════════════════════════════════════════════════════
+ *
+ * This file configures the OpenTelemetry Java Agent for Stove test tracing.
+ * When a test fails, Stove can display the execution trace showing exactly
+ * what happened during the test - HTTP calls, Kafka messages, database queries, etc.
+ *
+ * HOW TO USE IN YOUR PROJECT:
+ * ───────────────────────────
+ * 1. Copy this file to your project's buildSrc/src/main/kotlin/ directory
+ *    (create the directory structure if it doesn't exist)
+ *
+ * 2. In your test module's build.gradle.kts, add:
+ *
+ *    import com.trendyol.stove.gradle.configureStoveTracing
+ *
+ *    configureStoveTracing {
+ *        serviceName = "my-service"
+ *    }
+ *
+ * 3. In your Stove test setup, enable tracing:
+ *
+ *    Stove(...)
+ *        .with {
+ *            tracing {
+ *                serviceName("my-service")
+ *                enableSpanReceiver() // Port is auto-configured from STOVE_TRACING_PORT env var
+ *            }
+ *            // ... other systems
+ *        }
+ *
+ * CONFIGURATION OPTIONS:
+ * ──────────────────────
+ * - serviceName: The service name shown in traces (required)
+ * - enabled: Toggle tracing on/off (default: true)
+ * - protocol: grpc or http/protobuf (default: grpc)
+ * - testTaskNames: Apply only to specific tasks (default: all test tasks)
+ * - otelAgentVersion: OTel agent version (default: 2.24.0)
+ *
+ * Note: The OTLP port is dynamically assigned to avoid conflicts when running
+ * parallel tests. The port is passed to tests via STOVE_TRACING_PORT env var.
+ *
+ * ADVANCED USAGE:
+ * ───────────────
+ * // Apply only to integration tests
+ * configureStoveTracing {
+ *     serviceName = "my-service"
+ *     testTaskNames = listOf("integrationTest")
+ * }
+ *
+ * // Custom OTel agent version
+ * configureStoveTracing {
+ *     serviceName = "my-service"
+ *     otelAgentVersion = "2.25.0"
+ * }
+ *
+ * // Disable specific instrumentations
+ * configureStoveTracing {
+ *     serviceName = "my-service"
+ *     disabledInstrumentations = listOf("jdbc", "hibernate")
+ * }
+ *
+ * ════════════════════════════════════════════════════════════════════════════════
+ */
+
+/**
+ * Constants for Stove tracing configuration.
+ */
+private object TracingDefaults {
+  const val DEFAULT_BSP_SCHEDULE_DELAY = 100
+  const val DEFAULT_BSP_MAX_BATCH_SIZE = 1
+  const val DEFAULT_OTEL_AGENT_VERSION = "2.24.0"
+  const val DEFAULT_PROTOCOL = "grpc"
+
+  /** Environment variable name for passing the OTLP port to tests */
+  const val STOVE_TRACING_PORT_ENV = "STOVE_TRACING_PORT"
+}
+
+/**
+ * Configures Stove tracing for a Gradle project.
+ *
+ * This function provides a simple way to set up OpenTelemetry Java Agent
+ * for test tracing without needing to apply a plugin.
+ *
+ * Example usage in build.gradle.kts:
+ * ```kotlin
+ * import com.trendyol.stove.gradle.configureStoveTracing
+ *
+ * configureStoveTracing {
+ *     serviceName = "my-service"
+ * }
+ * ```
+ *
+ * To configure only specific test tasks:
+ * ```kotlin
+ * configureStoveTracing {
+ *     serviceName = "my-service"
+ *     testTaskNames = listOf("integrationTest") // Only apply to integrationTest task
+ * }
+ * ```
+ */
+fun Project.configureStoveTracing(configure: StoveTracingConfig.() -> Unit = {}) {
+  val config = StoveTracingConfig().apply(configure)
+
+  // Create otelAgent configuration
+  val otelAgentConfig = configurations.create("otelAgent").apply {
+    isTransitive = false
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    description = "OpenTelemetry Java Agent for Stove test tracing"
+  }
+
+  // Add OTel agent dependency after evaluation
+  afterEvaluate {
+    if (!config.enabled) {
+      logger.info("Stove tracing is disabled, skipping configuration")
+      return@afterEvaluate
+    }
+
+    dependencies.add(
+      "otelAgent",
+      "io.opentelemetry.javaagent:opentelemetry-javaagent:${config.otelAgentVersion}"
+    )
+
+    // Configure test tasks
+    val testTasks = resolveTestTasks(config)
+    testTasks.forEach { testTask ->
+      configureTestTask(testTask, otelAgentConfig, config)
+    }
+
+    logConfiguration(config, testTasks)
+  }
+}
+
+private fun Project.resolveTestTasks(config: StoveTracingConfig): List<Test> =
+  if (config.testTaskNames.isEmpty()) {
+    tasks.withType(Test::class.java).toList()
+  } else {
+    config.testTaskNames.mapNotNull { taskName ->
+      tasks.findByName(taskName) as? Test
+    }
+  }
+
+private fun Project.logConfiguration(config: StoveTracingConfig, testTasks: List<Test>) {
+  val taskInfo = if (config.testTaskNames.isEmpty()) {
+    "all test tasks"
+  } else {
+    "tasks: ${testTasks.joinToString(", ") { it.name }}"
+  }
+  logger.info(
+    "Stove tracing configured for service '${config.serviceName}' " +
+      "with dynamic port assignment on $taskInfo"
+  )
+}
+
+private fun configureTestTask(
+  testTask: Test,
+  otelAgentConfig: Configuration,
+  config: StoveTracingConfig
+) {
+  testTask.doFirst {
+    val agentFiles = otelAgentConfig.files
+    if (agentFiles.isEmpty()) {
+      testTask.logger.warn("No OTel agent JAR found in otelAgent configuration")
+      return@doFirst
+    }
+
+    // Find an available port dynamically to avoid conflicts when running multiple test tasks
+    val port = findAvailablePort()
+    testTask.environment(TracingDefaults.STOVE_TRACING_PORT_ENV, port.toString())
+
+    val agentPath = agentFiles.first().absolutePath
+    val jvmArgs = buildJvmArgs(agentPath, config, port)
+
+    testTask.jvmArgs(jvmArgs)
+    testTask.logger.info(
+      "Stove tracing: Attached OTel agent on port {} with {} JVM arguments",
+      port,
+      jvmArgs.size
+    )
+  }
+}
+
+private fun findAvailablePort(): Int =
+  ServerSocket(0).use { it.localPort }
+
+private fun buildJvmArgs(agentPath: String, config: StoveTracingConfig, port: Int): List<String> = buildList {
+  // Agent attachment
+  add("-javaagent:$agentPath")
+
+  // Core export configuration
+  addAll(buildCoreExportArgs(config, port))
+
+  // Propagation
+  add("-Dotel.propagators=tracecontext,baggage")
+
+  // Test optimization
+  addAll(buildTestOptimizationArgs(config))
+
+  // HTTP headers capture
+  if (config.captureHttpHeaders) {
+    addAll(buildHttpHeaderCaptureArgs())
+  }
+
+  // Experimental telemetry
+  if (config.captureExperimentalTelemetry) {
+    addAll(buildExperimentalTelemetryArgs())
+  }
+
+  // Custom annotations
+  if (config.customAnnotations.isNotEmpty()) {
+    add("-Dotel.instrumentation.annotations.methods=${config.customAnnotations.joinToString(",")}")
+  }
+
+  // Instrumentation control
+  addAll(buildInstrumentationControlArgs(config))
+}
+
+private fun buildCoreExportArgs(config: StoveTracingConfig, port: Int): List<String> = buildList {
+  val endpoint = "http://localhost:$port"
+  add("-Dotel.traces.exporter=otlp")
+  add("-Dotel.exporter.otlp.protocol=${config.protocol}")
+  add("-Dotel.exporter.otlp.endpoint=$endpoint")
+  add("-Dotel.metrics.exporter=none")
+  add("-Dotel.logs.exporter=none")
+  add("-Dotel.service.name=${config.serviceName}")
+  add("-Dotel.resource.attributes=service.name=${config.serviceName},deployment.environment=test")
+
+  // Disable gRPC instrumentation when using gRPC protocol to avoid instrumenting the exporter
+  if (config.protocol == "grpc") {
+    add("-Dotel.instrumentation.grpc.enabled=false")
+  }
+}
+
+private fun buildTestOptimizationArgs(config: StoveTracingConfig): List<String> = listOf(
+  "-Dotel.traces.sampler=always_on",
+  "-Dotel.bsp.schedule.delay=${config.bspScheduleDelay}",
+  "-Dotel.bsp.max.export.batch.size=${config.bspMaxBatchSize}"
+)
+
+private fun buildHttpHeaderCaptureArgs(): List<String> = listOf(
+  "-Dotel.instrumentation.http.client.capture-request-headers=content-type,accept",
+  "-Dotel.instrumentation.http.client.capture-response-headers=content-type",
+  "-Dotel.instrumentation.http.server.capture-request-headers=content-type,accept,user-agent",
+  "-Dotel.instrumentation.http.server.capture-response-headers=content-type"
+)
+
+private fun buildExperimentalTelemetryArgs(): List<String> = listOf(
+  "-Dotel.instrumentation.http.client.emit-experimental-telemetry=true",
+  "-Dotel.instrumentation.http.server.emit-experimental-telemetry=true",
+  "-Dotel.instrumentation.servlet.experimental.capture-request-parameters=*"
+)
+
+private fun buildInstrumentationControlArgs(config: StoveTracingConfig): List<String> = buildList {
+  if (config.disabledInstrumentations.isNotEmpty()) {
+    add("-Dotel.instrumentation.common.default-enabled=true")
+    addAll(config.disabledInstrumentations.map { "-Dotel.instrumentation.$it.enabled=false" })
+  }
+  addAll(config.additionalInstrumentations.map { "-Dotel.instrumentation.$it.enabled=true" })
+}
+
+/**
+ * Configuration for Stove tracing.
+ *
+ * @see configureStoveTracing
+ */
+class StoveTracingConfig {
+  /** The service name to use in traces. This should match your application's service name. */
+  var serviceName: String = "stove-traced-app"
+
+  /** Whether tracing is enabled. Set to false to disable tracing without removing configuration. */
+  var enabled: Boolean = true
+
+  /**
+   * The OTLP protocol to use. Options: "grpc" or "http/protobuf".
+   * Note: The port is dynamically assigned to avoid conflicts when running parallel tests.
+   */
+  var protocol: String = TracingDefaults.DEFAULT_PROTOCOL
+
+  /** The batch span processor schedule delay in milliseconds. Lower = faster export. */
+  var bspScheduleDelay: Int = TracingDefaults.DEFAULT_BSP_SCHEDULE_DELAY
+
+  /** The maximum batch size for span export. 1 = immediate export per span. */
+  var bspMaxBatchSize: Int = TracingDefaults.DEFAULT_BSP_MAX_BATCH_SIZE
+
+  /** Whether to capture HTTP headers in spans. Useful for debugging request/response details. */
+  var captureHttpHeaders: Boolean = true
+
+  /** Whether to enable experimental HTTP telemetry features. */
+  var captureExperimentalTelemetry: Boolean = true
+
+  /** List of instrumentation modules to disable. Example: listOf("jdbc", "hibernate") */
+  var disabledInstrumentations: List<String> = emptyList()
+
+  /** List of additional instrumentation modules to enable. */
+  var additionalInstrumentations: List<String> = emptyList()
+
+  /** List of custom annotation class names to instrument. */
+  var customAnnotations: List<String> = emptyList()
+
+  /** The OpenTelemetry Java Agent version to use. */
+  var otelAgentVersion: String = TracingDefaults.DEFAULT_OTEL_AGENT_VERSION
+
+  /**
+   * List of test task names to configure. If empty, applies to all test tasks.
+   * Example: listOf("integrationTest") to only apply to the integrationTest task.
+   */
+  var testTaskNames: List<String> = emptyList()
+}

--- a/docs/Components/14-tracing.md
+++ b/docs/Components/14-tracing.md
@@ -1,0 +1,418 @@
+# Distributed Tracing
+
+Stove provides built-in distributed tracing capabilities to capture detailed execution traces of code paths within your application under test.
+
+## Overview
+
+When tracing is enabled, Stove **automatically**:
+- Starts and ends traces for each test (via Kotest/JUnit extensions)
+- Injects W3C `traceparent` headers into HTTP requests
+- Injects trace headers into Kafka messages
+- Injects trace metadata into gRPC calls
+- Correlates all spans back to the originating test
+- **Displays execution traces on test failures** showing exactly what went wrong
+
+This allows you to see exactly what happened inside your application during a test, making debugging failures much easier.
+
+## Installation
+
+The tracing module is included automatically when using the Kotest or JUnit extensions:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    testImplementation("com.trendyol:stove-tracing:$stoveVersion")
+    testImplementation("com.trendyol:stove-extensions-kotest:$stoveVersion")
+    // or
+    testImplementation("com.trendyol:stove-extensions-junit:$stoveVersion")
+}
+```
+
+## Quick Start
+
+Tracing is **automatic** - no manual setup required! Just write your tests:
+
+```kotlin
+test("order creation flow") {
+    stove {
+        // Trace headers are automatically injected
+        http {
+            post<OrderResponse>("/orders", orderRequest) { response ->
+                response.status shouldBe "created"
+            }
+        }
+
+        kafka {
+            shouldBeConsumed<OrderCreatedEvent> { event ->
+                event.orderId shouldBe response.orderId
+            }
+        }
+    }
+}
+```
+
+## Capturing Application Execution Flow
+
+To capture the **internal** execution flow of your application under test (controller methods, database queries, Kafka operations, etc.), you need:
+
+1. **Stove's span receiver** - Collects spans exported from the app
+2. **OpenTelemetry Java Agent** - Auto-instruments your application
+
+### Step 1: Enable Span Receiver in Stove
+
+In your Stove test configuration:
+
+```kotlin
+Stove(...)
+    .with {
+        tracing {
+            serviceName("my-service")
+            enableSpanReceiver(port = 4317)  // Start OTLP gRPC receiver
+        }
+        // ... other systems
+    }
+```
+
+### Step 2: Configure OpenTelemetry Java Agent
+
+The easiest way to configure the OTel agent is to copy Stove's configuration helper to your project.
+
+#### Option A: Copy Configuration File (Recommended)
+
+1. **Copy the configuration file** from [StoveTracingConfiguration.kt](https://github.com/Trendyol/stove/blob/main/buildSrc/src/main/kotlin/com/trendyol/stove/gradle/StoveTracingConfiguration.kt) to your project's `buildSrc/src/main/kotlin/` directory.
+
+2. **Use it in your build.gradle.kts:**
+
+```kotlin
+import com.trendyol.stove.gradle.configureStoveTracing
+
+configureStoveTracing {
+    serviceName = "my-service"
+}
+```
+
+That's it! The configuration handles:
+- Downloading the OpenTelemetry Java Agent
+- Configuring all necessary JVM arguments
+- Attaching the agent to test tasks
+
+#### Option B: Manual Configuration
+
+If you prefer manual setup:
+
+```kotlin
+// build.gradle.kts
+val otelAgent by configurations.creating {
+    isTransitive = false
+}
+
+dependencies {
+    otelAgent("io.opentelemetry.javaagent:opentelemetry-javaagent:2.24.0")
+}
+
+tasks.test {
+    doFirst {
+        jvmArgs(
+            "-javaagent:${otelAgent.singleFile.absolutePath}",
+            "-Dotel.traces.exporter=otlp",
+            "-Dotel.exporter.otlp.protocol=grpc",
+            "-Dotel.exporter.otlp.endpoint=http://localhost:4317",
+            "-Dotel.metrics.exporter=none",
+            "-Dotel.logs.exporter=none",
+            "-Dotel.service.name=my-service",
+            "-Dotel.propagators=tracecontext,baggage",
+            "-Dotel.traces.sampler=always_on",
+            "-Dotel.bsp.schedule.delay=100",
+            "-Dotel.bsp.max.export.batch.size=1",
+            "-Dotel.instrumentation.grpc.enabled=false"  // Avoid instrumenting the exporter
+        )
+    }
+}
+```
+
+### Configuration Options
+
+When using `configureStoveTracing`:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `serviceName` | `"stove-traced-app"` | Service name shown in traces |
+| `enabled` | `true` | Toggle tracing on/off |
+| `endpoint` | `"http://localhost:4317"` | OTLP endpoint |
+| `protocol` | `"grpc"` | OTLP protocol (grpc or http/protobuf) |
+| `testTaskNames` | `[]` | Apply only to specific tasks (empty = all) |
+| `otelAgentVersion` | `"2.24.0"` | OTel agent version |
+| `captureHttpHeaders` | `true` | Capture HTTP headers in spans |
+| `disabledInstrumentations` | `[]` | Disable specific instrumentations |
+
+#### Apply to Specific Test Tasks
+
+```kotlin
+configureStoveTracing {
+    serviceName = "my-service"
+    testTaskNames = listOf("integrationTest")  // Only apply to integrationTest
+}
+```
+
+#### Disable Specific Instrumentations
+
+```kotlin
+configureStoveTracing {
+    serviceName = "my-service"
+    disabledInstrumentations = listOf("jdbc", "hibernate")
+}
+```
+
+### What Gets Instrumented Automatically
+
+The OTel agent auto-instruments 100+ libraries with **zero code changes**:
+- **Spring MVC/WebFlux** - All controller methods
+- **JDBC/Hibernate/R2DBC** - All database queries
+- **Kafka** - Producer and consumer spans
+- **HTTP clients** - OkHttp, Apache HttpClient, WebClient
+- **gRPC** - Client and server calls
+- **Redis, MongoDB, Elasticsearch** - All operations
+
+## Test Failure Reports
+
+When a test fails, Stove automatically includes the execution trace in the failure report:
+
+```
+STOVE EXECUTION REPORT
+═══════════════════════════════════════════════════════════════════════════════
+
+TIMELINE
+────────
+14:45:38.439 ✓ PASSED [HTTP] POST /api/product/create
+14:45:38.472 ✗ FAILED [Kafka] shouldBePublished<ProductCreatedEvent>
+
+SYSTEM SNAPSHOTS
+────────────────
+KAFKA
+  Consumed: 0
+  Produced: 1
+  Failed: 1
+    [0] topic: orders.created
+        reason: Something went wrong
+
+═══════════════════════════════════════════════════════════════════════════════
+EXECUTION TRACE (Call Chain)
+═══════════════════════════════════════════════════════════════════════════════
+✓ POST (377ms)
+  ✓ POST /api/product/create (361ms)
+    ✓ ProductController.create (141ms)
+      ✓ ProductCreator.create (0ms)
+      ✓ KafkaProducer.send (137ms)
+        ✓ orders.created publish (81ms)
+          ✗ orders.created process (82ms)  ← FAILURE POINT
+```
+
+The trace clearly shows:
+- ✓ Successful operations
+- ✗ Failed operations and where they occurred
+- Timing for each operation
+
+## Tracing DSL
+
+To validate traces or access trace context programmatically, use the `tracing { }` DSL:
+
+```kotlin
+test("validate trace spans") {
+    stove {
+        http {
+            get<UserResponse>("/users/123") { ... }
+        }
+
+        // Access trace context and validation methods directly
+        tracing {
+            // Context properties
+            println("TraceId: $traceId")
+            println("TestId: $testId")
+
+            // Validation methods available directly
+            shouldContainSpan("UserController.getUser")
+            shouldNotHaveFailedSpans()
+            spanCountShouldBeAtLeast(2)
+
+            // Render trace tree
+            println(renderTree())
+        }
+    }
+}
+```
+
+## Trace Validation Methods
+
+All validation methods are available directly inside the `tracing { }` block:
+
+```kotlin
+tracing {
+    // Span existence
+    shouldContainSpan("UserService.findById")
+    shouldContainSpanMatching { it.operationName.contains("Repository") }
+    shouldNotContainSpan("AdminService.delete")
+
+    // Failure assertions
+    shouldNotHaveFailedSpans()
+    shouldHaveFailedSpan("PaymentGateway.charge")
+
+    // Count assertions
+    spanCountShouldBe(10)
+    spanCountShouldBeAtLeast(5)
+    spanCountShouldBeAtMost(20)
+
+    // Timing assertions
+    executionTimeShouldBeLessThan(500.milliseconds)
+    executionTimeShouldBeGreaterThan(10.milliseconds)
+
+    // Attribute assertions
+    shouldHaveSpanWithAttribute("http.method", "GET")
+    shouldHaveSpanWithAttributeContaining("http.url", "/api/users")
+
+    // Get data for custom assertions
+    val failedSpans = getFailedSpans()
+    val totalDuration = getTotalDuration()
+    val span = findSpanByName("OrderService.process")
+
+    // Render for debugging
+    println(renderTree())
+    println(renderSummary())
+}
+```
+
+## Recording Custom Spans
+
+You can record custom spans for testing:
+
+```kotlin
+tracing {
+    collector.record(
+        SpanInfo(
+            traceId = traceId,
+            spanId = TraceContext.generateSpanId(),
+            parentSpanId = rootSpanId,
+            operationName = "CustomOperation",
+            serviceName = "my-service",
+            startTimeNanos = System.nanoTime(),
+            endTimeNanos = System.nanoTime() + 1_000_000,
+            status = SpanStatus.OK
+        )
+    )
+
+    shouldContainSpan("CustomOperation")
+}
+```
+
+## Trace Tree Rendering
+
+Traces are rendered as hierarchical trees showing the execution flow:
+
+```
+Execution Trace for test: order-creation-test
+══════════════════════════════════════════════════════════════════════════════
+
+✓ OrderController.createOrder [100ms]
+├── ✓ OrderService.processOrder [95ms]
+│   ├── ✓ UserRepository.findById [10ms]
+│   │   └── db.system: postgresql
+│   └── ✓ PaymentClient.charge [65ms]
+│       └── http.url: https://payment.api/charge
+
+══════════════════════════════════════════════════════════════════════════════
+Summary: 4 spans, 0 failures, total: 100ms
+```
+
+When failures occur, they're clearly marked:
+
+```
+✗ PaymentGateway.charge [80ms] ⚠ FAILURE POINT
+├── Exception: PaymentDeclinedException
+│   Message: Card declined
+│   at PaymentGateway.charge(PaymentGateway.kt:42)
+```
+
+## Automatic Header Injection
+
+When a trace is active, Stove automatically injects trace headers:
+
+### HTTP Requests
+```kotlin
+// Headers automatically injected:
+// - traceparent: 00-{traceId}-{spanId}-01
+// - X-Stove-Test-Id: {testId}
+
+http {
+    get<UserResponse>("/users/123") { user ->
+        user.name shouldBe "John"
+    }
+}
+```
+
+### Kafka Messages
+```kotlin
+kafka {
+    // Headers automatically injected into the message
+    publish("orders.created", OrderCreatedEvent(orderId = "123"))
+}
+```
+
+### gRPC Calls
+```kotlin
+grpc {
+    channel<GreeterServiceStub> {
+        // Metadata automatically includes trace context
+        sayHello(HelloRequest(name = "World"))
+    }
+}
+```
+
+## Trace Context Properties
+
+Inside the `tracing { }` block, you have access to:
+
+| Property | Description |
+|----------|-------------|
+| `traceId` | The W3C trace ID (32 hex characters) |
+| `rootSpanId` | The root span ID (16 hex characters) |
+| `testId` | The test identifier (e.g., `"MySpec::my test"`) |
+| `ctx` | The full `TraceContext` object |
+| `collector` | The span collector for recording custom spans |
+
+## Best Practices
+
+1. **Tracing is automatic** - No need to manually start/end traces
+2. **Use `tracing { }` for validation** - Only when you need to assert on spans
+3. **Check for failures first** - `shouldNotHaveFailedSpans()` catches unexpected errors
+4. **Use `renderTree()` for debugging** - Visualize the execution flow
+5. **Filter noise** - Use `disabledInstrumentations` to exclude noisy libraries
+
+## Troubleshooting
+
+### Spans not appearing in failure report
+
+1. Ensure the `stove-tracing` dependency is included
+2. Verify `enableSpanReceiver(port = 4317)` is configured
+3. Check that the OTel agent is attached (look for "Stove tracing: Attached OTel agent" in logs)
+4. Verify the endpoint in `configureStoveTracing` matches the `enableSpanReceiver` port
+
+### OTel agent not attaching
+
+1. Ensure `configureStoveTracing` is called in your build.gradle.kts
+2. Check that the `otelAgent` dependency is being downloaded
+3. Look for agent attachment messages in test output
+
+### Too many spans
+
+1. Use `disabledInstrumentations` to exclude noisy libraries:
+   ```kotlin
+   configureStoveTracing {
+       serviceName = "my-service"
+       disabledInstrumentations = listOf("jdbc", "hibernate", "spring-scheduling")
+   }
+   ```
+
+### Missing parent-child relationships
+
+1. Ensure trace context is propagated through async boundaries
+2. Check that all services use the same trace ID from the `traceparent` header
+3. Verify the OTel agent version is compatible with your framework version

--- a/examples/ktor-example/build.gradle.kts
+++ b/examples/ktor-example/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.trendyol.stove.gradle.configureStoveTracing
+
 plugins {
   kotlin("jvm") version libs.versions.kotlin
   application
@@ -17,6 +19,10 @@ application {
   applicationDefaultJvmArgs = listOf("-Dio.ktor.development=$isDevelopment")
 }
 
+configureStoveTracing {
+  serviceName = "ktor-example"
+}
+
 dependencies {
   implementation(libs.ktor.server)
   implementation(libs.ktor.server.netty)
@@ -31,6 +37,9 @@ dependencies {
   implementation(libs.hoplite.yaml)
   implementation(libs.jackson.kotlin)
   implementation(libs.jackson.databind)
+
+  // OpenTelemetry API for manual span recording (exceptions in catch blocks)
+  implementation(libs.opentelemetry.api)
 
   // gRPC service clients (FeatureToggle, Pricing)
   implementation(libs.io.grpc)

--- a/examples/ktor-example/src/main/kotlin/stove/ktor/example/app/routing.kt
+++ b/examples/ktor-example/src/main/kotlin/stove/ktor/example/app/routing.kt
@@ -5,6 +5,8 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode
 import org.koin.ktor.ext.get
 import stove.ktor.example.application.*
 
@@ -19,6 +21,11 @@ fun Application.configureRouting() {
       } catch (
         @Suppress("TooGenericExceptionCaught") ex: Exception
       ) {
+        // Record exception in span for tracing visibility
+        Span.current().apply {
+          recordException(ex)
+          setStatus(StatusCode.ERROR, ex.message ?: "Unknown error")
+        }
         ex.printStackTrace()
         call.respond(HttpStatusCode.BadRequest)
       }

--- a/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/StoveConfig.kt
+++ b/examples/ktor-example/src/test/kotlin/com/stove/ktor/example/e2e/StoveConfig.kt
@@ -1,19 +1,15 @@
 package com.stove.ktor.example.e2e
 
-import com.trendyol.stove.*
 import com.trendyol.stove.extensions.kotest.StoveKotestExtension
-import com.trendyol.stove.grpc.GrpcSystemOptions
-import com.trendyol.stove.grpc.grpc
+import com.trendyol.stove.grpc.*
 import com.trendyol.stove.http.*
 import com.trendyol.stove.kafka.*
-import com.trendyol.stove.ktor.bridge
-import com.trendyol.stove.ktor.ktor
+import com.trendyol.stove.ktor.*
 import com.trendyol.stove.postgres.*
 import com.trendyol.stove.serialization.StoveSerde
 import com.trendyol.stove.system.*
-import com.trendyol.stove.system.Stove
-import com.trendyol.stove.testing.grpcmock.GrpcMockSystemOptions
-import com.trendyol.stove.testing.grpcmock.grpcMock
+import com.trendyol.stove.testing.grpcmock.*
+import com.trendyol.stove.tracing.tracing
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import stove.ktor.example.app.objectMapperRef
@@ -39,6 +35,7 @@ class StoveConfig : AbstractProjectConfig() {
 
   override val extensions: List<Extension> = listOf(StoveKotestExtension())
 
+  @Suppress("LongMethod")
   override suspend fun beforeProject() = Stove()
     .with {
       httpClient {
@@ -47,6 +44,10 @@ class StoveConfig : AbstractProjectConfig() {
         )
       }
       bridge()
+      tracing {
+        serviceName("ktor-example")
+        enableSpanReceiver(port = 4317)
+      }
       postgresql {
         PostgresqlOptions(configureExposedConfiguration = { cfg ->
           listOf(

--- a/examples/micronaut-example/src/test/kotlin/com/stove/micronaut/example/e2e/StoveConfig.kt
+++ b/examples/micronaut-example/src/test/kotlin/com/stove/micronaut/example/e2e/StoveConfig.kt
@@ -5,6 +5,7 @@ import com.trendyol.stove.http.*
 import com.trendyol.stove.micronaut.*
 import com.trendyol.stove.postgres.*
 import com.trendyol.stove.system.Stove
+import com.trendyol.stove.tracing.tracing
 import com.trendyol.stove.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
@@ -40,6 +41,10 @@ class StoveConfig : AbstractProjectConfig() {
           }
         }
         bridge()
+        tracing {
+          serviceName("micronaut-example")
+          enableSpanReceiver(port = 4318)
+        }
         wiremock {
           WireMockSystemOptions(
             port = 7079,

--- a/examples/spring-4x-example/build.gradle.kts
+++ b/examples/spring-4x-example/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.trendyol.stove.gradle.configureStoveTracing
+
 plugins {
   alias(libs.plugins.spring.plugin)
   alias(libs.plugins.spring.boot.four)
@@ -16,15 +18,37 @@ dependencies {
   implementation(libs.kotlinx.core)
   implementation(libs.kotlinx.reactive)
   implementation(libs.kotlinx.slf4j)
+
+  // OpenTelemetry instrumentation API for @WithSpan annotation
+  implementation(libs.opentelemetry.instrumentation.annotations)
 }
 
 dependencies {
-  testImplementation(project(":test-extensions:stove-extensions-kotest"))
+  testImplementation(projects.stove.testExtensions.stoveExtensionsKotest)
   testImplementation(libs.jackson3.kotlin)
   testImplementation(projects.stove.lib.stoveHttp)
   testImplementation(projects.stove.lib.stoveWiremock)
+  testImplementation(projects.stove.lib.stoveTracing)
   testImplementation(projects.stove.starters.spring.stoveSpring)
   testImplementation(projects.stove.starters.spring.stoveSpringKafka)
 }
 
 application { mainClass.set("stove.spring.example4x.ExampleAppkt") }
+
+// ============================================================================
+// TRACING SETUP - OpenTelemetry Java Agent
+// ============================================================================
+configureStoveTracing {
+  serviceName = "spring-4x-example"
+  // Plugin handles:
+  // - Adding opentelemetry-javaagent dependency
+  // - Configuring test task JVM args for OTLP export
+  // - Optimizing batch span processor for tests
+}
+
+tasks.test {
+  testLogging {
+    events("passed", "skipped", "failed", "standardOut", "standardError")
+    showStandardStreams = true
+  }
+}

--- a/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/application/handlers/ProductCreator.kt
+++ b/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/application/handlers/ProductCreator.kt
@@ -1,10 +1,12 @@
 package stove.spring.example4x.application.handlers
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.stereotype.Service
 import stove.spring.example4x.infrastructure.api.ProductCreateRequest
 
 @Service
 class ProductCreator {
+  @WithSpan("ProductCreator.create")
   suspend fun create(request: ProductCreateRequest) {
     // In a real application, this would persist the product
     println("Creating product: ${request.name} with id ${request.id}")

--- a/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/api/ProductController.kt
+++ b/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/api/ProductController.kt
@@ -1,5 +1,6 @@
 package stove.spring.example4x.infrastructure.api
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import stove.spring.example4x.application.handlers.*
@@ -16,6 +17,7 @@ class ProductController(
     @RequestParam(required = false) keyword: String?
   ): ResponseEntity<String> = ResponseEntity.ok("Hi from Stove framework with ${keyword ?: "no keyword"}")
 
+  @WithSpan("ProductController.create")
   @PostMapping("/product/create")
   suspend fun create(
     @RequestBody request: ProductCreateRequest

--- a/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/messaging/kafka/KafkaProducer.kt
+++ b/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/messaging/kafka/KafkaProducer.kt
@@ -1,5 +1,7 @@
 package stove.spring.example4x.infrastructure.messaging.kafka
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import kotlinx.coroutines.future.await
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 import stove.spring.example4x.application.handlers.ProductCreatedEvent
@@ -9,8 +11,9 @@ class KafkaProducer(
   private val kafkaTemplate: KafkaTemplate<String, Any>,
   private val kafkaProperties: KafkaProperties
 ) {
+  @WithSpan("KafkaProducer.send")
   suspend fun send(event: ProductCreatedEvent) {
     val topic = "${kafkaProperties.topicPrefix}.productCreated.1"
-    kafkaTemplate.send(topic, event.id.toString(), event)
+    kafkaTemplate.send(topic, event.id.toString(), event).await()
   }
 }

--- a/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/messaging/kafka/ProductCreateConsumer.kt
+++ b/examples/spring-4x-example/src/main/kotlin/stove/spring/example4x/infrastructure/messaging/kafka/ProductCreateConsumer.kt
@@ -26,6 +26,22 @@ class ProductCreateConsumer(
   }
 }
 
+@Component
+class ProductEventsConsumer {
+  private val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+  @KafkaListener(
+    topics = ["trendyol.stove.service.productCreated.1"],
+    groupId = "\${kafka.groupId}",
+    containerFactory = "kafkaListenerContainerFactory"
+  )
+  fun consumeProductCreatedEvent(
+    @Payload message: String
+  ) {
+    logger.info("Received message: $message")
+  }
+}
+
 data class CreateProductCommand(
   val id: Long,
   val name: String,

--- a/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/ExampleTest.kt
+++ b/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/ExampleTest.kt
@@ -1,9 +1,9 @@
 package com.stove.spring.example4x.e2e
 
 import arrow.core.some
-import com.trendyol.stove.http.*
+import com.trendyol.stove.http.http
 import com.trendyol.stove.kafka.kafka
-import com.trendyol.stove.system.*
+import com.trendyol.stove.system.stove
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -40,7 +40,13 @@ class ExampleTest :
         }
 
         kafka {
-          shouldBePublished<ProductCreatedEvent> {
+          shouldBePublished<ProductCreatedEvent>(10.seconds) {
+            actual.id == productCreateRequest.id &&
+              actual.name == productCreateRequest.name &&
+              actual.supplierId == productCreateRequest.supplierId
+          }
+
+          shouldBeConsumed<ProductCreatedEvent>(10.seconds) {
             actual.id == productCreateRequest.id &&
               actual.name == productCreateRequest.name &&
               actual.supplierId == productCreateRequest.supplierId

--- a/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/StoveConfig.kt
+++ b/examples/spring-4x-example/src/test/kotlin/com/stove/spring/example4x/e2e/StoveConfig.kt
@@ -1,14 +1,11 @@
 package com.stove.spring.example4x.e2e
 
-import com.trendyol.stove.*
 import com.trendyol.stove.extensions.kotest.StoveKotestExtension
 import com.trendyol.stove.http.*
 import com.trendyol.stove.kafka.*
-import com.trendyol.stove.spring.addTestDependencies4x
-import com.trendyol.stove.spring.bridge
-import com.trendyol.stove.spring.springBoot
+import com.trendyol.stove.spring.*
 import com.trendyol.stove.system.Stove
-import com.trendyol.stove.system.stove
+import com.trendyol.stove.tracing.*
 import com.trendyol.stove.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
@@ -41,6 +38,13 @@ class StoveConfig : AbstractProjectConfig() {
           )
         }
         bridge()
+
+        // Enable tracing - starts OTLP gRPC receiver on port 4317
+        tracing {
+          serviceName("spring-4x-example")
+          enableSpanReceiver(port = 4317)
+        }
+
         wiremock {
           WireMockSystemOptions(
             port = 7080,
@@ -52,6 +56,8 @@ class StoveConfig : AbstractProjectConfig() {
         }
         springBoot(
           runner = { parameters ->
+            // The application will be auto-instrumented by OTel agent
+            // configured in build.gradle.kts tasks.test { }
             run(parameters) {
               addTestDependencies4x {
                 registerBean<TestSystemKafkaInterceptor<*, *>>(primary = true)

--- a/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/StoveConfig.kt
+++ b/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/StoveConfig.kt
@@ -9,6 +9,7 @@ import com.trendyol.stove.spring.bridge
 import com.trendyol.stove.spring.springBoot
 import com.trendyol.stove.system.Stove
 import com.trendyol.stove.system.stove
+import com.trendyol.stove.tracing.tracing
 import com.trendyol.stove.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
@@ -24,6 +25,10 @@ class StoveConfig : AbstractProjectConfig() {
   override suspend fun beforeProject(): Unit =
     Stove()
       .with {
+        tracing {
+          serviceName("spring-example")
+          enableSpanReceiver()
+        }
         httpClient {
           HttpClientSystemOptions(
             baseUrl = "http://localhost:8004"
@@ -64,6 +69,7 @@ class StoveConfig : AbstractProjectConfig() {
             }
           )
         }
+
         springBoot(
           runner = { parameters ->
             run(parameters) {

--- a/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/TracingValidationTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/TracingValidationTest.kt
@@ -1,0 +1,111 @@
+package com.stove.spring.example.e2e
+
+import arrow.core.some
+import com.trendyol.stove.http.*
+import com.trendyol.stove.system.*
+import com.trendyol.stove.tracing.*
+import com.trendyol.stove.wiremock.wiremock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import stove.spring.example.application.handlers.ProductCreateRequest
+import stove.spring.example.application.services.SupplierPermission
+
+class TracingValidationTest :
+  FunSpec({
+
+    test("tracing should capture HTTP request context implicitly") {
+      stove {
+        // Trace is auto-started, just make HTTP call
+        http {
+          get<String>("/api/index", queryParams = mapOf("keyword" to "tracing-test")) { actual ->
+            actual shouldContain "Hi from Stove framework"
+          }
+        }
+
+        // Access trace context for validation - all props accessible directly
+        tracing {
+          traceId.length shouldBe 32
+          rootSpanId.length shouldBe 16
+
+          val traceparent = toTraceparent()
+          traceparent shouldContain traceId
+
+          println("✓ Trace context created implicitly:")
+          println("  - traceId: $traceId")
+          println("  - testId: $testId")
+          println("  - traceparent: $traceparent")
+        }
+      }
+    }
+
+    test("tracing should work with full request flow") {
+      stove {
+        val productCreateRequest = ProductCreateRequest(100L, name = "traced product", 999L)
+        val supplierPermission = SupplierPermission(productCreateRequest.supplierId, isAllowed = true)
+
+        wiremock {
+          mockGet(
+            "/suppliers/${productCreateRequest.supplierId}/allowed",
+            statusCode = 200,
+            responseBody = supplierPermission.some()
+          )
+        }
+
+        http {
+          postAndExpectBodilessResponse(uri = "/api/product/create", body = productCreateRequest.some()) { actual ->
+            actual.status shouldBe 200
+          }
+        }
+
+        // Validate trace was captured
+        tracing {
+          println("✓ Full request flow traced:")
+          println("  - traceId: $traceId")
+          println("  - testId: $testId")
+        }
+      }
+    }
+
+    test("trace collector should record spans") {
+      stove {
+        tracing {
+          // Record test spans
+          collector.record(
+            SpanInfo(
+              traceId = traceId,
+              spanId = TraceContext.generateSpanId(),
+              parentSpanId = rootSpanId,
+              operationName = "TestController.handleRequest",
+              serviceName = "collector-test",
+              startTimeNanos = System.nanoTime(),
+              endTimeNanos = System.nanoTime() + 1_000_000,
+              status = SpanStatus.OK
+            )
+          )
+
+          collector.record(
+            SpanInfo(
+              traceId = traceId,
+              spanId = TraceContext.generateSpanId(),
+              parentSpanId = rootSpanId,
+              operationName = "TestService.processData",
+              serviceName = "collector-test",
+              startTimeNanos = System.nanoTime(),
+              endTimeNanos = System.nanoTime() + 2_000_000,
+              status = SpanStatus.OK
+            )
+          )
+
+          // Validate spans - methods available directly
+          shouldContainSpan("TestController.handleRequest")
+          shouldContainSpan("TestService.processData")
+          shouldNotHaveFailedSpans()
+          spanCountShouldBeAtLeast(2)
+
+          println("✓ Trace collector recorded spans:")
+          println(renderTree())
+        }
+      }
+    }
+  })

--- a/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/StoveConfig.kt
+++ b/examples/spring-standalone-example/src/test/kotlin/com/stove/spring/standalone/example/e2e/StoveConfig.kt
@@ -10,6 +10,7 @@ import com.trendyol.stove.spring.bridge
 import com.trendyol.stove.spring.springBoot
 import com.trendyol.stove.system.*
 import com.trendyol.stove.system.Stove
+import com.trendyol.stove.tracing.tracing
 import com.trendyol.stove.wiremock.*
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
@@ -64,6 +65,10 @@ class StoveConfig : AbstractProjectConfig() {
           }
         }
         bridge()
+        tracing {
+          serviceName("spring-standalone-example")
+          enableSpanReceiver(port = 4318)
+        }
         wiremock {
           WireMockSystemOptions(
             port = 9099,

--- a/examples/spring-streams-example/src/test/kotlin/com/stove/spring/streams/example/e2e/StoveConfig.kt
+++ b/examples/spring-streams-example/src/test/kotlin/com/stove/spring/streams/example/e2e/StoveConfig.kt
@@ -11,6 +11,7 @@ import com.trendyol.stove.spring.springBoot
 import com.trendyol.stove.system.*
 import com.trendyol.stove.system.Stove
 import com.trendyol.stove.system.stove
+import com.trendyol.stove.tracing.tracing
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import org.apache.kafka.clients.admin.NewTopic
@@ -42,6 +43,10 @@ class StoveConfig : AbstractProjectConfig() {
         }
       }
       bridge()
+      tracing {
+        serviceName("spring-streams-example")
+        enableSpanReceiver(port = 4318)
+      }
       springBoot(
         runner = { parameters ->
           run(parameters)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,10 @@ micronaut = "4.10.14"
 micronaut-platform = "4.10.7"
 micronaut-micrometer = "1.3.1"
 ktlint = "1.8.0"
+opentelemetry = "1.58.0"
+opentelemetry-semconv = "1.38.0"
+opentelemetry-instrumentation = "2.24.0"
+bytebuddy = "1.14.18"
 
 [libraries]
 # exposed
@@ -203,6 +207,21 @@ google-gson = { module = "com.google.code.gson:gson", version = "2.13.2" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.3" }
 pprint = { module = "io.exoquery:pprint-kotlin", version = "3.0.0" }
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
+
+# OpenTelemetry
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
+opentelemetry-sdk-trace = { module = "io.opentelemetry:opentelemetry-sdk-trace", version.ref = "opentelemetry" }
+opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
+opentelemetry-extension-trace-propagators = { module = "io.opentelemetry:opentelemetry-extension-trace-propagators", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-javaagent = { module = "io.opentelemetry.javaagent:opentelemetry-javaagent", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version = "1.9.0-alpha" }
+
+# ByteBuddy
+bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "bytebuddy" }
 
 # testing
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }

--- a/lib/stove-couchbase/build.gradle.kts
+++ b/lib/stove-couchbase/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.couchbase.kotlin)
   api(libs.testcontainers.couchbase)
 }

--- a/lib/stove-elasticsearch/build.gradle.kts
+++ b/lib/stove-elasticsearch/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {}
 
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.elastic)
   api(libs.testcontainers.elasticsearch)
   implementation(libs.jackson.databind)

--- a/lib/stove-grpc/build.gradle.kts
+++ b/lib/stove-grpc/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.io.grpc)
   api(libs.io.grpc.stub)
   api(libs.io.grpc.kotlin)

--- a/lib/stove-http/build.gradle.kts
+++ b/lib/stove-http/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.ktor.client.core)
   api(libs.ktor.client.okhttp)
   api(libs.ktor.client.plugins.logging)

--- a/lib/stove-http/src/main/kotlin/com/trendyol/stove/http/HttpSystem.kt
+++ b/lib/stove-http/src/main/kotlin/com/trendyol/stove/http/HttpSystem.kt
@@ -8,6 +8,7 @@ import com.trendyol.stove.serialization.StoveSerde
 import com.trendyol.stove.system.*
 import com.trendyol.stove.system.abstractions.*
 import com.trendyol.stove.system.annotations.StoveDsl
+import com.trendyol.stove.tracing.TraceContext
 import io.ktor.client.call.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
@@ -775,6 +776,14 @@ class HttpSystem(
     url { appendEncodedPathSegments(uri) }
     headers.forEach { (key, value) -> header(key, value) }
     token.map { header(HeaderConstants.AUTHORIZATION, HeaderConstants.bearer(it)) }
+    injectTraceHeaders()
+  }
+
+  private fun HttpRequestBuilder.injectTraceHeaders() {
+    TraceContext.current()?.let { ctx ->
+      header(TraceContext.TRACEPARENT_HEADER, ctx.toTraceparent())
+      header(TraceContext.STOVE_TEST_ID_HEADER, ctx.testId)
+    }
   }
 
   @PublishedApi

--- a/lib/stove-kafka/build.gradle.kts
+++ b/lib/stove-kafka/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.testcontainers.kafka)
   api(libs.kafka)
   api(libs.kafka.embedded)

--- a/lib/stove-mongodb/build.gradle.kts
+++ b/lib/stove-mongodb/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.testcontainers.mongodb)
   implementation(libs.mongodb.kotlin.coroutine)
   implementation(libs.kotlinx.io.reactor.extensions)

--- a/lib/stove-rdbms/build.gradle.kts
+++ b/lib/stove-rdbms/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.testcontainers.jdbc)
   api(libs.kotliquery)
   api(libs.h2Database)

--- a/lib/stove-redis/build.gradle.kts
+++ b/lib/stove-redis/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.lettuce.core)
   api(libs.testcontainers.redis)
 }

--- a/lib/stove-tracing/api/stove-tracing.api
+++ b/lib/stove-tracing/api/stove-tracing.api
@@ -1,0 +1,227 @@
+public abstract class com/trendyol/stove/tracing/OTLPReceiverError : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/trendyol/stove/tracing/OTLPReceiverError$StartupFailed : com/trendyol/stove/tracing/OTLPReceiverError {
+	public fun <init> (ILjava/io/IOException;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/io/IOException;
+	public final fun copy (ILjava/io/IOException;)Lcom/trendyol/stove/tracing/OTLPReceiverError$StartupFailed;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/OTLPReceiverError$StartupFailed;ILjava/io/IOException;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/OTLPReceiverError$StartupFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCause ()Ljava/io/IOException;
+	public synthetic fun getCause ()Ljava/lang/Throwable;
+	public final fun getPort ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/OTLPSpanReceiver {
+	public fun <init> (Lcom/trendyol/stove/tracing/StoveTraceCollector;I)V
+	public synthetic fun <init> (Lcom/trendyol/stove/tracing/StoveTraceCollector;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun start ()Larrow/core/Either;
+	public final fun stop ()V
+}
+
+public final class com/trendyol/stove/tracing/StoveTraceCollector {
+	public fun <init> ()V
+	public final fun clear (Ljava/lang/String;)V
+	public final fun clearAll ()V
+	public final fun clearForTest (Ljava/lang/String;)V
+	public final fun getAllTraces ()Ljava/util/Map;
+	public final fun getFailedSpans (Ljava/lang/String;)Ljava/util/List;
+	public final fun getTestId (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getTrace (Ljava/lang/String;)Ljava/util/List;
+	public final fun getTraceTree (Ljava/lang/String;)Lcom/trendyol/stove/tracing/SpanNode;
+	public final fun getTracesForTest (Ljava/lang/String;)Ljava/util/List;
+	public final fun hasFailures (Ljava/lang/String;)Z
+	public final fun record (Lcom/trendyol/stove/tracing/SpanInfo;)V
+	public final fun recordAll (Ljava/util/Collection;)V
+	public final fun registerTrace (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun spanCount (Ljava/lang/String;)I
+	public final fun totalSpanCount ()I
+	public final fun traceCount ()I
+	public final fun waitForSpans (Ljava/lang/String;IJ)Ljava/util/List;
+	public static synthetic fun waitForSpans$default (Lcom/trendyol/stove/tracing/StoveTraceCollector;Ljava/lang/String;IJILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class com/trendyol/stove/tracing/TraceContext {
+	public static final field Companion Lcom/trendyol/stove/tracing/TraceContext$Companion;
+	public static final field STOVE_TEST_ID_HEADER Ljava/lang/String;
+	public static final field TRACEPARENT_HEADER Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/TraceContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/TraceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRootSpanId ()Ljava/lang/String;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTraceId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun toTraceparent ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/TraceContext$Companion {
+	public final fun clear ()V
+	public final fun current ()Lcom/trendyol/stove/tracing/TraceContext;
+	public final fun generateSpanId ()Ljava/lang/String;
+	public final fun generateTraceId ()Ljava/lang/String;
+	public final fun parseTraceparent (Ljava/lang/String;)Lkotlin/Pair;
+	public final fun start (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceContext;
+	public final fun use (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class com/trendyol/stove/tracing/TraceReportBuilder {
+	public static final field DEFAULT_ERROR_MESSAGE Ljava/lang/String;
+	public static final field INSTANCE Lcom/trendyol/stove/tracing/TraceReportBuilder;
+	public final fun buildFullReport ()Ljava/lang/String;
+	public final fun shouldEnrichFailures (Lcom/trendyol/stove/system/StoveOptions;)Z
+}
+
+public final class com/trendyol/stove/tracing/TraceValidationDsl {
+	public fun <init> (Lcom/trendyol/stove/tracing/StoveTraceCollector;Ljava/lang/String;)V
+	public final fun executionTimeShouldBeGreaterThan-LRDsOJo (J)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun executionTimeShouldBeLessThan-LRDsOJo (J)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun findSpan (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/tracing/SpanInfo;
+	public final fun findSpanByName (Ljava/lang/String;)Lcom/trendyol/stove/tracing/SpanInfo;
+	public final fun getFailedSpanCount ()I
+	public final fun getFailedSpans ()Ljava/util/List;
+	public final fun getSpanCount ()I
+	public final fun getTotalDuration-UwyO8pc ()J
+	public final fun renderSummary ()Ljava/lang/String;
+	public final fun renderTree ()Ljava/lang/String;
+	public final fun shouldContainSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldContainSpanMatching (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveFailedSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveSpanWithAttribute (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveSpanWithAttributeContaining (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldNotContainSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldNotHaveFailedSpans ()Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBe (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBeAtLeast (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBeAtMost (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanTree ()Lcom/trendyol/stove/tracing/SpanNode;
+}
+
+public final class com/trendyol/stove/tracing/TracingConstants {
+	public static final field DEFAULT_MAX_SPANS_PER_TRACE I
+	public static final field DEFAULT_OTLP_GRPC_PORT I
+	public static final field DEFAULT_OTLP_HTTP_PORT I
+	public static final field DEFAULT_SPAN_POLL_INTERVAL_MS J
+	public static final field DEFAULT_SPAN_WAIT_TIMEOUT_MS J
+	public static final field INSTANCE Lcom/trendyol/stove/tracing/TracingConstants;
+	public static final field MAX_STACK_TRACE_LINES I
+	public static final field NANOS_TO_MILLIS J
+	public static final field OTEL_EXCEPTION_EVENT_NAME Ljava/lang/String;
+	public static final field OTEL_EXCEPTION_MESSAGE_ATTRIBUTE Ljava/lang/String;
+	public static final field OTEL_EXCEPTION_STACKTRACE_ATTRIBUTE Ljava/lang/String;
+	public static final field OTEL_EXCEPTION_TYPE_ATTRIBUTE Ljava/lang/String;
+	public static final field OTEL_SERVICE_NAME_ATTRIBUTE Ljava/lang/String;
+	public static final field OTEL_STATUS_CODE_ERROR I
+	public static final field SERVER_SHUTDOWN_TIMEOUT_SECONDS J
+	public static final field SPAN_ID_LENGTH I
+	public static final field STOVE_TRACING_PORT_ENV Ljava/lang/String;
+	public static final field STRAGGLER_WAIT_TIME_MS J
+	public static final field TRACEPARENT_MIN_PARTS I
+	public final fun getGRPC_INTERNAL_SPAN_PATTERNS ()Ljava/util/List;
+}
+
+public abstract interface annotation class com/trendyol/stove/tracing/TracingDsl : java/lang/annotation/Annotation {
+}
+
+public final class com/trendyol/stove/tracing/TracingOptions {
+	public fun <init> ()V
+	public final fun copy ()Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun disabled ()Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun enableSpanReceiver (Ljava/lang/Integer;)Lcom/trendyol/stove/tracing/TracingOptions;
+	public static synthetic fun enableSpanReceiver$default (Lcom/trendyol/stove/tracing/TracingOptions;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun enabled ()Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun getEnabled ()Z
+	public final fun getMaxSpansPerTrace ()I
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getSpanCollectionTimeout-UwyO8pc ()J
+	public final fun getSpanFilter ()Lkotlin/jvm/functions/Function1;
+	public final fun getSpanReceiverEnabled ()Z
+	public final fun getSpanReceiverPort ()I
+	public final fun maxSpansPerTrace (I)Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun serviceName (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun spanCollectionTimeout-LRDsOJo (J)Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun spanFilter (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/tracing/TracingOptions;
+}
+
+public final class com/trendyol/stove/tracing/TracingSystem : com/trendyol/stove/reporting/TraceProvider, com/trendyol/stove/system/abstractions/PluggedSystem, com/trendyol/stove/system/abstractions/RunAware {
+	public fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/tracing/TracingSystemOptions;)V
+	public fun close ()V
+	public final fun currentContext ()Larrow/core/Option;
+	public final fun endTrace ()V
+	public final fun ensureTraceStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getStove ()Lcom/trendyol/stove/system/Stove;
+	public fun getTraceVisualizationForCurrentTest (J)Larrow/core/Option;
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun then ()Lcom/trendyol/stove/system/Stove;
+	public final fun validation ()Larrow/core/Option;
+	public final fun validation (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+}
+
+public final class com/trendyol/stove/tracing/TracingSystemKt {
+	public static final fun tracing-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun tracing-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/system/Stove;
+	public static synthetic fun tracing-ypJx7X8$default (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/system/Stove;
+	public static final fun tracingSystem-71YW2E0 (Lcom/trendyol/stove/system/Stove;)Lcom/trendyol/stove/tracing/TracingSystem;
+}
+
+public final class com/trendyol/stove/tracing/TracingSystemOptions {
+	public fun <init> ()V
+	public fun <init> (Lcom/trendyol/stove/tracing/TracingOptions;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/tracing/TracingOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/trendyol/stove/tracing/TracingOptions;
+	public final fun copy (Lcom/trendyol/stove/tracing/TracingOptions;)Lcom/trendyol/stove/tracing/TracingSystemOptions;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/TracingSystemOptions;Lcom/trendyol/stove/tracing/TracingOptions;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/TracingSystemOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTracingOptions ()Lcom/trendyol/stove/tracing/TracingOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/TracingValidationScope {
+	public fun <init> (Lcom/trendyol/stove/tracing/TraceContext;Lcom/trendyol/stove/tracing/TraceValidationDsl;Lcom/trendyol/stove/tracing/StoveTraceCollector;)V
+	public final fun executionTimeShouldBeGreaterThan-LRDsOJo (J)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun executionTimeShouldBeLessThan-LRDsOJo (J)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun findSpan (Lkotlin/jvm/functions/Function1;)Larrow/core/Option;
+	public final fun findSpanByName (Ljava/lang/String;)Larrow/core/Option;
+	public final fun getAllTraceVisualizations ()Ljava/util/List;
+	public final fun getCollector ()Lcom/trendyol/stove/tracing/StoveTraceCollector;
+	public final fun getCtx ()Lcom/trendyol/stove/tracing/TraceContext;
+	public final fun getFailedSpanCount ()I
+	public final fun getFailedSpans ()Ljava/util/List;
+	public final fun getRootSpanId ()Ljava/lang/String;
+	public final fun getSpanCount ()I
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTotalDuration-UwyO8pc ()J
+	public final fun getTraceId ()Ljava/lang/String;
+	public final fun getTraceVisualization ()Lcom/trendyol/stove/tracing/TraceVisualization;
+	public final fun renderSummary ()Ljava/lang/String;
+	public final fun renderTree ()Ljava/lang/String;
+	public final fun shouldContainSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldContainSpanMatching (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveFailedSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveSpanWithAttribute (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldHaveSpanWithAttributeContaining (Ljava/lang/String;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldNotContainSpan (Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun shouldNotHaveFailedSpans ()Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBe (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBeAtLeast (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanCountShouldBeAtMost (I)Lcom/trendyol/stove/tracing/TraceValidationDsl;
+	public final fun spanTree ()Larrow/core/Option;
+	public final fun toTraceparent ()Ljava/lang/String;
+	public final fun waitForSpans (IJ)Ljava/util/List;
+	public static synthetic fun waitForSpans$default (Lcom/trendyol/stove/tracing/TracingValidationScope;IJILjava/lang/Object;)Ljava/util/List;
+}
+

--- a/lib/stove-tracing/build.gradle.kts
+++ b/lib/stove-tracing/build.gradle.kts
@@ -1,0 +1,17 @@
+dependencies {
+  api(projects.lib.stove)
+  implementation(libs.kotlinx.core)
+  implementation(libs.kotlinx.slf4j)
+
+  // OTLP gRPC protocol support for receiving spans from OTel Java Agent
+  implementation(libs.opentelemetry.proto)
+  implementation(libs.io.grpc)
+  implementation(libs.io.grpc.stub)
+  implementation(libs.io.grpc.protobuf)
+  implementation(libs.io.grpc.netty)
+}
+
+dependencies {
+  testImplementation(project(":test-extensions:stove-extensions-kotest"))
+  testImplementation(libs.logback.classic)
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/Constants.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/Constants.kt
@@ -1,0 +1,67 @@
+package com.trendyol.stove.tracing
+
+/**
+ * Constants used throughout the tracing module.
+ * Centralizes magic numbers and configuration defaults.
+ */
+object TracingConstants {
+  /** Default gRPC port for OTLP protocol */
+  const val DEFAULT_OTLP_GRPC_PORT = 4317
+
+  /** Environment variable name for OTLP port (set by Gradle configuration) */
+  const val STOVE_TRACING_PORT_ENV = "STOVE_TRACING_PORT"
+
+  /** Default HTTP port for OTLP protocol */
+  const val DEFAULT_OTLP_HTTP_PORT = 4318
+
+  /** Nanoseconds to milliseconds conversion factor */
+  const val NANOS_TO_MILLIS = 1_000_000L
+
+  /** Default polling interval when waiting for spans (milliseconds) */
+  const val DEFAULT_SPAN_POLL_INTERVAL_MS = 50L
+
+  /** Default timeout when waiting for spans (milliseconds) */
+  const val DEFAULT_SPAN_WAIT_TIMEOUT_MS = 2000L
+
+  /** Additional wait time for straggler spans after first span arrives (milliseconds) */
+  const val STRAGGLER_WAIT_TIME_MS = 200L
+
+  /** Server shutdown grace period (seconds) */
+  const val SERVER_SHUTDOWN_TIMEOUT_SECONDS = 5L
+
+  /** Default maximum spans per trace to prevent memory issues */
+  const val DEFAULT_MAX_SPANS_PER_TRACE = 1000
+
+  /** Span ID length in W3C trace context */
+  const val SPAN_ID_LENGTH = 16
+
+  /** Minimum parts required in a W3C traceparent header */
+  const val TRACEPARENT_MIN_PARTS = 3
+
+  /** Maximum stack trace lines to display in trace trees */
+  const val MAX_STACK_TRACE_LINES = 3
+
+  /** OpenTelemetry status code for ERROR */
+  const val OTEL_STATUS_CODE_ERROR = 2
+
+  /** Service name attribute key in OpenTelemetry */
+  const val OTEL_SERVICE_NAME_ATTRIBUTE = "service.name"
+
+  /** gRPC internal span patterns to filter out */
+  val GRPC_INTERNAL_SPAN_PATTERNS = listOf(
+    "TraceService/Export",
+    "opentelemetry.proto.collector"
+  )
+
+  /** OpenTelemetry exception event name */
+  const val OTEL_EXCEPTION_EVENT_NAME = "exception"
+
+  /** OpenTelemetry exception type attribute key */
+  const val OTEL_EXCEPTION_TYPE_ATTRIBUTE = "exception.type"
+
+  /** OpenTelemetry exception message attribute key */
+  const val OTEL_EXCEPTION_MESSAGE_ATTRIBUTE = "exception.message"
+
+  /** OpenTelemetry exception stacktrace attribute key */
+  const val OTEL_EXCEPTION_STACKTRACE_ATTRIBUTE = "exception.stacktrace"
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/OTLPSpanReceiver.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/OTLPSpanReceiver.kt
@@ -1,0 +1,251 @@
+package com.trendyol.stove.tracing
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.google.protobuf.ByteString
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.Status
+import io.grpc.stub.StreamObserver
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc
+import io.opentelemetry.proto.trace.v1.ResourceSpans
+import io.opentelemetry.proto.trace.v1.ScopeSpans
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * OTLP-compatible span receiver that collects spans from the application under test via gRPC.
+ *
+ * This uses gRPC protocol which is the default for OpenTelemetry Java Agent and avoids
+ * classloader isolation issues since the agent communicates via protocol rather than shared classes.
+ *
+ * Example app configuration (OpenTelemetry Java Agent):
+ * ```
+ * -Dotel.traces.exporter=otlp
+ * -Dotel.exporter.otlp.protocol=grpc
+ * -Dotel.exporter.otlp.endpoint=http://localhost:4317
+ * -Dotel.service.name=my-service
+ * ```
+ *
+ * Inspired by TestSpanCollector from beholder-otel-extension.
+ */
+class OTLPSpanReceiver(
+  private val collector: StoveTraceCollector,
+  private val port: Int = TracingConstants.DEFAULT_OTLP_GRPC_PORT
+) {
+  private val logger = LoggerFactory.getLogger(OTLPSpanReceiver::class.java)
+  private val lock = ReentrantLock()
+  private var server: Server? = null
+
+  @Volatile private var running = false
+
+  val endpoint: String get() = "http://localhost:$port"
+
+  fun start(): Either<OTLPReceiverError, Unit> = lock.withLock {
+    try {
+      if (running) {
+        return Unit.right()
+      }
+
+      server = ServerBuilder
+        .forPort(port)
+        .addService(TraceServiceImpl(collector, logger))
+        .build()
+        .start()
+
+      running = true
+      logger.info("[StoveOtlp] Started OTLP gRPC collector on port {}", port)
+      Unit.right()
+    } catch (e: IOException) {
+      OTLPReceiverError.StartupFailed(port, e).left()
+    }
+  }
+
+  fun stop(): Unit = lock.withLock {
+    if (!running || server == null) {
+      return
+    }
+
+    try {
+      server?.shutdown()
+      val terminated = server?.awaitTermination(
+        TracingConstants.SERVER_SHUTDOWN_TIMEOUT_SECONDS,
+        TimeUnit.SECONDS
+      ) ?: false
+
+      if (!terminated) {
+        server?.shutdownNow()
+      }
+    } catch (_: InterruptedException) {
+      server?.shutdownNow()
+      Thread.currentThread().interrupt()
+    }
+
+    running = false
+    logger.info("[StoveOtlp] Stopped OTLP gRPC collector")
+  }
+}
+
+/**
+ * gRPC service implementation that receives OTLP trace data.
+ */
+private class TraceServiceImpl(
+  private val collector: StoveTraceCollector,
+  private val logger: org.slf4j.Logger
+) : TraceServiceGrpc.TraceServiceImplBase() {
+  override fun export(
+    request: ExportTraceServiceRequest,
+    responseObserver: StreamObserver<ExportTraceServiceResponse>
+  ) {
+    try {
+      val spans = extractSpansFromRequest(request)
+      spans.forEach { collector.record(it) }
+
+      if (spans.isNotEmpty()) {
+        logger.info(
+          "[StoveOtlp] Received {} spans from service '{}'",
+          spans.size,
+          spans.firstOrNull()?.serviceName ?: "unknown"
+        )
+      }
+      logger.debug("[StoveOtlp] Processed {} spans total", spans.size)
+
+      responseObserver.onNext(ExportTraceServiceResponse.getDefaultInstance())
+      responseObserver.onCompleted()
+    } catch (e: IOException) {
+      logger.error("[StoveOtlp] IO error processing spans", e)
+      responseObserver.onError(
+        Status.INTERNAL
+          .withDescription("Failed to process spans: ${e.message}")
+          .withCause(e)
+          .asException()
+      )
+    } catch (e: IllegalArgumentException) {
+      logger.warn("[StoveOtlp] Invalid span data received", e)
+      responseObserver.onError(
+        Status.INVALID_ARGUMENT
+          .withDescription("Invalid span data: ${e.message}")
+          .withCause(e)
+          .asException()
+      )
+    } catch (e: IllegalStateException) {
+      logger.warn("[StoveOtlp] Unexpected state during span processing", e)
+      responseObserver.onError(
+        Status.FAILED_PRECONDITION
+          .withDescription("Unexpected state: ${e.message}")
+          .withCause(e)
+          .asException()
+      )
+    }
+  }
+
+  private fun extractSpansFromRequest(request: ExportTraceServiceRequest): List<SpanInfo> =
+    request.resourceSpansList
+      .flatMap { resourceSpans -> extractSpansFromResource(resourceSpans) }
+      .filterNot { isInternalGrpcSpan(it.operationName) }
+
+  private fun extractSpansFromResource(resourceSpans: ResourceSpans): List<SpanInfo> {
+    val serviceName = extractServiceName(resourceSpans)
+    return resourceSpans.scopeSpansList
+      .flatMap { scopeSpans -> extractSpansFromScope(scopeSpans, serviceName) }
+  }
+
+  private fun extractServiceName(resourceSpans: ResourceSpans): String =
+    resourceSpans.resource
+      ?.attributesList
+      ?.find { it.key == TracingConstants.OTEL_SERVICE_NAME_ATTRIBUTE }
+      ?.value
+      ?.stringValue
+      ?: "unknown"
+
+  private fun extractSpansFromScope(scopeSpans: ScopeSpans, serviceName: String): List<SpanInfo> =
+    scopeSpans.spansList.map { span ->
+      SpanInfo(
+        traceId = span.traceId.toHex(),
+        spanId = span.spanId.toHex(),
+        parentSpanId = if (span.parentSpanId.isEmpty) null else span.parentSpanId.toHex(),
+        operationName = span.name,
+        serviceName = serviceName,
+        startTimeNanos = span.startTimeUnixNano,
+        endTimeNanos = span.endTimeUnixNano,
+        status = when (span.status.codeValue) {
+          TracingConstants.OTEL_STATUS_CODE_ERROR -> SpanStatus.ERROR
+          else -> SpanStatus.OK
+        },
+        attributes = span.attributesList.associate { kv ->
+          kv.key to extractAttributeValue(kv.value)
+        },
+        exception = extractExceptionFromSpan(span)
+      )
+    }
+
+  private fun extractExceptionFromSpan(
+    span: io.opentelemetry.proto.trace.v1.Span
+  ): ExceptionInfo? {
+    // First try to extract exception from events (preferred - contains full details)
+    val exceptionEvent = span.eventsList.find { event ->
+      event.name == TracingConstants.OTEL_EXCEPTION_EVENT_NAME
+    }
+
+    if (exceptionEvent != null) {
+      val attributes = exceptionEvent.attributesList.associate { kv ->
+        kv.key to extractAttributeValue(kv.value)
+      }
+      val exceptionType = attributes[TracingConstants.OTEL_EXCEPTION_TYPE_ATTRIBUTE] ?: "Exception"
+      val exceptionMessage = attributes[TracingConstants.OTEL_EXCEPTION_MESSAGE_ATTRIBUTE] ?: ""
+      val stackTrace = attributes[TracingConstants.OTEL_EXCEPTION_STACKTRACE_ATTRIBUTE]
+        ?.split("\n")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?: emptyList()
+
+      return ExceptionInfo(exceptionType, exceptionMessage, stackTrace)
+    }
+
+    // Fallback to status message if error status but no exception event
+    if (span.status.codeValue == TracingConstants.OTEL_STATUS_CODE_ERROR &&
+      span.status.message.isNotEmpty()
+    ) {
+      return ExceptionInfo("Error", span.status.message, emptyList())
+    }
+
+    return null
+  }
+
+  private fun extractAttributeValue(value: io.opentelemetry.proto.common.v1.AnyValue): String = when {
+    value.hasStringValue() -> value.stringValue
+    value.hasIntValue() -> value.intValue.toString()
+    value.hasBoolValue() -> value.boolValue.toString()
+    value.hasDoubleValue() -> value.doubleValue.toString()
+    else -> ""
+  }
+
+  private fun isInternalGrpcSpan(spanName: String): Boolean =
+    TracingConstants.GRPC_INTERNAL_SPAN_PATTERNS.any { pattern ->
+      spanName.contains(pattern)
+    }
+
+  private fun ByteString.toHex(): String {
+    if (isEmpty) return ""
+    return toByteArray().joinToString("") { "%02x".format(it) }
+  }
+}
+
+/**
+ * Errors that can occur during OTLP receiver operations.
+ */
+sealed class OTLPReceiverError(
+  message: String,
+  cause: Throwable? = null
+) : Exception(message, cause) {
+  data class StartupFailed(
+    val port: Int,
+    override val cause: IOException
+  ) : OTLPReceiverError("Failed to start OTLP gRPC collector on port $port", cause)
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/StoveTraceCollector.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/StoveTraceCollector.kt
@@ -1,0 +1,96 @@
+package com.trendyol.stove.tracing
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class StoveTraceCollector {
+  private val spans = ConcurrentHashMap<String, CopyOnWriteArrayList<SpanInfo>>()
+  private val traceToTest = ConcurrentHashMap<String, String>()
+
+  fun registerTrace(traceId: String, testId: String) {
+    traceToTest[traceId] = testId
+    spans.computeIfAbsent(traceId) { CopyOnWriteArrayList() }
+  }
+
+  fun record(span: SpanInfo) {
+    spans.computeIfAbsent(span.traceId) { CopyOnWriteArrayList() }.add(span)
+  }
+
+  fun recordAll(spansToRecord: Collection<SpanInfo>) {
+    spansToRecord.forEach { record(it) }
+  }
+
+  fun getTrace(traceId: String): List<SpanInfo> =
+    spans[traceId]?.toList() ?: emptyList()
+
+  fun getTraceTree(traceId: String): SpanNode? =
+    SpanTree.build(getTrace(traceId))
+
+  fun getTracesForTest(testId: String): List<String> =
+    traceToTest.filterValues { it == testId }.keys.toList()
+
+  fun getTestId(traceId: String): String? =
+    traceToTest[traceId]
+
+  fun getAllTraces(): Map<String, List<SpanInfo>> =
+    spans.mapValues { it.value.toList() }
+
+  fun getFailedSpans(traceId: String): List<SpanInfo> =
+    getTrace(traceId).filter { it.isFailed }
+
+  fun hasFailures(traceId: String): Boolean =
+    getTrace(traceId).any { it.isFailed }
+
+  fun clear(traceId: String) {
+    spans.remove(traceId)
+    traceToTest.remove(traceId)
+  }
+
+  fun clearForTest(testId: String) {
+    val traceIds = getTracesForTest(testId)
+    traceIds.forEach { clear(it) }
+  }
+
+  fun clearAll() {
+    spans.clear()
+    traceToTest.clear()
+  }
+
+  fun spanCount(traceId: String): Int =
+    spans[traceId]?.size ?: 0
+
+  fun totalSpanCount(): Int =
+    spans.values.sumOf { it.size }
+
+  fun traceCount(): Int = spans.size
+
+  /**
+   * Waits for at least the expected number of spans to be collected.
+   * Inspired by beholder-otel-extension's TestSpanCollector.
+   *
+   * @param traceId the trace ID to wait for
+   * @param expectedCount minimum number of spans to wait for
+   * @param timeoutMs maximum wait time in milliseconds
+   * @return the collected spans for the trace
+   */
+  fun waitForSpans(
+    traceId: String,
+    expectedCount: Int,
+    timeoutMs: Long = TracingConstants.DEFAULT_SPAN_WAIT_TIMEOUT_MS
+  ): List<SpanInfo> {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val currentSpans = getTrace(traceId)
+      if (currentSpans.size >= expectedCount) {
+        return currentSpans
+      }
+      try {
+        Thread.sleep(TracingConstants.DEFAULT_SPAN_POLL_INTERVAL_MS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        break
+      }
+    }
+    return getTrace(traceId)
+  }
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceContext.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceContext.kt
@@ -1,0 +1,80 @@
+package com.trendyol.stove.tracing
+
+import java.util.UUID
+
+data class TraceContext(
+  val traceId: String,
+  val testId: String,
+  val rootSpanId: String
+) {
+  fun toTraceparent(): String = "00-$traceId-$rootSpanId-01"
+
+  companion object {
+    /** W3C trace context header name */
+    const val TRACEPARENT_HEADER = "traceparent"
+
+    /** Stove test ID header name */
+    const val STOVE_TEST_ID_HEADER = "X-Stove-Test-Id"
+
+    /**
+     * Uses InheritableThreadLocal to propagate trace context to child threads.
+     * IMPORTANT: Always call [clear] when done with the trace to avoid memory leaks.
+     * Prefer using [use] for automatic cleanup.
+     */
+    private val current = InheritableThreadLocal<TraceContext>()
+
+    fun start(testId: String): TraceContext {
+      val ctx = TraceContext(
+        traceId = generateTraceId(),
+        testId = testId,
+        rootSpanId = generateSpanId()
+      )
+      current.set(ctx)
+      return ctx
+    }
+
+    fun current(): TraceContext? = current.get()
+
+    /**
+     * Clears the current trace context from the thread-local storage.
+     * IMPORTANT: Always call this method when done with a trace to prevent memory leaks.
+     */
+    fun clear() = current.remove()
+
+    /**
+     * Executes the given block with a new trace context, ensuring cleanup afterward.
+     * This is the preferred way to use trace contexts to avoid memory leaks.
+     *
+     * @param testId The test identifier for the trace
+     * @param block The code block to execute within the trace context
+     * @return The result of the block execution
+     */
+    inline fun <T> use(testId: String, block: (TraceContext) -> T): T {
+      val ctx = start(testId)
+      return try {
+        block(ctx)
+      } finally {
+        clear()
+      }
+    }
+
+    fun generateTraceId(): String =
+      UUID.randomUUID().toString().replace("-", "")
+
+    fun generateSpanId(): String =
+      UUID
+        .randomUUID()
+        .toString()
+        .replace("-", "")
+        .take(TracingConstants.SPAN_ID_LENGTH)
+
+    fun parseTraceparent(traceparent: String): Pair<String, String>? {
+      val parts = traceparent.split("-")
+      return if (parts.size >= TracingConstants.TRACEPARENT_MIN_PARTS) {
+        parts[1] to parts[2]
+      } else {
+        null
+      }
+    }
+  }
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceReportBuilder.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceReportBuilder.kt
@@ -1,0 +1,59 @@
+package com.trendyol.stove.tracing
+
+import arrow.core.getOrElse
+import arrow.core.toOption
+import com.trendyol.stove.system.Stove
+import com.trendyol.stove.system.StoveOptions
+
+/**
+ * Builds trace-enriched failure reports for test extensions.
+ *
+ * This centralizes the common logic for building reports that include
+ * both Stove's execution report and the execution trace tree.
+ */
+object TraceReportBuilder {
+  private const val SPAN_WAIT_TIME_MS = 500L
+  private const val NO_SPANS_MESSAGE = "No spans in trace"
+  private const val TRACE_HEADER_LINE = "═══════════════════════════════════════════════════════════════"
+  private const val TRACE_HEADER_TITLE = "EXECUTION TRACE (Call Chain)"
+
+  const val DEFAULT_ERROR_MESSAGE = "Test failed"
+
+  /**
+   * Builds the full report including Stove execution report and trace tree.
+   */
+  fun buildFullReport(): String {
+    val options = Stove.options()
+    val report = Stove.reporter().dumpIfFailed(options.failureRenderer)
+    val traceTree = getTraceTreeIfEnabled()
+    return buildReport(report, traceTree)
+  }
+
+  /**
+   * Checks if failure enrichment should be performed based on options.
+   */
+  fun StoveOptions.shouldEnrichFailures(): Boolean =
+    dumpReportOnTestFailure && reportingEnabled
+
+  private fun getTraceTreeIfEnabled(): String =
+    TraceContext
+      .current()
+      .toOption()
+      .flatMap { Stove.getSystemOrNone<TracingSystem>() }
+      .flatMap { it.getTraceVisualizationForCurrentTest(SPAN_WAIT_TIME_MS) }
+      .map { it.tree }
+      .getOrElse { "" }
+
+  private fun buildReport(stoveReport: String, traceTree: String): String = buildString {
+    if (stoveReport.isNotEmpty()) {
+      append(stoveReport)
+    }
+    if (traceTree.isNotEmpty() && traceTree != NO_SPANS_MESSAGE) {
+      if (isNotEmpty()) appendLine().appendLine()
+      appendLine(TRACE_HEADER_LINE)
+      appendLine(TRACE_HEADER_TITLE)
+      appendLine(TRACE_HEADER_LINE)
+      append(traceTree)
+    }
+  }
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceValidation.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TraceValidation.kt
@@ -1,0 +1,145 @@
+package com.trendyol.stove.tracing
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@DslMarker
+annotation class TracingDsl
+
+@TracingDsl
+class TraceValidationDsl(
+  private val collector: StoveTraceCollector,
+  private val traceId: String
+) {
+  private val trace: List<SpanInfo> by lazy { collector.getTrace(traceId) }
+  private val tree: SpanNode? by lazy { collector.getTraceTree(traceId) }
+
+  fun shouldContainSpan(operationName: String): TraceValidationDsl {
+    require(trace.any { it.operationName.contains(operationName) }) {
+      "Expected span containing '$operationName' but found: ${trace.map { it.operationName }}"
+    }
+    return this
+  }
+
+  fun shouldContainSpanMatching(predicate: (SpanInfo) -> Boolean): TraceValidationDsl {
+    require(trace.any(predicate)) {
+      "Expected span matching predicate but none found in: ${trace.map { it.operationName }}"
+    }
+    return this
+  }
+
+  fun shouldNotContainSpan(operationName: String): TraceValidationDsl {
+    val matchingSpans = trace.filter { it.operationName.contains(operationName) }
+    require(matchingSpans.isEmpty()) {
+      "Expected no span containing '$operationName' but found: ${matchingSpans.map { it.operationName }}"
+    }
+    return this
+  }
+
+  fun shouldNotHaveFailedSpans(): TraceValidationDsl {
+    val failed = trace.filter { it.isFailed }
+    require(failed.isEmpty()) {
+      val failureMessages = failed.map { span ->
+        "${span.operationName}: ${span.exception?.message ?: "unknown error"}"
+      }
+      "Expected no failed spans but found: $failureMessages"
+    }
+    return this
+  }
+
+  fun shouldHaveFailedSpan(operationName: String): TraceValidationDsl {
+    val failedSpans = trace.filter { it.isFailed }
+    val failedMatching = failedSpans.filter { it.operationName.contains(operationName) }
+
+    require(failedMatching.isNotEmpty()) {
+      "Expected failed span containing '$operationName' but found failed spans: ${failedSpans.map { it.operationName }}"
+    }
+    return this
+  }
+
+  fun executionTimeShouldBeLessThan(duration: Duration): TraceValidationDsl {
+    val totalDuration = calculateTotalDuration()
+    require(totalDuration <= duration) {
+      "Expected execution time <= $duration but was $totalDuration"
+    }
+    return this
+  }
+
+  fun executionTimeShouldBeGreaterThan(duration: Duration): TraceValidationDsl {
+    val totalDuration = calculateTotalDuration()
+    require(totalDuration >= duration) {
+      "Expected execution time >= $duration but was $totalDuration"
+    }
+    return this
+  }
+
+  fun spanCountShouldBe(expected: Int): TraceValidationDsl {
+    require(trace.size == expected) {
+      "Expected $expected spans but found ${trace.size}"
+    }
+    return this
+  }
+
+  fun spanCountShouldBeAtLeast(minimum: Int): TraceValidationDsl {
+    require(trace.size >= minimum) {
+      "Expected at least $minimum spans but found ${trace.size}"
+    }
+    return this
+  }
+
+  fun spanCountShouldBeAtMost(maximum: Int): TraceValidationDsl {
+    require(trace.size <= maximum) {
+      "Expected at most $maximum spans but found ${trace.size}"
+    }
+    return this
+  }
+
+  fun shouldHaveSpanWithAttribute(key: String, value: String): TraceValidationDsl {
+    require(trace.any { it.attributes[key] == value }) {
+      "Expected span with attribute '$key'='$value' but none found"
+    }
+    return this
+  }
+
+  fun shouldHaveSpanWithAttributeContaining(key: String, substring: String): TraceValidationDsl {
+    require(trace.any { it.attributes[key]?.contains(substring) == true }) {
+      "Expected span with attribute '$key' containing '$substring' but none found"
+    }
+    return this
+  }
+
+  fun getSpanCount(): Int = trace.size
+
+  fun getFailedSpans(): List<SpanInfo> = trace.filter { it.isFailed }
+
+  fun getFailedSpanCount(): Int = getFailedSpans().size
+
+  fun findSpan(predicate: (SpanInfo) -> Boolean): SpanInfo? = trace.find(predicate)
+
+  fun findSpanByName(operationName: String): SpanInfo? =
+    trace.find { it.operationName.contains(operationName) }
+
+  fun spanTree(): SpanNode? = tree
+
+  fun getTotalDuration(): Duration = calculateTotalDuration()
+
+  private fun calculateTotalDuration(): Duration {
+    if (trace.isEmpty()) return 0.milliseconds
+
+    val minStart = trace.minOf { it.startTimeNanos }
+    val maxEnd = trace.maxOf { it.endTimeNanos }
+    val durationMs = (maxEnd - minStart) / TracingConstants.NANOS_TO_MILLIS
+
+    return durationMs.milliseconds
+  }
+
+  fun renderTree(): String {
+    val root = tree ?: return "No spans in trace"
+    return TraceTreeRenderer.render(root)
+  }
+
+  fun renderSummary(): String {
+    val root = tree ?: return "No spans in trace"
+    return TraceTreeRenderer.renderSummary(root)
+  }
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TracingOptions.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TracingOptions.kt
@@ -1,0 +1,93 @@
+@file:Suppress("unused")
+
+package com.trendyol.stove.tracing
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configuration options for the Stove tracing system.
+ *
+ * The tracing system works by receiving OTLP spans from the application under test.
+ * Configure your application to use the OpenTelemetry Java Agent and export spans
+ * to the Stove OTLP receiver endpoint.
+ */
+class TracingOptions {
+  var enabled: Boolean = false
+    private set
+
+  var spanCollectionTimeout: Duration = 5.seconds
+    private set
+
+  var spanFilter: (SpanInfo) -> Boolean = { true }
+    private set
+
+  var maxSpansPerTrace: Int = TracingConstants.DEFAULT_MAX_SPANS_PER_TRACE
+    private set
+
+  var serviceName: String = "stove-traced-app"
+    private set
+
+  var spanReceiverEnabled: Boolean = false
+    private set
+
+  var spanReceiverPort: Int = TracingConstants.DEFAULT_OTLP_GRPC_PORT
+    private set
+
+  fun enabled(): TracingOptions = apply { enabled = true }
+
+  fun disabled(): TracingOptions = apply { enabled = false }
+
+  fun spanCollectionTimeout(timeout: Duration): TracingOptions = apply {
+    spanCollectionTimeout = timeout
+  }
+
+  fun spanFilter(filter: (SpanInfo) -> Boolean): TracingOptions = apply {
+    spanFilter = filter
+  }
+
+  fun maxSpansPerTrace(max: Int): TracingOptions = apply {
+    maxSpansPerTrace = max
+  }
+
+  fun serviceName(name: String): TracingOptions = apply {
+    serviceName = name
+  }
+
+  /**
+   * Enable the OTLP span receiver to collect spans from the application under test.
+   *
+   * The port is determined in the following order:
+   * 1. Explicitly provided port parameter
+   * 2. STOVE_TRACING_PORT environment variable (set by Gradle configuration)
+   * 3. Default port 4317
+   *
+   * The application should be configured to export spans via the OpenTelemetry Java Agent:
+   * ```
+   * -javaagent:path/to/opentelemetry-javaagent.jar
+   * -Dotel.exporter.otlp.endpoint=http://localhost:{port}
+   * -Dotel.exporter.otlp.protocol=grpc
+   * -Dotel.service.name=my-service
+   * ```
+   *
+   * @param port The port for the OTLP gRPC receiver. If not specified, reads from
+   *             STOVE_TRACING_PORT env var or defaults to 4317.
+   */
+  fun enableSpanReceiver(port: Int? = null): TracingOptions = apply {
+    spanReceiverEnabled = true
+    spanReceiverPort = port ?: portFromEnv() ?: TracingConstants.DEFAULT_OTLP_GRPC_PORT
+  }
+
+  private fun portFromEnv(): Int? =
+    System.getenv(TracingConstants.STOVE_TRACING_PORT_ENV)?.toIntOrNull()
+
+  fun copy(): TracingOptions = TracingOptions().also { copy ->
+    copy.enabled = this.enabled
+    copy.spanCollectionTimeout = this.spanCollectionTimeout
+    copy.spanFilter = this.spanFilter
+    copy.maxSpansPerTrace = this.maxSpansPerTrace
+    copy.serviceName = this.serviceName
+    copy.spanReceiverEnabled = this.spanReceiverEnabled
+    copy.spanReceiverPort = this.spanReceiverPort
+  }
+}

--- a/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TracingSystem.kt
+++ b/lib/stove-tracing/src/main/kotlin/com/trendyol/stove/tracing/TracingSystem.kt
@@ -1,0 +1,343 @@
+@file:Suppress("unused")
+
+package com.trendyol.stove.tracing
+
+import arrow.core.*
+import com.trendyol.stove.reporting.*
+import com.trendyol.stove.system.*
+import com.trendyol.stove.system.abstractions.*
+import com.trendyol.stove.system.annotations.StoveDsl
+
+@StoveDsl
+class TracingSystem(
+  override val stove: Stove,
+  private val options: TracingSystemOptions
+) : PluggedSystem,
+  RunAware,
+  TraceProvider {
+  private val logger = org.slf4j.LoggerFactory.getLogger(TracingSystem::class.java)
+  internal val collector: StoveTraceCollector = StoveTraceCollector()
+  private var spanReceiver: OTLPSpanReceiver? = null
+
+  override suspend fun run() {
+    if (options.tracingOptions.spanReceiverEnabled) {
+      startSpanReceiver()
+    }
+  }
+
+  override suspend fun stop() {
+    stopSpanReceiver()
+    clearAllTraces()
+  }
+
+  override fun getTraceVisualizationForCurrentTest(waitTimeMs: Long): Option<TraceVisualization> {
+    val ctx = TraceContext.current() ?: return None
+    val spans = pollForSpans(ctx.traceId, waitTimeMs)
+    return createVisualizationOrFallback(ctx.traceId, ctx.testId, spans)
+  }
+
+  @StoveDsl
+  suspend fun ensureTraceStarted(): TraceContext =
+    TraceContext.current() ?: startNewTrace()
+
+  @StoveDsl
+  fun endTrace() {
+    TraceContext.clear()
+  }
+
+  @StoveDsl
+  fun currentContext(): Option<TraceContext> =
+    TraceContext.current().toOption()
+
+  @StoveDsl
+  fun validation(): Option<TraceValidationDsl> =
+    currentContext().map { createValidation(it.traceId) }
+
+  @StoveDsl
+  fun validation(traceId: String): TraceValidationDsl =
+    createValidation(traceId)
+
+  @StoveDsl
+  override fun then(): Stove = stove
+
+  override fun close() {
+    clearAllTraces()
+  }
+
+  // Private helper methods
+
+  private fun startSpanReceiver() {
+    spanReceiver = OTLPSpanReceiver(collector, options.tracingOptions.spanReceiverPort)
+    spanReceiver?.start()?.fold(
+      ifLeft = { error ->
+        // Port binding failure is non-fatal - tests continue without span collection
+        // This commonly happens when multiple test modules run in parallel on CI
+        logger.warn(
+          "[StoveTracing] Failed to start OTLP receiver on port {}: {}. " +
+            "Tracing spans will not be collected. This is usually caused by another " +
+            "test module already using this port.",
+          options.tracingOptions.spanReceiverPort,
+          error.message
+        )
+        spanReceiver = null
+      },
+      ifRight = { /* Started successfully */ }
+    )
+  }
+
+  private fun stopSpanReceiver() {
+    spanReceiver?.stop()
+  }
+
+  private fun clearAllTraces() {
+    collector.clearAll()
+    TraceContext.clear()
+  }
+
+  /**
+   * Polls for spans with intelligent waiting strategy.
+   * Returns as soon as first spans arrive, then waits briefly for stragglers.
+   */
+  private fun pollForSpans(traceId: String, maxWaitTimeMs: Long): List<SpanInfo> {
+    val deadline = System.currentTimeMillis() + maxWaitTimeMs
+
+    // Poll until we find spans or timeout
+    val initialSpans = pollUntilSpansArrive(traceId, deadline)
+
+    // If we found spans, wait a bit more for stragglers
+    return if (initialSpans.isNotEmpty()) {
+      waitForStragglersAndCollect(traceId, deadline)
+    } else {
+      emptyList()
+    }
+  }
+
+  /**
+   * Polls repeatedly until spans arrive or deadline is reached.
+   */
+  private fun pollUntilSpansArrive(traceId: String, deadline: Long): List<SpanInfo> {
+    while (System.currentTimeMillis() < deadline) {
+      val spans = collector.getTrace(traceId)
+      if (spans.isNotEmpty()) return spans
+
+      if (!sleepQuietly(TracingConstants.DEFAULT_SPAN_POLL_INTERVAL_MS)) {
+        break // Interrupted
+      }
+    }
+    return emptyList()
+  }
+
+  /**
+   * Waits briefly for straggler spans, then collects final result.
+   */
+  private fun waitForStragglersAndCollect(traceId: String, deadline: Long): List<SpanInfo> {
+    val remainingTime = deadline - System.currentTimeMillis()
+    val stragglerWait = minOf(TracingConstants.STRAGGLER_WAIT_TIME_MS, remainingTime).coerceAtLeast(0)
+
+    sleepQuietly(stragglerWait)
+    return collector.getTrace(traceId)
+  }
+
+  /**
+   * Sleeps quietly, handling interruption gracefully.
+   * Returns true if sleep completed, false if interrupted.
+   */
+  private fun sleepQuietly(millis: Long): Boolean {
+    if (millis <= 0) return true
+
+    return try {
+      Thread.sleep(millis)
+      true
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+      false
+    }
+  }
+
+  /**
+   * Creates visualization from spans, or falls back to most relevant trace if empty.
+   */
+  private fun createVisualizationOrFallback(
+    traceId: String,
+    testId: String,
+    spans: List<SpanInfo>
+  ): Option<TraceVisualization> = when {
+    spans.isNotEmpty() -> TraceVisualization.from(traceId, testId, spans).some()
+    else -> findMostRelevantTrace(testId)
+  }
+
+  /**
+   * Finds the most relevant trace when the expected trace ID has no spans.
+   * Uses the most recent trace (by start time) as a heuristic, as it's likely
+   * to be the trace closest to the test execution.
+   */
+  private fun findMostRelevantTrace(testId: String): Option<TraceVisualization> {
+    val allTraces = collector.getAllTraces()
+    if (allTraces.isEmpty()) return None
+
+    // Find the trace with the most recent span start time
+    val (traceId, traceSpans) = allTraces
+      .filter { it.value.isNotEmpty() }
+      .maxByOrNull { entry -> entry.value.maxOf { it.startTimeNanos } }
+      ?: return None
+
+    return TraceVisualization.from(traceId, testId, traceSpans).some()
+  }
+
+  private suspend fun startNewTrace(): TraceContext {
+    val testId = resolveTestId()
+    val ctx = TraceContext.start(testId)
+    collector.registerTrace(ctx.traceId, testId)
+    return ctx
+  }
+
+  private suspend fun resolveTestId(): String =
+    resolveKotestTestId()
+      ?: resolveJUnitTestId()
+      ?: generateFallbackTestId()
+
+  private suspend fun resolveKotestTestId(): String? =
+    currentStoveTestContext()?.testId
+
+  private fun resolveJUnitTestId(): String? =
+    StoveTestContextHolder.get()?.testId
+
+  private fun generateFallbackTestId(): String =
+    "stove-trace-${System.currentTimeMillis()}"
+
+  private fun createValidation(traceId: String): TraceValidationDsl =
+    TraceValidationDsl(collector, traceId)
+}
+
+data class TracingSystemOptions(
+  val tracingOptions: TracingOptions = TracingOptions().enabled()
+)
+
+internal fun Stove.withTracing(options: TracingSystemOptions): Stove {
+  this.getOrRegister(TracingSystem(this, options))
+  return this
+}
+
+internal fun Stove.tracingSystem(): TracingSystem = getOrNone<TracingSystem>().getOrElse {
+  throw SystemNotRegisteredException(TracingSystem::class)
+}
+
+@StoveDsl
+fun WithDsl.tracing(configure: @StoveDsl TracingOptions.() -> Unit = {}): Stove =
+  this.stove.withTracing(createTracingOptions(configure))
+
+private fun createTracingOptions(configure: TracingOptions.() -> Unit): TracingSystemOptions {
+  val options = TracingOptions()
+  options.configure()
+  options.enabled()
+  return TracingSystemOptions(options)
+}
+
+/**
+ * DSL scope for tracing validation - exposes trace context and all validation methods directly.
+ */
+@StoveDsl
+class TracingValidationScope(
+  val ctx: TraceContext,
+  private val validation: TraceValidationDsl,
+  val collector: StoveTraceCollector
+) {
+  val traceId: String get() = ctx.traceId
+  val rootSpanId: String get() = ctx.rootSpanId
+  val testId: String get() = ctx.testId
+
+  fun toTraceparent(): String = ctx.toTraceparent()
+
+  // Validation method delegates
+  fun shouldContainSpan(operationName: String) = validation.shouldContainSpan(operationName)
+
+  fun shouldContainSpanMatching(predicate: (SpanInfo) -> Boolean) = validation.shouldContainSpanMatching(predicate)
+
+  fun shouldNotContainSpan(operationName: String) = validation.shouldNotContainSpan(operationName)
+
+  fun shouldNotHaveFailedSpans() = validation.shouldNotHaveFailedSpans()
+
+  fun shouldHaveFailedSpan(operationName: String) = validation.shouldHaveFailedSpan(operationName)
+
+  fun executionTimeShouldBeLessThan(duration: kotlin.time.Duration) = validation.executionTimeShouldBeLessThan(duration)
+
+  fun executionTimeShouldBeGreaterThan(duration: kotlin.time.Duration) = validation.executionTimeShouldBeGreaterThan(duration)
+
+  fun spanCountShouldBe(expected: Int) = validation.spanCountShouldBe(expected)
+
+  fun spanCountShouldBeAtLeast(minimum: Int) = validation.spanCountShouldBeAtLeast(minimum)
+
+  fun spanCountShouldBeAtMost(maximum: Int) = validation.spanCountShouldBeAtMost(maximum)
+
+  fun shouldHaveSpanWithAttribute(key: String, value: String) = validation.shouldHaveSpanWithAttribute(key, value)
+
+  fun shouldHaveSpanWithAttributeContaining(key: String, substring: String) =
+    validation.shouldHaveSpanWithAttributeContaining(key, substring)
+
+  // Query methods
+  fun getSpanCount(): Int = validation.getSpanCount()
+
+  fun getFailedSpans(): List<SpanInfo> = validation.getFailedSpans()
+
+  fun getFailedSpanCount(): Int = validation.getFailedSpanCount()
+
+  fun findSpan(predicate: (SpanInfo) -> Boolean): Option<SpanInfo> = validation.findSpan(predicate).toOption()
+
+  fun findSpanByName(operationName: String): Option<SpanInfo> = validation.findSpanByName(operationName).toOption()
+
+  fun spanTree(): Option<SpanNode> = validation.spanTree().toOption()
+
+  fun getTotalDuration(): kotlin.time.Duration = validation.getTotalDuration()
+
+  fun renderTree(): String = validation.renderTree()
+
+  fun renderSummary(): String = validation.renderSummary()
+
+  /**
+   * Waits for at least the expected number of spans to be collected.
+   * Useful for ensuring spans have been exported before making assertions.
+   */
+  fun waitForSpans(expectedCount: Int, timeoutMs: Long = 2000): List<SpanInfo> =
+    collector.waitForSpans(traceId, expectedCount, timeoutMs)
+
+  /**
+   * Gets a visualization of the trace for this test.
+   * Includes all spans for this trace ID formatted as a tree.
+   */
+  fun getTraceVisualization(): TraceVisualization {
+    val spans = collector.getTrace(traceId)
+    return TraceVisualization.from(traceId, testId, spans)
+  }
+
+  /**
+   * Gets visualizations for ALL collected traces (not just this test's trace ID).
+   * Useful for seeing all activity during the test execution.
+   */
+  fun getAllTraceVisualizations(): List<TraceVisualization> {
+    val allTraces = collector.getAllTraces()
+    return allTraces.map { (traceId, spans) ->
+      TraceVisualization.from(traceId, testId, spans)
+    }
+  }
+}
+
+@StoveDsl
+suspend fun ValidationDsl.tracing(
+  validation: @StoveDsl suspend TracingValidationScope.() -> Unit
+) {
+  val system = this.stove.tracingSystem()
+  val ctx = system.ensureTraceStarted()
+  val scope = createTracingValidationScope(system, ctx)
+  validation(scope)
+}
+
+private fun createTracingValidationScope(
+  system: TracingSystem,
+  ctx: TraceContext
+): TracingValidationScope {
+  val traceValidation = system.validation(ctx.traceId)
+  return TracingValidationScope(ctx, traceValidation, system.collector)
+}
+
+@StoveDsl
+fun ValidationDsl.tracingSystem(): TracingSystem = this.stove.tracingSystem()

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/OtlpSpanReceiverTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/OtlpSpanReceiverTest.kt
@@ -1,0 +1,623 @@
+package com.trendyol.stove.tracing
+
+import arrow.core.getOrElse
+import io.grpc.ManagedChannelBuilder
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc
+import io.opentelemetry.proto.common.v1.AnyValue
+import io.opentelemetry.proto.common.v1.KeyValue
+import io.opentelemetry.proto.resource.v1.Resource
+import io.opentelemetry.proto.trace.v1.ResourceSpans
+import io.opentelemetry.proto.trace.v1.ScopeSpans
+import io.opentelemetry.proto.trace.v1.Span
+import io.opentelemetry.proto.trace.v1.Status
+import java.util.concurrent.TimeUnit
+
+private const val TEST_STACKTRACE = """java.lang.RuntimeException: Something went wrong
+	at com.example.Service.process(Service.kt:42)
+	at com.example.Controller.handle(Controller.kt:15)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)"""
+
+class OtlpSpanReceiverTest :
+  FunSpec({
+    val testPort = 14317 // Use a non-standard port to avoid conflicts
+
+    test("start should succeed on available port") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        val result = receiver.start()
+        result.isRight() shouldBe true
+        receiver.endpoint shouldBe "http://localhost:$testPort"
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("start should be idempotent") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+        val result = receiver.start() // Second start should also succeed
+        result.isRight() shouldBe true
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("stop should be safe to call multiple times") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      receiver.start()
+      receiver.stop()
+      receiver.stop() // Should not throw
+    }
+
+    test("export should record spans to collector") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        // Create a gRPC client
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          // Create a test span
+          val request = createExportRequest(
+            serviceName = "test-service",
+            traceId = "0123456789abcdef0123456789abcdef",
+            spanId = "0123456789abcdef",
+            spanName = "test-operation"
+          )
+
+          stub.export(request)
+
+          // Give some time for the span to be recorded
+          Thread.sleep(100)
+
+          val trace = collector.getTrace("0123456789abcdef0123456789abcdef")
+          trace shouldHaveSize 1
+          trace[0].operationName shouldBe "test-operation"
+          trace[0].serviceName shouldBe "test-service"
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should filter out internal gRPC spans") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          // Create spans including internal gRPC span that should be filtered
+          val request = createExportRequest(
+            serviceName = "test-service",
+            traceId = "abcdef0123456789abcdef0123456789",
+            spanId = "fedcba9876543210",
+            spanName = "TraceService/Export" // This should be filtered out
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          // The internal span should be filtered out
+          val trace = collector.getTrace("abcdef0123456789abcdef0123456789")
+          trace shouldHaveSize 0
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should extract service name from resource attributes") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          val request = createExportRequest(
+            serviceName = "my-custom-service",
+            traceId = "11111111111111111111111111111111",
+            spanId = "2222222222222222",
+            spanName = "custom-operation"
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          val trace = collector.getTrace("11111111111111111111111111111111")
+          trace shouldHaveSize 1
+          trace[0].serviceName shouldBe "my-custom-service"
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should handle multiple spans in single request") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          val traceId = "33333333333333333333333333333333"
+          val request = createExportRequestWithMultipleSpans(
+            serviceName = "test-service",
+            traceId = traceId,
+            spanNames = listOf("span1", "span2", "span3")
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          val trace = collector.getTrace(traceId)
+          trace shouldHaveSize 3
+          trace.map { it.operationName } shouldBe listOf("span1", "span2", "span3")
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should handle span with error status") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          val traceId = "44444444444444444444444444444444"
+          val request = createExportRequestWithErrorSpan(
+            serviceName = "test-service",
+            traceId = traceId,
+            spanId = "5555555555555555",
+            spanName = "failed-operation",
+            errorMessage = "Something went wrong"
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          val trace = collector.getTrace(traceId)
+          trace shouldHaveSize 1
+          trace[0].status shouldBe SpanStatus.ERROR
+          trace[0].exception?.message shouldBe "Something went wrong"
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should extract exception from span events") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          val traceId = "88888888888888888888888888888888"
+          val request = createExportRequestWithExceptionEvent(
+            serviceName = "test-service",
+            traceId = traceId,
+            spanId = "9999999999999999",
+            spanName = "failed-operation",
+            exceptionType = "java.lang.RuntimeException",
+            exceptionMessage = "Something went wrong",
+            exceptionStacktrace = TEST_STACKTRACE
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          val trace = collector.getTrace(traceId)
+          trace shouldHaveSize 1
+          trace[0].status shouldBe SpanStatus.ERROR
+          trace[0].exception?.type shouldBe "java.lang.RuntimeException"
+          trace[0].exception?.message shouldBe "Something went wrong"
+          trace[0].exception?.stackTrace?.size shouldBe 4
+          trace[0].exception?.stackTrace?.get(1) shouldBe "at com.example.Service.process(Service.kt:42)"
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("export should extract span attributes") {
+      val collector = StoveTraceCollector()
+      val receiver = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver.start()
+
+        val channel = ManagedChannelBuilder
+          .forAddress("localhost", testPort)
+          .usePlaintext()
+          .build()
+
+        try {
+          val stub = TraceServiceGrpc.newBlockingStub(channel)
+
+          val traceId = "66666666666666666666666666666666"
+          val request = createExportRequestWithAttributes(
+            serviceName = "test-service",
+            traceId = traceId,
+            spanId = "7777777777777777",
+            spanName = "db-operation",
+            attributes = mapOf(
+              "db.system" to "postgresql",
+              "db.name" to "test_db"
+            )
+          )
+
+          stub.export(request)
+
+          Thread.sleep(100)
+
+          val trace = collector.getTrace(traceId)
+          trace shouldHaveSize 1
+          trace[0].attributes["db.system"] shouldBe "postgresql"
+          trace[0].attributes["db.name"] shouldBe "test_db"
+        } finally {
+          channel.shutdown()
+          channel.awaitTermination(5, TimeUnit.SECONDS)
+        }
+      } finally {
+        receiver.stop()
+      }
+    }
+
+    test("start should fail on port already in use") {
+      val collector = StoveTraceCollector()
+      val receiver1 = OTLPSpanReceiver(collector, testPort)
+      val receiver2 = OTLPSpanReceiver(collector, testPort)
+
+      try {
+        receiver1.start()
+        val result = receiver2.start()
+
+        result.isLeft() shouldBe true
+        result.getOrElse { it }.shouldBeInstanceOf<OTLPReceiverError.StartupFailed>()
+      } finally {
+        receiver1.stop()
+        receiver2.stop()
+      }
+    }
+  })
+
+private fun hexStringToByteString(hex: String): com.google.protobuf.ByteString {
+  val bytes = hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+  return com.google.protobuf.ByteString
+    .copyFrom(bytes)
+}
+
+private fun createExportRequest(
+  serviceName: String,
+  traceId: String,
+  spanId: String,
+  spanName: String
+): ExportTraceServiceRequest {
+  val resource = Resource
+    .newBuilder()
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey("service.name")
+        .setValue(AnyValue.newBuilder().setStringValue(serviceName))
+    ).build()
+
+  val span = Span
+    .newBuilder()
+    .setTraceId(hexStringToByteString(traceId))
+    .setSpanId(hexStringToByteString(spanId))
+    .setName(spanName)
+    .setStartTimeUnixNano(System.nanoTime())
+    .setEndTimeUnixNano(System.nanoTime() + 1_000_000)
+    .build()
+
+  val scopeSpans = ScopeSpans
+    .newBuilder()
+    .addSpans(span)
+    .build()
+
+  val resourceSpans = ResourceSpans
+    .newBuilder()
+    .setResource(resource)
+    .addScopeSpans(scopeSpans)
+    .build()
+
+  return ExportTraceServiceRequest
+    .newBuilder()
+    .addResourceSpans(resourceSpans)
+    .build()
+}
+
+private fun createExportRequestWithMultipleSpans(
+  serviceName: String,
+  traceId: String,
+  spanNames: List<String>
+): ExportTraceServiceRequest {
+  val resource = Resource
+    .newBuilder()
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey("service.name")
+        .setValue(AnyValue.newBuilder().setStringValue(serviceName))
+    ).build()
+
+  val scopeSpansBuilder = ScopeSpans.newBuilder()
+
+  spanNames.forEachIndexed { index, name ->
+    val span = Span
+      .newBuilder()
+      .setTraceId(hexStringToByteString(traceId))
+      .setSpanId(hexStringToByteString("${index + 1}".padStart(16, '0')))
+      .setName(name)
+      .setStartTimeUnixNano(System.nanoTime())
+      .setEndTimeUnixNano(System.nanoTime() + 1_000_000)
+      .build()
+    scopeSpansBuilder.addSpans(span)
+  }
+
+  val resourceSpans = ResourceSpans
+    .newBuilder()
+    .setResource(resource)
+    .addScopeSpans(scopeSpansBuilder.build())
+    .build()
+
+  return ExportTraceServiceRequest
+    .newBuilder()
+    .addResourceSpans(resourceSpans)
+    .build()
+}
+
+private fun createExportRequestWithErrorSpan(
+  serviceName: String,
+  traceId: String,
+  spanId: String,
+  spanName: String,
+  errorMessage: String
+): ExportTraceServiceRequest {
+  val resource = Resource
+    .newBuilder()
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey("service.name")
+        .setValue(AnyValue.newBuilder().setStringValue(serviceName))
+    ).build()
+
+  val span = Span
+    .newBuilder()
+    .setTraceId(hexStringToByteString(traceId))
+    .setSpanId(hexStringToByteString(spanId))
+    .setName(spanName)
+    .setStartTimeUnixNano(System.nanoTime())
+    .setEndTimeUnixNano(System.nanoTime() + 1_000_000)
+    .setStatus(
+      Status
+        .newBuilder()
+        .setCodeValue(TracingConstants.OTEL_STATUS_CODE_ERROR)
+        .setMessage(errorMessage)
+    ).build()
+
+  val scopeSpans = ScopeSpans
+    .newBuilder()
+    .addSpans(span)
+    .build()
+
+  val resourceSpans = ResourceSpans
+    .newBuilder()
+    .setResource(resource)
+    .addScopeSpans(scopeSpans)
+    .build()
+
+  return ExportTraceServiceRequest
+    .newBuilder()
+    .addResourceSpans(resourceSpans)
+    .build()
+}
+
+private fun createExportRequestWithAttributes(
+  serviceName: String,
+  traceId: String,
+  spanId: String,
+  spanName: String,
+  attributes: Map<String, String>
+): ExportTraceServiceRequest {
+  val resource = Resource
+    .newBuilder()
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey("service.name")
+        .setValue(AnyValue.newBuilder().setStringValue(serviceName))
+    ).build()
+
+  val spanBuilder = Span
+    .newBuilder()
+    .setTraceId(hexStringToByteString(traceId))
+    .setSpanId(hexStringToByteString(spanId))
+    .setName(spanName)
+    .setStartTimeUnixNano(System.nanoTime())
+    .setEndTimeUnixNano(System.nanoTime() + 1_000_000)
+
+  attributes.forEach { (key, value) ->
+    spanBuilder.addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey(key)
+        .setValue(AnyValue.newBuilder().setStringValue(value))
+    )
+  }
+
+  val scopeSpans = ScopeSpans
+    .newBuilder()
+    .addSpans(spanBuilder.build())
+    .build()
+
+  val resourceSpans = ResourceSpans
+    .newBuilder()
+    .setResource(resource)
+    .addScopeSpans(scopeSpans)
+    .build()
+
+  return ExportTraceServiceRequest
+    .newBuilder()
+    .addResourceSpans(resourceSpans)
+    .build()
+}
+
+private fun createExportRequestWithExceptionEvent(
+  serviceName: String,
+  traceId: String,
+  spanId: String,
+  spanName: String,
+  exceptionType: String,
+  exceptionMessage: String,
+  exceptionStacktrace: String
+): ExportTraceServiceRequest {
+  val resource = Resource
+    .newBuilder()
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey("service.name")
+        .setValue(AnyValue.newBuilder().setStringValue(serviceName))
+    ).build()
+
+  val exceptionEvent = Span.Event
+    .newBuilder()
+    .setName(TracingConstants.OTEL_EXCEPTION_EVENT_NAME)
+    .setTimeUnixNano(System.nanoTime())
+    .addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey(TracingConstants.OTEL_EXCEPTION_TYPE_ATTRIBUTE)
+        .setValue(AnyValue.newBuilder().setStringValue(exceptionType))
+    ).addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey(TracingConstants.OTEL_EXCEPTION_MESSAGE_ATTRIBUTE)
+        .setValue(AnyValue.newBuilder().setStringValue(exceptionMessage))
+    ).addAttributes(
+      KeyValue
+        .newBuilder()
+        .setKey(TracingConstants.OTEL_EXCEPTION_STACKTRACE_ATTRIBUTE)
+        .setValue(AnyValue.newBuilder().setStringValue(exceptionStacktrace))
+    ).build()
+
+  val span = Span
+    .newBuilder()
+    .setTraceId(hexStringToByteString(traceId))
+    .setSpanId(hexStringToByteString(spanId))
+    .setName(spanName)
+    .setStartTimeUnixNano(System.nanoTime())
+    .setEndTimeUnixNano(System.nanoTime() + 1_000_000)
+    .setStatus(
+      Status
+        .newBuilder()
+        .setCodeValue(TracingConstants.OTEL_STATUS_CODE_ERROR)
+        .setMessage(exceptionMessage)
+    ).addEvents(exceptionEvent)
+    .build()
+
+  val scopeSpans = ScopeSpans
+    .newBuilder()
+    .addSpans(span)
+    .build()
+
+  val resourceSpans = ResourceSpans
+    .newBuilder()
+    .setResource(resource)
+    .addScopeSpans(scopeSpans)
+    .build()
+
+  return ExportTraceServiceRequest
+    .newBuilder()
+    .addResourceSpans(resourceSpans)
+    .build()
+}

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/SpanInfoTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/SpanInfoTest.kt
@@ -1,0 +1,71 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpanInfoTest :
+  FunSpec({
+
+    test("durationMs should calculate correctly") {
+      val span = createSpan(
+        startTimeNanos = 1_000_000_000L,
+        endTimeNanos = 1_500_000_000L
+      )
+
+      span.durationMs shouldBe 500L
+    }
+
+    test("durationNanos should return correct value") {
+      val span = createSpan(
+        startTimeNanos = 1_000_000_000L,
+        endTimeNanos = 1_500_000_000L
+      )
+
+      span.durationNanos shouldBe 500_000_000L
+    }
+
+    test("isFailed should return true for ERROR status") {
+      val span = createSpan(status = SpanStatus.ERROR)
+
+      span.isFailed shouldBe true
+      span.isSuccess shouldBe false
+    }
+
+    test("isSuccess should return true for OK status") {
+      val span = createSpan(status = SpanStatus.OK)
+
+      span.isSuccess shouldBe true
+      span.isFailed shouldBe false
+    }
+
+    test("UNSET status should not be failed or success") {
+      val span = createSpan(status = SpanStatus.UNSET)
+
+      span.isFailed shouldBe false
+      span.isSuccess shouldBe false
+    }
+  })
+
+private fun createSpan(
+  traceId: String = "trace123",
+  spanId: String = "span123",
+  parentSpanId: String? = null,
+  operationName: String = "test.operation",
+  serviceName: String = "test-service",
+  startTimeNanos: Long = 1_000_000_000L,
+  endTimeNanos: Long = 1_100_000_000L,
+  status: SpanStatus = SpanStatus.OK,
+  attributes: Map<String, String> = emptyMap(),
+  exception: ExceptionInfo? = null
+) = SpanInfo(
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  operationName = operationName,
+  serviceName = serviceName,
+  startTimeNanos = startTimeNanos,
+  endTimeNanos = endTimeNanos,
+  status = status,
+  attributes = attributes,
+  exception = exception
+)

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/SpanTreeTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/SpanTreeTest.kt
@@ -1,0 +1,182 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class SpanTreeTest :
+  FunSpec({
+
+    test("build should return null for empty list") {
+      val tree = SpanTree.build(emptyList())
+
+      tree.shouldBeNull()
+    }
+
+    test("build should create single node for single span") {
+      val span = createSpan(spanId = "root", parentSpanId = null)
+
+      val tree = SpanTree.build(listOf(span))
+
+      tree.shouldNotBeNull()
+      tree.span.spanId shouldBe "root"
+      tree.children.shouldHaveSize(0)
+    }
+
+    test("build should create proper parent-child relationships") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null),
+        createSpan(spanId = "child1", parentSpanId = "root"),
+        createSpan(spanId = "child2", parentSpanId = "root"),
+        createSpan(spanId = "grandchild", parentSpanId = "child1")
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      tree.span.spanId shouldBe "root"
+      tree.children shouldHaveSize 2
+
+      val child1 = tree.children.find { it.span.spanId == "child1" }
+      child1.shouldNotBeNull()
+      child1.children shouldHaveSize 1
+      child1.children[0].span.spanId shouldBe "grandchild"
+    }
+
+    test("build should sort children by start time") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null, startTimeNanos = 1000),
+        createSpan(spanId = "child3", parentSpanId = "root", startTimeNanos = 3000),
+        createSpan(spanId = "child1", parentSpanId = "root", startTimeNanos = 1000),
+        createSpan(spanId = "child2", parentSpanId = "root", startTimeNanos = 2000)
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      tree.children[0].span.spanId shouldBe "child1"
+      tree.children[1].span.spanId shouldBe "child2"
+      tree.children[2].span.spanId shouldBe "child3"
+    }
+
+    test("SpanNode.hasFailedDescendants should detect failures in subtree") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null, status = SpanStatus.OK),
+        createSpan(spanId = "child", parentSpanId = "root", status = SpanStatus.OK),
+        createSpan(spanId = "grandchild", parentSpanId = "child", status = SpanStatus.ERROR)
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      tree.hasFailedDescendants shouldBe true
+      tree.span.isFailed shouldBe false
+    }
+
+    test("SpanNode.depth should calculate correct depth") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null),
+        createSpan(spanId = "child", parentSpanId = "root"),
+        createSpan(spanId = "grandchild", parentSpanId = "child")
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      tree.depth shouldBe 3
+    }
+
+    test("SpanNode.spanCount should count all nodes") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null),
+        createSpan(spanId = "child1", parentSpanId = "root"),
+        createSpan(spanId = "child2", parentSpanId = "root"),
+        createSpan(spanId = "grandchild", parentSpanId = "child1")
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      tree.spanCount shouldBe 4
+    }
+
+    test("SpanNode.findFailurePoint should find deepest failure") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null, status = SpanStatus.OK),
+        createSpan(spanId = "child", parentSpanId = "root", status = SpanStatus.ERROR),
+        createSpan(spanId = "grandchild", parentSpanId = "child", status = SpanStatus.ERROR)
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      val failurePoint = tree.findFailurePoint()
+      failurePoint.shouldNotBeNull()
+      failurePoint.span.spanId shouldBe "grandchild"
+    }
+
+    test("SpanNode.flatten should return all spans in order") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null),
+        createSpan(spanId = "child1", parentSpanId = "root"),
+        createSpan(spanId = "child2", parentSpanId = "root")
+      )
+
+      val tree = SpanTree.build(spans)
+
+      tree.shouldNotBeNull()
+      val flattened = tree.flatten()
+      flattened shouldHaveSize 3
+      flattened[0].spanId shouldBe "root"
+    }
+
+    test("findSpan should locate span by predicate") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null, operationName = "root.op"),
+        createSpan(spanId = "child", parentSpanId = "root", operationName = "child.op")
+      )
+
+      val tree = SpanTree.build(spans)!!
+
+      val found = SpanTree.findSpan(tree) { it.operationName == "child.op" }
+
+      found.shouldNotBeNull()
+      found.span.spanId shouldBe "child"
+    }
+
+    test("filterSpans should return all matching spans") {
+      val spans = listOf(
+        createSpan(spanId = "root", parentSpanId = null, status = SpanStatus.OK),
+        createSpan(spanId = "child1", parentSpanId = "root", status = SpanStatus.ERROR),
+        createSpan(spanId = "child2", parentSpanId = "root", status = SpanStatus.ERROR)
+      )
+
+      val tree = SpanTree.build(spans)!!
+
+      val failed = SpanTree.filterSpans(tree) { it.isFailed }
+
+      failed shouldHaveSize 2
+    }
+  })
+
+private fun createSpan(
+  traceId: String = "trace123",
+  spanId: String = "span123",
+  parentSpanId: String? = null,
+  operationName: String = "test.operation",
+  serviceName: String = "test-service",
+  startTimeNanos: Long = 1_000_000_000L,
+  endTimeNanos: Long = 1_100_000_000L,
+  status: SpanStatus = SpanStatus.OK
+) = SpanInfo(
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  operationName = operationName,
+  serviceName = serviceName,
+  startTimeNanos = startTimeNanos,
+  endTimeNanos = endTimeNanos,
+  status = status
+)

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/StoveTraceCollectorTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/StoveTraceCollectorTest.kt
@@ -1,0 +1,186 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class StoveTraceCollectorTest :
+  FunSpec({
+
+    test("registerTrace should create empty span list") {
+      val collector = StoveTraceCollector()
+
+      collector.registerTrace("trace-1", "test-1")
+
+      collector.getTrace("trace-1").shouldBeEmpty()
+      collector.getTestId("trace-1") shouldBe "test-1"
+    }
+
+    test("record should add span to the correct trace") {
+      val collector = StoveTraceCollector()
+      collector.registerTrace("trace-1", "test-1")
+      val span = createSpan(traceId = "trace-1", spanId = "span-1")
+
+      collector.record(span)
+
+      collector.getTrace("trace-1") shouldHaveSize 1
+      collector.getTrace("trace-1") shouldContain span
+    }
+
+    test("record should auto-create trace if not registered") {
+      val collector = StoveTraceCollector()
+      val span = createSpan(traceId = "trace-1", spanId = "span-1")
+
+      collector.record(span)
+
+      collector.getTrace("trace-1") shouldHaveSize 1
+    }
+
+    test("recordAll should add multiple spans") {
+      val collector = StoveTraceCollector()
+      val spans = listOf(
+        createSpan(traceId = "trace-1", spanId = "span-1"),
+        createSpan(traceId = "trace-1", spanId = "span-2"),
+        createSpan(traceId = "trace-1", spanId = "span-3")
+      )
+
+      collector.recordAll(spans)
+
+      collector.getTrace("trace-1") shouldHaveSize 3
+    }
+
+    test("getTraceTree should build span tree") {
+      val collector = StoveTraceCollector()
+      val rootSpan = createSpan(traceId = "trace-1", spanId = "root", parentSpanId = null)
+      val childSpan = createSpan(traceId = "trace-1", spanId = "child", parentSpanId = "root")
+
+      collector.record(rootSpan)
+      collector.record(childSpan)
+
+      val tree = collector.getTraceTree("trace-1")
+      tree.shouldNotBeNull()
+      tree.span.spanId shouldBe "root"
+      tree.children shouldHaveSize 1
+      tree.children[0].span.spanId shouldBe "child"
+    }
+
+    test("getTracesForTest should return all traces for a test") {
+      val collector = StoveTraceCollector()
+      collector.registerTrace("trace-1", "test-1")
+      collector.registerTrace("trace-2", "test-1")
+      collector.registerTrace("trace-3", "test-2")
+
+      val traces = collector.getTracesForTest("test-1")
+
+      traces shouldHaveSize 2
+      traces shouldContain "trace-1"
+      traces shouldContain "trace-2"
+    }
+
+    test("getFailedSpans should return only failed spans") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "trace-1", spanId = "ok-1", status = SpanStatus.OK))
+      collector.record(createSpan(traceId = "trace-1", spanId = "error-1", status = SpanStatus.ERROR))
+      collector.record(createSpan(traceId = "trace-1", spanId = "ok-2", status = SpanStatus.OK))
+
+      val failed = collector.getFailedSpans("trace-1")
+
+      failed shouldHaveSize 1
+      failed[0].spanId shouldBe "error-1"
+    }
+
+    test("hasFailures should detect failures") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "trace-1", spanId = "ok-1", status = SpanStatus.OK))
+
+      collector.hasFailures("trace-1") shouldBe false
+
+      collector.record(createSpan(traceId = "trace-1", spanId = "error-1", status = SpanStatus.ERROR))
+
+      collector.hasFailures("trace-1") shouldBe true
+    }
+
+    test("clear should remove trace data") {
+      val collector = StoveTraceCollector()
+      collector.registerTrace("trace-1", "test-1")
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-1"))
+
+      collector.clear("trace-1")
+
+      collector.getTrace("trace-1").shouldBeEmpty()
+      collector.getTestId("trace-1").shouldBeNull()
+    }
+
+    test("clearForTest should remove all traces for a test") {
+      val collector = StoveTraceCollector()
+      collector.registerTrace("trace-1", "test-1")
+      collector.registerTrace("trace-2", "test-1")
+      collector.registerTrace("trace-3", "test-2")
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-1"))
+      collector.record(createSpan(traceId = "trace-2", spanId = "span-2"))
+      collector.record(createSpan(traceId = "trace-3", spanId = "span-3"))
+
+      collector.clearForTest("test-1")
+
+      collector.getTrace("trace-1").shouldBeEmpty()
+      collector.getTrace("trace-2").shouldBeEmpty()
+      collector.getTrace("trace-3") shouldHaveSize 1
+    }
+
+    test("clearAll should remove all data") {
+      val collector = StoveTraceCollector()
+      collector.registerTrace("trace-1", "test-1")
+      collector.registerTrace("trace-2", "test-2")
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-1"))
+      collector.record(createSpan(traceId = "trace-2", spanId = "span-2"))
+
+      collector.clearAll()
+
+      collector.traceCount() shouldBe 0
+      collector.totalSpanCount() shouldBe 0
+    }
+
+    test("spanCount should return correct count for trace") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-1"))
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-2"))
+      collector.record(createSpan(traceId = "trace-2", spanId = "span-3"))
+
+      collector.spanCount("trace-1") shouldBe 2
+      collector.spanCount("trace-2") shouldBe 1
+      collector.spanCount("trace-3") shouldBe 0
+    }
+
+    test("totalSpanCount should return total across all traces") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-1"))
+      collector.record(createSpan(traceId = "trace-1", spanId = "span-2"))
+      collector.record(createSpan(traceId = "trace-2", spanId = "span-3"))
+
+      collector.totalSpanCount() shouldBe 3
+    }
+  })
+
+private fun createSpan(
+  traceId: String = "trace123",
+  spanId: String = "span123",
+  parentSpanId: String? = null,
+  operationName: String = "test.operation",
+  serviceName: String = "test-service",
+  startTimeNanos: Long = 1_000_000_000L,
+  endTimeNanos: Long = 1_100_000_000L,
+  status: SpanStatus = SpanStatus.OK
+) = SpanInfo(
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  operationName = operationName,
+  serviceName = serviceName,
+  startTimeNanos = startTimeNanos,
+  endTimeNanos = endTimeNanos,
+  status = status
+)

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TraceContextTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TraceContextTest.kt
@@ -1,0 +1,87 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
+
+class TraceContextTest :
+  FunSpec({
+
+    beforeTest {
+      TraceContext.clear()
+    }
+
+    afterTest {
+      TraceContext.clear()
+    }
+
+    test("start should create a new TraceContext with valid IDs") {
+      val ctx = TraceContext.start("test-1")
+
+      ctx.testId shouldBe "test-1"
+      ctx.traceId shouldHaveLength 32
+      ctx.rootSpanId shouldHaveLength 16
+      ctx.traceId shouldMatch Regex("[a-f0-9]{32}")
+      ctx.rootSpanId shouldMatch Regex("[a-f0-9]{16}")
+    }
+
+    test("current should return the active context") {
+      TraceContext.current().shouldBeNull()
+
+      val ctx = TraceContext.start("test-1")
+
+      TraceContext.current().shouldNotBeNull()
+      TraceContext.current() shouldBe ctx
+    }
+
+    test("clear should remove the current context") {
+      TraceContext.start("test-1")
+      TraceContext.current().shouldNotBeNull()
+
+      TraceContext.clear()
+
+      TraceContext.current().shouldBeNull()
+    }
+
+    test("toTraceparent should generate valid W3C traceparent header") {
+      val ctx = TraceContext.start("test-1")
+
+      val traceparent = ctx.toTraceparent()
+
+      traceparent shouldMatch Regex("00-[a-f0-9]{32}-[a-f0-9]{16}-01")
+      traceparent shouldBe "00-${ctx.traceId}-${ctx.rootSpanId}-01"
+    }
+
+    test("parseTraceparent should extract traceId and spanId") {
+      val traceparent = "00-abcd1234abcd1234abcd1234abcd1234-1234567890abcdef-01"
+
+      val result = TraceContext.parseTraceparent(traceparent)
+
+      result.shouldNotBeNull()
+      result.first shouldBe "abcd1234abcd1234abcd1234abcd1234"
+      result.second shouldBe "1234567890abcdef"
+    }
+
+    test("parseTraceparent should return null for invalid format") {
+      val invalidTraceparent = "invalid"
+
+      val result = TraceContext.parseTraceparent(invalidTraceparent)
+
+      result.shouldBeNull()
+    }
+
+    test("generateTraceId should produce unique IDs") {
+      val ids = (1..100).map { TraceContext.generateTraceId() }.toSet()
+
+      ids.size shouldBe 100
+    }
+
+    test("generateSpanId should produce unique IDs") {
+      val ids = (1..100).map { TraceContext.generateSpanId() }.toSet()
+
+      ids.size shouldBe 100
+    }
+  })

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TraceTreeRendererTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TraceTreeRendererTest.kt
@@ -1,0 +1,148 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+class TraceTreeRendererTest :
+  FunSpec({
+
+    test("render should show operation name and duration") {
+      val span = createSpan(
+        spanId = "root",
+        operationName = "OrderService.createOrder",
+        startTimeNanos = 0,
+        endTimeNanos = 100_000_000
+      )
+      val tree = SpanNode(span)
+
+      val output = TraceTreeRenderer.render(tree)
+
+      output shouldContain "OrderService.createOrder"
+      output shouldContain "[100ms]"
+    }
+
+    test("render should show checkmark for successful span") {
+      val span = createSpan(status = SpanStatus.OK)
+      val tree = SpanNode(span)
+
+      val output = TraceTreeRenderer.render(tree)
+
+      output shouldContain "✓"
+      output shouldNotContain "✗"
+    }
+
+    test("render should show X for failed span") {
+      val span = createSpan(status = SpanStatus.ERROR)
+      val tree = SpanNode(span)
+
+      val output = TraceTreeRenderer.render(tree)
+
+      output shouldContain "✗"
+    }
+
+    test("render should mark failure point") {
+      val span = createSpan(
+        status = SpanStatus.ERROR,
+        exception = ExceptionInfo("RuntimeException", "Something went wrong", listOf("at Test.kt:10"))
+      )
+      val tree = SpanNode(span)
+
+      val output = TraceTreeRenderer.render(tree)
+
+      output shouldContain "◄── FAILURE POINT"
+      output shouldContain "Error: RuntimeException: Something went wrong"
+    }
+
+    test("render should show relevant attributes") {
+      val span = createSpan(
+        attributes = mapOf(
+          "db.system" to "postgresql",
+          "db.statement" to "SELECT * FROM users",
+          "internal.flag" to "true"
+        )
+      )
+      val tree = SpanNode(span)
+
+      val output = TraceTreeRenderer.render(tree, includeAttributes = true)
+
+      output shouldContain "db.system: postgresql"
+      output shouldContain "db.statement: SELECT * FROM users"
+      output shouldNotContain "internal.flag"
+    }
+
+    test("render should show nested hierarchy") {
+      val grandchild = SpanNode(createSpan(spanId = "grandchild", operationName = "Repository.save"))
+      val child = SpanNode(createSpan(spanId = "child", operationName = "Service.process"), listOf(grandchild))
+      val root = SpanNode(createSpan(spanId = "root", operationName = "Controller.handle"), listOf(child))
+
+      val output = TraceTreeRenderer.render(root)
+
+      output shouldContain "Controller.handle"
+      output shouldContain "Service.process"
+      output shouldContain "Repository.save"
+    }
+
+    test("renderCompact should produce condensed output") {
+      val child = SpanNode(createSpan(operationName = "child.op", startTimeNanos = 0, endTimeNanos = 30_000_000))
+      val root =
+        SpanNode(createSpan(operationName = "root.op", startTimeNanos = 0, endTimeNanos = 50_000_000), listOf(child))
+
+      val output = TraceTreeRenderer.renderCompact(root)
+
+      output shouldContain "✓ root.op (50ms)"
+      output shouldContain "✓ child.op (30ms)"
+    }
+
+    test("renderSummary should show statistics") {
+      val failedChild = SpanNode(
+        createSpan(
+          spanId = "child",
+          startTimeNanos = 10_000_000,
+          endTimeNanos = 50_000_000,
+          status = SpanStatus.ERROR,
+          exception = ExceptionInfo("TestException", "Test error")
+        )
+      )
+      val root = SpanNode(
+        createSpan(
+          spanId = "root",
+          startTimeNanos = 0,
+          endTimeNanos = 100_000_000,
+          status = SpanStatus.OK
+        ),
+        listOf(failedChild)
+      )
+
+      val output = TraceTreeRenderer.renderSummary(root)
+
+      output shouldContain "Total spans: 2"
+      output shouldContain "Failed spans: 1"
+      output shouldContain "Total duration: 100ms"
+      output shouldContain "Max depth: 2"
+    }
+  })
+
+private fun createSpan(
+  traceId: String = "trace123",
+  spanId: String = "span123",
+  parentSpanId: String? = null,
+  operationName: String = "test.operation",
+  serviceName: String = "test-service",
+  startTimeNanos: Long = 1_000_000_000L,
+  endTimeNanos: Long = 1_100_000_000L,
+  status: SpanStatus = SpanStatus.OK,
+  attributes: Map<String, String> = emptyMap(),
+  exception: ExceptionInfo? = null
+) = SpanInfo(
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  operationName = operationName,
+  serviceName = serviceName,
+  startTimeNanos = startTimeNanos,
+  endTimeNanos = endTimeNanos,
+  status = status,
+  attributes = attributes,
+  exception = exception
+)

--- a/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TracingDslTest.kt
+++ b/lib/stove-tracing/src/test/kotlin/com/trendyol/stove/tracing/TracingDslTest.kt
@@ -1,0 +1,201 @@
+package com.trendyol.stove.tracing
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.time.Duration.Companion.milliseconds
+
+class TracingDslTest :
+  FunSpec({
+
+    test("shouldContainSpan should pass when span exists") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", operationName = "OrderService.create"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.shouldContainSpan("OrderService")
+      dsl.shouldContainSpan("create")
+    }
+
+    test("shouldContainSpan should fail when span not found") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", operationName = "OrderService.create"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      val exception = shouldThrow<IllegalArgumentException> {
+        dsl.shouldContainSpan("PaymentService")
+      }
+      exception.message shouldContain "Expected span containing 'PaymentService'"
+    }
+
+    test("shouldNotContainSpan should pass when span absent") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", operationName = "OrderService.create"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.shouldNotContainSpan("PaymentService")
+    }
+
+    test("shouldNotHaveFailedSpans should pass when no failures") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", status = SpanStatus.OK))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.shouldNotHaveFailedSpans()
+    }
+
+    test("shouldNotHaveFailedSpans should fail when failures exist") {
+      val collector = StoveTraceCollector()
+      collector.record(
+        createSpan(
+          traceId = "t1",
+          operationName = "failed.op",
+          status = SpanStatus.ERROR,
+          exception = ExceptionInfo("TestException", "test error")
+        )
+      )
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      val exception = shouldThrow<IllegalArgumentException> {
+        dsl.shouldNotHaveFailedSpans()
+      }
+      exception.message shouldContain "Expected no failed spans"
+    }
+
+    test("shouldHaveFailedSpan should pass when matching failure exists") {
+      val collector = StoveTraceCollector()
+      collector.record(
+        createSpan(
+          traceId = "t1",
+          operationName = "PaymentService.charge",
+          status = SpanStatus.ERROR
+        )
+      )
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.shouldHaveFailedSpan("PaymentService")
+    }
+
+    test("executionTimeShouldBeLessThan should validate duration") {
+      val collector = StoveTraceCollector()
+      collector.record(
+        createSpan(
+          traceId = "t1",
+          startTimeNanos = 0,
+          endTimeNanos = 50_000_000 // 50ms
+        )
+      )
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.executionTimeShouldBeLessThan(100.milliseconds)
+
+      shouldThrow<IllegalArgumentException> {
+        dsl.executionTimeShouldBeLessThan(10.milliseconds)
+      }
+    }
+
+    test("spanCountShouldBe should validate exact count") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", spanId = "s1"))
+      collector.record(createSpan(traceId = "t1", spanId = "s2"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.spanCountShouldBe(2)
+    }
+
+    test("shouldHaveSpanWithAttribute should find attribute") {
+      val collector = StoveTraceCollector()
+      collector.record(
+        createSpan(
+          traceId = "t1",
+          attributes = mapOf("db.system" to "postgresql")
+        )
+      )
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      dsl.shouldHaveSpanWithAttribute("db.system", "postgresql")
+    }
+
+    test("findSpanByName should locate span") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", operationName = "OrderService.create"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      val found = dsl.findSpanByName("OrderService")
+      found.shouldNotBeNull()
+      found.operationName shouldBe "OrderService.create"
+    }
+
+    test("spanTree should return span tree") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", spanId = "root", parentSpanId = null))
+      collector.record(createSpan(traceId = "t1", spanId = "child", parentSpanId = "root"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      val tree = dsl.spanTree()
+      tree.shouldNotBeNull()
+      tree.spanCount shouldBe 2
+    }
+
+    test("renderTree should produce output") {
+      val collector = StoveTraceCollector()
+      collector.record(createSpan(traceId = "t1", spanId = "root", operationName = "root.op"))
+
+      val dsl = TraceValidationDsl(collector, "t1")
+
+      val rendered = dsl.renderTree()
+      rendered shouldContain "root.op"
+    }
+
+    test("tracing DSL should configure options") {
+      val options = TracingOptions().apply {
+        enabled()
+        maxSpansPerTrace(500)
+        serviceName("my-app")
+        enableSpanReceiver(port = 4318)
+      }
+
+      options.enabled shouldBe true
+      options.maxSpansPerTrace shouldBe 500
+      options.serviceName shouldBe "my-app"
+      options.spanReceiverEnabled shouldBe true
+      options.spanReceiverPort shouldBe 4318
+    }
+  })
+
+private fun createSpan(
+  traceId: String = "trace123",
+  spanId: String = "span123",
+  parentSpanId: String? = null,
+  operationName: String = "test.operation",
+  serviceName: String = "test-service",
+  startTimeNanos: Long = 1_000_000_000L,
+  endTimeNanos: Long = 1_100_000_000L,
+  status: SpanStatus = SpanStatus.OK,
+  attributes: Map<String, String> = emptyMap(),
+  exception: ExceptionInfo? = null
+) = SpanInfo(
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  operationName = operationName,
+  serviceName = serviceName,
+  startTimeNanos = startTimeNanos,
+  endTimeNanos = endTimeNanos,
+  status = status,
+  attributes = attributes,
+  exception = exception
+)

--- a/lib/stove-wiremock/build.gradle.kts
+++ b/lib/stove-wiremock/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.wiremock.standalone)
   api(libs.caffeine)
 }

--- a/lib/stove/api/stove.api
+++ b/lib/stove/api/stove.api
@@ -406,11 +406,13 @@ public final class com/trendyol/stove/reporting/PrettyConsoleRenderer : com/tren
 
 public final class com/trendyol/stove/reporting/ReportEntry {
 	public static final field Companion Lcom/trendyol/stove/reporting/ReportEntry$Companion;
-	public fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)V
-	public synthetic fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)V
+	public synthetic fun <init> (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/time/Instant;
 	public final fun component10 ()Larrow/core/Option;
 	public final fun component11 ()Larrow/core/Option;
+	public final fun component12 ()Larrow/core/Option;
+	public final fun component13 ()Larrow/core/Option;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -419,13 +421,15 @@ public final class com/trendyol/stove/reporting/ReportEntry {
 	public final fun component7 ()Larrow/core/Option;
 	public final fun component8 ()Ljava/util/Map;
 	public final fun component9 ()Larrow/core/Option;
-	public final fun copy (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)Lcom/trendyol/stove/reporting/ReportEntry;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/reporting/ReportEntry;Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILjava/lang/Object;)Lcom/trendyol/stove/reporting/ReportEntry;
+	public final fun copy (Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)Lcom/trendyol/stove/reporting/ReportEntry;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/reporting/ReportEntry;Ljava/time/Instant;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/trendyol/stove/reporting/AssertionResult;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILjava/lang/Object;)Lcom/trendyol/stove/reporting/ReportEntry;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ljava/lang/String;
 	public final fun getActual ()Larrow/core/Option;
 	public final fun getError ()Larrow/core/Option;
+	public final fun getExecutionTrace ()Larrow/core/Option;
 	public final fun getExpected ()Larrow/core/Option;
+	public final fun getHasTrace ()Z
 	public final fun getInput ()Larrow/core/Option;
 	public final fun getMetadata ()Ljava/util/Map;
 	public final fun getOutput ()Larrow/core/Option;
@@ -434,6 +438,7 @@ public final class com/trendyol/stove/reporting/ReportEntry {
 	public final fun getSystem ()Ljava/lang/String;
 	public final fun getTestId ()Ljava/lang/String;
 	public final fun getTimestamp ()Ljava/time/Instant;
+	public final fun getTraceId ()Larrow/core/Option;
 	public fun hashCode ()I
 	public final fun isFailed ()Z
 	public final fun isPassed ()Z
@@ -441,8 +446,8 @@ public final class com/trendyol/stove/reporting/ReportEntry {
 }
 
 public final class com/trendyol/stove/reporting/ReportEntry$Companion {
-	public final fun action (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)Lcom/trendyol/stove/reporting/ReportEntry;
-	public static synthetic fun action$default (Lcom/trendyol/stove/reporting/ReportEntry$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILjava/lang/Object;)Lcom/trendyol/stove/reporting/ReportEntry;
+	public final fun action (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;)Lcom/trendyol/stove/reporting/ReportEntry;
+	public static synthetic fun action$default (Lcom/trendyol/stove/reporting/ReportEntry$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;Larrow/core/Option;ILjava/lang/Object;)Lcom/trendyol/stove/reporting/ReportEntry;
 	public final fun failure (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;)Lcom/trendyol/stove/reporting/ReportEntry;
 	public static synthetic fun failure$default (Lcom/trendyol/stove/reporting/ReportEntry$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;ILjava/lang/Object;)Lcom/trendyol/stove/reporting/ReportEntry;
 	public final fun success (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;)Lcom/trendyol/stove/reporting/ReportEntry;
@@ -568,6 +573,15 @@ public final class com/trendyol/stove/reporting/TestReportKt {
 	public static final fun forSystem (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
 	public static final fun forTest (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
 	public static final fun passed (Ljava/util/List;)Ljava/util/List;
+}
+
+public abstract interface class com/trendyol/stove/reporting/TraceProvider {
+	public abstract fun getTraceVisualizationForCurrentTest (J)Larrow/core/Option;
+	public static synthetic fun getTraceVisualizationForCurrentTest$default (Lcom/trendyol/stove/reporting/TraceProvider;JILjava/lang/Object;)Larrow/core/Option;
+}
+
+public final class com/trendyol/stove/reporting/TraceProvider$DefaultImpls {
+	public static synthetic fun getTraceVisualizationForCurrentTest$default (Lcom/trendyol/stove/reporting/TraceProvider;JILjava/lang/Object;)Larrow/core/Option;
 }
 
 public final class com/trendyol/stove/serialization/E2eObjectMapperConfig {
@@ -786,6 +800,7 @@ public final class com/trendyol/stove/system/Stove : com/trendyol/stove/system/a
 
 public final class com/trendyol/stove/system/Stove$Companion {
 	public final fun getSystem (Lkotlin/reflect/KClass;)Lcom/trendyol/stove/system/abstractions/PluggedSystem;
+	public final fun getSystemOrNone (Lkotlin/reflect/KClass;)Larrow/core/Option;
 	public final fun instanceInitialized ()Z
 	public final fun options ()Lcom/trendyol/stove/system/StoveOptions;
 	public final fun reporter ()Lcom/trendyol/stove/reporting/StoveReporter;
@@ -1010,5 +1025,157 @@ public abstract interface class com/trendyol/stove/system/abstractions/Validated
 }
 
 public abstract interface annotation class com/trendyol/stove/system/annotations/StoveDsl : java/lang/annotation/Annotation {
+}
+
+public final class com/trendyol/stove/tracing/ExceptionInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/trendyol/stove/tracing/ExceptionInfo;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/ExceptionInfo;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/ExceptionInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStackTrace ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/SpanInfo {
+	public static final field Companion Lcom/trendyol/stove/tracing/SpanInfo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLcom/trendyol/stove/tracing/SpanStatus;Ljava/util/Map;Lcom/trendyol/stove/tracing/ExceptionInfo;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLcom/trendyol/stove/tracing/SpanStatus;Ljava/util/Map;Lcom/trendyol/stove/tracing/ExceptionInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/trendyol/stove/tracing/ExceptionInfo;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()Lcom/trendyol/stove/tracing/SpanStatus;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLcom/trendyol/stove/tracing/SpanStatus;Ljava/util/Map;Lcom/trendyol/stove/tracing/ExceptionInfo;)Lcom/trendyol/stove/tracing/SpanInfo;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/SpanInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLcom/trendyol/stove/tracing/SpanStatus;Ljava/util/Map;Lcom/trendyol/stove/tracing/ExceptionInfo;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/SpanInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/Map;
+	public final fun getDurationMs ()J
+	public final fun getDurationNanos ()J
+	public final fun getEndTimeNanos ()J
+	public final fun getException ()Lcom/trendyol/stove/tracing/ExceptionInfo;
+	public final fun getOperationName ()Ljava/lang/String;
+	public final fun getParentSpanId ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getSpanId ()Ljava/lang/String;
+	public final fun getStartTimeNanos ()J
+	public final fun getStatus ()Lcom/trendyol/stove/tracing/SpanStatus;
+	public final fun getTraceId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isFailed ()Z
+	public final fun isSuccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/SpanInfo$Companion {
+}
+
+public final class com/trendyol/stove/tracing/SpanNode {
+	public fun <init> (Lcom/trendyol/stove/tracing/SpanInfo;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/tracing/SpanInfo;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/trendyol/stove/tracing/SpanInfo;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lcom/trendyol/stove/tracing/SpanInfo;Ljava/util/List;)Lcom/trendyol/stove/tracing/SpanNode;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/SpanNode;Lcom/trendyol/stove/tracing/SpanInfo;Ljava/util/List;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/SpanNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun findFailurePoint ()Lcom/trendyol/stove/tracing/SpanNode;
+	public final fun flatten ()Ljava/util/List;
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getDepth ()I
+	public final fun getHasFailedDescendants ()Z
+	public final fun getSpan ()Lcom/trendyol/stove/tracing/SpanInfo;
+	public final fun getSpanCount ()I
+	public final fun getTotalDurationMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/SpanStatus : java/lang/Enum {
+	public static final field ERROR Lcom/trendyol/stove/tracing/SpanStatus;
+	public static final field OK Lcom/trendyol/stove/tracing/SpanStatus;
+	public static final field UNSET Lcom/trendyol/stove/tracing/SpanStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/trendyol/stove/tracing/SpanStatus;
+	public static fun values ()[Lcom/trendyol/stove/tracing/SpanStatus;
+}
+
+public final class com/trendyol/stove/tracing/SpanTree {
+	public static final field INSTANCE Lcom/trendyol/stove/tracing/SpanTree;
+	public final fun build (Ljava/util/List;)Lcom/trendyol/stove/tracing/SpanNode;
+	public final fun filterSpans (Lcom/trendyol/stove/tracing/SpanNode;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public final fun findSpan (Lcom/trendyol/stove/tracing/SpanNode;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/tracing/SpanNode;
+}
+
+public final class com/trendyol/stove/tracing/TraceTreeRenderer {
+	public static final field INSTANCE Lcom/trendyol/stove/tracing/TraceTreeRenderer;
+	public final fun render (Lcom/trendyol/stove/tracing/SpanNode;ZLjava/util/List;)Ljava/lang/String;
+	public static synthetic fun render$default (Lcom/trendyol/stove/tracing/TraceTreeRenderer;Lcom/trendyol/stove/tracing/SpanNode;ZLjava/util/List;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun renderCompact (Lcom/trendyol/stove/tracing/SpanNode;)Ljava/lang/String;
+	public final fun renderSummary (Lcom/trendyol/stove/tracing/SpanNode;)Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/TraceVisualization {
+	public static final field Companion Lcom/trendyol/stove/tracing/TraceVisualization$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IILjava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IILjava/util/List;Ljava/lang/String;)Lcom/trendyol/stove/tracing/TraceVisualization;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/TraceVisualization;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/TraceVisualization;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFailedSpans ()I
+	public final fun getSpans ()Ljava/util/List;
+	public final fun getTestId ()Ljava/lang/String;
+	public final fun getTotalSpans ()I
+	public final fun getTraceId ()Ljava/lang/String;
+	public final fun getTree ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/TraceVisualization$Companion {
+	public final fun from (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/trendyol/stove/tracing/TraceVisualization;
+}
+
+public final class com/trendyol/stove/tracing/VisualSpan {
+	public static final field Companion Lcom/trendyol/stove/tracing/VisualSpan$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DLjava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()D
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DLjava/lang/String;Ljava/util/Map;)Lcom/trendyol/stove/tracing/VisualSpan;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/tracing/VisualSpan;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DLjava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/trendyol/stove/tracing/VisualSpan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/Map;
+	public final fun getDurationMs ()D
+	public final fun getOperationName ()Ljava/lang/String;
+	public final fun getParentSpanId ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getSpanId ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/tracing/VisualSpan$Companion {
+	public final fun from (Lcom/trendyol/stove/tracing/SpanInfo;)Lcom/trendyol/stove/tracing/VisualSpan;
 }
 

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/reporting/ReportEntry.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/reporting/ReportEntry.kt
@@ -3,6 +3,7 @@ package com.trendyol.stove.reporting
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import com.trendyol.stove.tracing.TraceVisualization
 import java.time.Instant
 
 /**
@@ -25,11 +26,14 @@ data class ReportEntry(
   val metadata: Map<String, Any> = emptyMap(),
   val expected: Option<Any> = None,
   val actual: Option<Any> = None,
-  val error: Option<String> = None
+  val error: Option<String> = None,
+  val traceId: Option<String> = None,
+  val executionTrace: Option<TraceVisualization> = None
 ) {
   val summary: String get() = "[$system] $action"
   val isFailed: Boolean get() = result == AssertionResult.FAILED
   val isPassed: Boolean get() = result == AssertionResult.PASSED
+  val hasTrace: Boolean get() = traceId.isSome()
 
   companion object {
     private fun now(): Instant = Instant.now()
@@ -68,7 +72,9 @@ data class ReportEntry(
       metadata: Map<String, Any> = emptyMap(),
       expected: Option<Any> = None,
       actual: Option<Any> = None,
-      error: Option<String> = None
+      error: Option<String> = None,
+      traceId: Option<String> = None,
+      executionTrace: Option<TraceVisualization> = None
     ): ReportEntry = ReportEntry(
       timestamp = now(),
       system = system,
@@ -80,7 +86,9 @@ data class ReportEntry(
       metadata = metadata,
       expected = expected,
       actual = actual,
-      error = error
+      error = error,
+      traceId = traceId,
+      executionTrace = executionTrace
     )
 
     /**

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/reporting/TraceProvider.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/reporting/TraceProvider.kt
@@ -1,0 +1,18 @@
+package com.trendyol.stove.reporting
+
+import arrow.core.Option
+import com.trendyol.stove.tracing.TraceVisualization
+
+/**
+ * Interface for systems that can provide execution trace information.
+ * Implemented by the tracing system to avoid circular dependencies.
+ */
+interface TraceProvider {
+  /**
+   * Gets trace visualization for the current test context.
+   * Returns None if no traces are available.
+   *
+   * @param waitTimeMs How long to wait for spans to be exported (default 300ms)
+   */
+  fun getTraceVisualizationForCurrentTest(waitTimeMs: Long = 300): Option<TraceVisualization>
+}

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/Stove.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/Stove.kt
@@ -122,6 +122,24 @@ class Stove(
       return instance.getSystemOrThrow(kClass) as T
     }
 
+    /**
+     * Returns the system of the given type as an Option.
+     * Returns None if Stove is not initialized or the system is not registered.
+     */
+    inline fun <reified T : PluggedSystem> getSystemOrNone(): Option<T> =
+      getSystemOrNone(T::class)
+
+    /**
+     * Returns the system of the given type as an Option.
+     * Returns None if Stove is not initialized or the system is not registered.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @PublishedApi
+    internal fun <T : PluggedSystem> getSystemOrNone(kClass: KClass<T>): Option<T> {
+      if (!::instance.isInitialized) return None
+      return instance.activeSystems.getOrNone(kClass).map { it as T }
+    }
+
     fun stop(): Unit = instance.close()
   }
 

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/SpanInfo.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/SpanInfo.kt
@@ -1,0 +1,51 @@
+package com.trendyol.stove.tracing
+
+/**
+ * Information about a single span in a trace.
+ */
+data class SpanInfo(
+  val traceId: String,
+  val spanId: String,
+  val parentSpanId: String?,
+  val operationName: String,
+  val serviceName: String,
+  val startTimeNanos: Long,
+  val endTimeNanos: Long,
+  val status: SpanStatus,
+  val attributes: Map<String, String> = emptyMap(),
+  val exception: ExceptionInfo? = null
+) {
+  val durationMs: Long
+    get() = (endTimeNanos - startTimeNanos) / NANOS_TO_MILLIS
+
+  val durationNanos: Long
+    get() = endTimeNanos - startTimeNanos
+
+  val isFailed: Boolean
+    get() = status == SpanStatus.ERROR
+
+  val isSuccess: Boolean
+    get() = status == SpanStatus.OK
+
+  companion object {
+    internal const val NANOS_TO_MILLIS = 1_000_000L
+  }
+}
+
+/**
+ * Exception information captured in a span.
+ */
+data class ExceptionInfo(
+  val type: String,
+  val message: String,
+  val stackTrace: List<String> = emptyList()
+)
+
+/**
+ * Status of a span.
+ */
+enum class SpanStatus {
+  OK,
+  ERROR,
+  UNSET
+}

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/SpanTree.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/SpanTree.kt
@@ -1,0 +1,93 @@
+package com.trendyol.stove.tracing
+
+/**
+ * Represents a node in the span tree.
+ * This is an immutable data structure - children cannot be modified after construction.
+ */
+data class SpanNode(
+  val span: SpanInfo,
+  val children: List<SpanNode> = emptyList()
+) {
+  val hasFailedDescendants: Boolean
+    get() = span.isFailed || children.any { it.hasFailedDescendants }
+
+  val totalDurationMs: Long
+    get() = span.durationMs
+
+  val depth: Int
+    get() = 1 + (children.maxOfOrNull { it.depth } ?: 0)
+
+  val spanCount: Int
+    get() = 1 + children.sumOf { it.spanCount }
+
+  fun findFailurePoint(): SpanNode? {
+    if (span.isFailed && children.none { it.hasFailedDescendants }) {
+      return this
+    }
+    return children.firstNotNullOfOrNull { it.findFailurePoint() }
+  }
+
+  fun flatten(): List<SpanInfo> = listOf(span) + children.flatMap { it.flatten() }
+}
+
+/**
+ * Utility object for building and querying span trees.
+ */
+object SpanTree {
+  fun build(spans: List<SpanInfo>): SpanNode? {
+    if (spans.isEmpty()) return null
+
+    val spanMap = spans.associateBy { it.spanId }
+    val childrenMap = mutableMapOf<String?, MutableList<SpanInfo>>()
+
+    // Group spans by their parent ID
+    for (span in spans) {
+      val effectiveParentId = if (span.parentSpanId != null && spanMap.containsKey(span.parentSpanId)) {
+        span.parentSpanId
+      } else {
+        null
+      }
+      childrenMap.getOrPut(effectiveParentId) { mutableListOf() }.add(span)
+    }
+
+    // Recursively build nodes bottom-up (immutably)
+    fun buildNode(spanInfo: SpanInfo): SpanNode {
+      val childSpans = childrenMap[spanInfo.spanId] ?: emptyList()
+      val sortedChildren = childSpans
+        .sortedBy { it.startTimeNanos }
+        .map { buildNode(it) }
+      return SpanNode(spanInfo, sortedChildren)
+    }
+
+    val roots = childrenMap[null] ?: return null
+    if (roots.isEmpty()) return null
+
+    val sortedRoots = roots.sortedBy { it.startTimeNanos }
+
+    return if (sortedRoots.size == 1) {
+      buildNode(sortedRoots.first())
+    } else {
+      // Create a virtual root containing multiple roots
+      val rootNodes = sortedRoots.map { buildNode(it) }
+      SpanNode(
+        span = sortedRoots.first().copy(
+          operationName = "trace-root",
+          parentSpanId = null
+        ),
+        children = rootNodes
+      )
+    }
+  }
+
+  fun findSpan(root: SpanNode, predicate: (SpanInfo) -> Boolean): SpanNode? {
+    if (predicate(root.span)) return root
+    return root.children.firstNotNullOfOrNull { findSpan(it, predicate) }
+  }
+
+  fun filterSpans(root: SpanNode, predicate: (SpanInfo) -> Boolean): List<SpanNode> {
+    val result = mutableListOf<SpanNode>()
+    if (predicate(root.span)) result.add(root)
+    root.children.forEach { result.addAll(filterSpans(it, predicate)) }
+    return result
+  }
+}

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/TraceTreeRenderer.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/TraceTreeRenderer.kt
@@ -1,0 +1,132 @@
+package com.trendyol.stove.tracing
+
+/**
+ * Renders span trees as human-readable text.
+ */
+object TraceTreeRenderer {
+  private const val INDENT = "│  "
+  private const val BRANCH = "├─ "
+  private const val LAST_BRANCH = "└─ "
+  private const val SPACE = "   "
+  private const val MAX_STACK_TRACE_LINES = 3
+
+  fun render(
+    root: SpanNode,
+    includeAttributes: Boolean = true,
+    attributePrefixes: List<String> = listOf("db.", "http.", "rpc.", "messaging.")
+  ): String {
+    val sb = StringBuilder()
+    renderNode(sb, root, "", true, includeAttributes, attributePrefixes)
+    return sb.toString()
+  }
+
+  private fun renderNode(
+    sb: StringBuilder,
+    node: SpanNode,
+    prefix: String,
+    isLast: Boolean,
+    includeAttributes: Boolean,
+    attributePrefixes: List<String>
+  ) {
+    val connector = when {
+      prefix.isEmpty() -> ""
+      isLast -> LAST_BRANCH
+      else -> BRANCH
+    }
+
+    val status = if (node.span.isFailed) "✗" else "✓"
+    val failureMarker = if (node.span.isFailed && node.children.none { it.hasFailedDescendants }) {
+      " ◄── FAILURE POINT"
+    } else {
+      ""
+    }
+
+    sb.appendLine("$prefix$connector${node.span.operationName} [${node.span.durationMs}ms] $status$failureMarker")
+
+    val childPrefix = prefix + when {
+      prefix.isEmpty() -> ""
+      isLast -> SPACE
+      else -> INDENT
+    }
+
+    if (node.span.exception != null && node.span.isFailed) {
+      renderException(sb, childPrefix, node.span.exception)
+    }
+
+    if (includeAttributes) {
+      renderRelevantAttributes(sb, childPrefix, node.span.attributes, attributePrefixes)
+    }
+
+    node.children.forEachIndexed { index, child ->
+      val isChildLast = index == node.children.lastIndex
+      renderNode(sb, child, childPrefix, isChildLast, includeAttributes, attributePrefixes)
+    }
+  }
+
+  private fun renderException(sb: StringBuilder, prefix: String, exception: ExceptionInfo) {
+    sb.appendLine("$prefix${INDENT}Error: ${exception.type}: ${exception.message}")
+    exception.stackTrace
+      .take(MAX_STACK_TRACE_LINES)
+      .forEach { line ->
+        sb.appendLine("$prefix$INDENT  $line")
+      }
+  }
+
+  private fun renderRelevantAttributes(
+    sb: StringBuilder,
+    prefix: String,
+    attributes: Map<String, String>,
+    attributePrefixes: List<String>
+  ) {
+    val relevantAttrs = attributes.filter { (key, _) ->
+      attributePrefixes.any { key.startsWith(it) }
+    }
+    relevantAttrs.forEach { (key, value) ->
+      sb.appendLine("$prefix${INDENT}$key: $value")
+    }
+  }
+
+  fun renderCompact(root: SpanNode): String {
+    val sb = StringBuilder()
+    renderCompactNode(sb, root, 0)
+    return sb.toString()
+  }
+
+  private fun renderCompactNode(
+    sb: StringBuilder,
+    node: SpanNode,
+    depth: Int
+  ) {
+    val indent = "  ".repeat(depth)
+    val status = if (node.span.isFailed) "✗" else "✓"
+    sb.appendLine("$indent$status ${node.span.operationName} (${node.span.durationMs}ms)")
+    node.children.forEach { child ->
+      renderCompactNode(sb, child, depth + 1)
+    }
+  }
+
+  fun renderSummary(root: SpanNode): String {
+    val totalSpans = root.spanCount
+    val failedSpans = root.flatten().count { it.isFailed }
+    val totalDuration = root.span.durationMs
+    val maxDepth = root.depth
+
+    return buildString {
+      appendLine("Trace Summary:")
+      appendLine("  Total spans: $totalSpans")
+      appendLine("  Failed spans: $failedSpans")
+      appendLine("  Total duration: ${totalDuration}ms")
+      appendLine("  Max depth: $maxDepth")
+
+      if (failedSpans > 0) {
+        val failurePoint = root.findFailurePoint()
+        if (failurePoint != null) {
+          appendLine("  Failure point: ${failurePoint.span.operationName}")
+          failurePoint.span.exception?.let { ex ->
+            appendLine("  Error: ${ex.type}: ${ex.message}")
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/TraceVisualization.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/tracing/TraceVisualization.kt
@@ -1,0 +1,74 @@
+package com.trendyol.stove.tracing
+
+/**
+ * Data structure for trace visualization in reports.
+ * Designed to be serializable and easy to render in different formats.
+ */
+data class TraceVisualization(
+  val traceId: String,
+  val testId: String,
+  val totalSpans: Int,
+  val failedSpans: Int,
+  val spans: List<VisualSpan>,
+  val tree: String
+) {
+  companion object {
+    fun from(traceId: String, testId: String, spans: List<SpanInfo>): TraceVisualization {
+      val visualSpans = spans.map { VisualSpan.from(it) }
+      val tree = buildTraceTree(spans)
+      return TraceVisualization(
+        traceId = traceId,
+        testId = testId,
+        totalSpans = spans.size,
+        failedSpans = spans.count { it.status == SpanStatus.ERROR },
+        spans = visualSpans,
+        tree = tree
+      )
+    }
+
+    /**
+     * Build a tree visualization of spans using SpanTree and TraceTreeRenderer.
+     * Consolidates tree-building logic in a single place.
+     */
+    private fun buildTraceTree(spans: List<SpanInfo>): String {
+      if (spans.isEmpty()) return "No spans in trace"
+
+      val root = SpanTree.build(spans) ?: return "No spans in trace"
+      return TraceTreeRenderer.render(root)
+    }
+  }
+}
+
+/**
+ * Simplified span representation for visualization
+ */
+data class VisualSpan(
+  val spanId: String,
+  val parentSpanId: String?,
+  val operationName: String,
+  val serviceName: String,
+  val durationMs: Double,
+  val status: String,
+  val attributes: Map<String, String>
+) {
+  companion object {
+    private const val NANOS_TO_MILLIS = 1_000_000L
+
+    fun from(span: SpanInfo): VisualSpan = VisualSpan(
+      spanId = span.spanId,
+      parentSpanId = span.parentSpanId,
+      operationName = span.operationName,
+      serviceName = span.serviceName,
+      durationMs = calculateDurationMs(span),
+      status = span.status.name,
+      attributes = span.attributes
+    )
+
+    private fun calculateDurationMs(span: SpanInfo): Double =
+      if (span.endTimeNanos > 0) {
+        (span.endTimeNanos - span.startTimeNanos).toDouble() / NANOS_TO_MILLIS
+      } else {
+        0.0
+      }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ rootProject.name = "stove"
 include(
   "lib:stove-bom",
   "lib:stove",
+  "lib:stove-tracing",
   "lib:stove-wiremock",
   "lib:stove-grpc-mock",
   "lib:stove-http",

--- a/test-extensions/stove-extensions-junit/build.gradle.kts
+++ b/test-extensions/stove-extensions-junit/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.junit.jupiter.api)
 }
 

--- a/test-extensions/stove-extensions-kotest/build.gradle.kts
+++ b/test-extensions/stove-extensions-kotest/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api(projects.lib.stove)
+  api(projects.lib.stoveTracing)
   api(libs.kotest.framework.engine)
 }
 


### PR DESCRIPTION
## Summary

  This PR introduces **distributed tracing** for Stove, enabling automatic capture and visualization of execution traces during end-to-end tests. When a test fails, you can see exactly what happened inside your application - HTTP calls, database queries, Kafka messages, gRPC calls - all correlated back to the test.

  ## What is Distributed Tracing in Stove?

  Stove's tracing system captures the internal execution flow of your application under test using OpenTelemetry. This provides visibility into:

  - **What code paths were executed** during the test
  - **Where failures occurred** in the call chain
  - **Exception details** including type, message, and stacktrace
  - **Timing information** for performance analysis

  ### How It Works

  1. **Automatic trace context propagation**: Stove injects W3C `traceparent` headers into HTTP requests, Kafka messages, and gRPC calls
  2. **Span collection**: An OTLP gRPC receiver collects spans exported by the OpenTelemetry Java Agent running in your application
  3. **Trace correlation**: All spans are correlated back to the originating test
  4. **Failure reporting**: When a test fails, the execution trace is included in the failure report

  ### Example Failure Report
```
  EXECUTION TRACE (Call Chain)
  ═══════════════════════════════════════════════════════════════
  POST [1093ms] ✗
  │  http.request.method: POST
  │  http.response.status_code: 400
  POST /products/{id} [972ms] ✗ ◄── FAILURE POINT
  │  Error: java.lang.RuntimeException: Something went wrong
  │    java.lang.RuntimeException: Something went wrong
  │    at com.example.ProductService.update(ProductService.kt:55)
  │    at com.example.ProductService$update$1.invokeSuspend(ProductService.kt)
  │  http.route: /products/{id}
  │  http.response.status_code: 400
```

## Setup

### 1. Enable tracing in Stove configuration

```kotlin
  Stove(...)
      .with {
          tracing {
              serviceName("my-service")
              enableSpanReceiver(port = 4317)
          }
      }
```

### 2. Configure OpenTelemetry Java Agent

 Copy StoveTracingConfiguration.kt to your project's buildSrc/src/main/kotlin/ and use it:

```kotlin
  import com.trendyol.stove.gradle.configureStoveTracing

  configureStoveTracing {
      serviceName = "my-service"
  }
```

  This automatically:
  - Downloads the OpenTelemetry Java Agent
  - Configures JVM arguments for test tasks
  - Exports spans to Stove's collector

### 3. Record exceptions in catch blocks (optional)

For exceptions that are caught and handled, record them manually:

```kotlin
  catch (ex: Exception) {
      Span.current().apply {
          recordException(ex)
          setStatus(StatusCode.ERROR, ex.message)
      }
      // handle the exception...
  }
```

ℹ️ Note: If you have already OTEL integrated, it will work out-of-the-box with your current instrumentation.

  Changes in This PR

  - OTLPSpanReceiver: Extract exception details from span events
  - TraceVisualization: Use full render with exception info
  - TraceReportBuilder: Shared logic for Kotest/JUnit extensions
  - StoveTracingConfiguration.kt: Copy-paste configuration for downstream users
  - Documentation: Updated docs/Components/14-tracing.md
  - Stove API: Added getSystemOrNone<T>() for functional lookups