### PR TITLE
feat: Stove version alignment across CLI, BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Stove()
   }.run()
 ```
 
+Keep `stove-cli`, the Stove BOM, and your Stove test dependencies on the same Stove version. The dashboard warns on version mismatches, but aligning versions avoids missing or inconsistent dashboard data.
+
 See [Dashboard docs](https://trendyol.github.io/stove/Components/18-dashboard/) and
 [0.23.0 release notes](https://trendyol.github.io/stove/release-notes/0.23.0/) for full details.
 

--- a/buildSrc/src/main/kotlin/GenerateDashboardVersionSourceTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateDashboardVersionSourceTask.kt
@@ -1,0 +1,32 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateDashboardVersionSourceTask : DefaultTask() {
+  @get:Input
+  abstract val stoveCompatibilityVersion: Property<String>
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @TaskAction
+  fun generate() {
+    val outputFile = outputDir
+      .file("com/trendyol/stove/dashboard/StoveCompatibilityVersion.kt")
+      .get()
+      .asFile
+    outputFile.parentFile.mkdirs()
+    outputFile.writeText(
+      """
+      package com.trendyol.stove.dashboard
+
+      internal object StoveCompatibilityVersion {
+        const val VALUE: String = "${stoveCompatibilityVersion.get()}"
+      }
+      """.trimIndent()
+    )
+  }
+}

--- a/docs/Components/18-dashboard.md
+++ b/docs/Components/18-dashboard.md
@@ -49,6 +49,9 @@ Unlike [Reporting](13-reporting.md) (console output on failure) and [Tracing](15
 
 The CLI is a single binary with no runtime dependencies. It embeds the web UI, so there's nothing else to install.
 
+!!! info "Keep Versions Aligned"
+    Keep `stove-cli`, the Stove BOM, and your Stove test dependencies on the same Stove version. The dashboard shows a warning when the runtime libraries and CLI drift apart, but matching versions avoids inconsistent dashboard data.
+
 ## Quick Start
 
 **1. Start the dashboard**
@@ -106,6 +109,8 @@ Stove()
 ```
 
 Navigate to [http://localhost:4040](http://localhost:4040). The UI updates in real time as tests execute.
+
+If the dashboard shows a version mismatch warning, align your Stove BOM and test dependencies with the `stove-cli` version, or upgrade `stove-cli` to the runtime version reported by the selected app.
 
 ## What Gets Captured
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,9 @@ dependencies {
 !!! info "Latest Version"
     Check the [Releases](https://github.com/Trendyol/stove/releases) page for the latest version.
 
+!!! tip "Version Alignment"
+    Keep the Stove BOM and all Stove test dependencies on the same version. If you use the dashboard, keep `stove-cli` on that same version too.
+
 Replace `stove-spring` with the starter that matches your runtime:
 
 - Spring Boot: `stove-spring`

--- a/lib/stove-dashboard-api/src/main/proto/stove/dashboard/v1/dashboard_events.proto
+++ b/lib/stove-dashboard-api/src/main/proto/stove/dashboard/v1/dashboard_events.proto
@@ -23,6 +23,7 @@ message RunStartedEvent {
   google.protobuf.Timestamp timestamp = 1;
   string app_name = 2;
   repeated string systems = 3;
+  string stove_version = 4;
 }
 
 message RunEndedEvent {

--- a/lib/stove-dashboard/build.gradle.kts
+++ b/lib/stove-dashboard/build.gradle.kts
@@ -1,3 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+val generatedDashboardSourcesDir =
+  layout.buildDirectory.dir("generated/source/stoveVersion/kotlin")
+val stoveCompatibilityVersionValue = providers
+  .fileContents(rootProject.layout.projectDirectory.file("gradle.properties"))
+  .asText
+  .map { gradleProperties ->
+    gradleProperties
+      .lineSequence()
+      .first { it.startsWith("version=") }
+      .substringAfter("version=")
+      .trim()
+  }
+
+val generateDashboardVersionSource by tasks.registering(GenerateDashboardVersionSourceTask::class) {
+  stoveCompatibilityVersion.set(stoveCompatibilityVersionValue)
+  outputDir.set(generatedDashboardSourcesDir)
+}
+
+extensions.configure<KotlinJvmProjectExtension> {
+  sourceSets.getByName("main").kotlin.srcDir(generatedDashboardSourcesDir)
+}
+
+tasks.named("compileKotlin") {
+  dependsOn(generateDashboardVersionSource)
+}
+
 dependencies {
   api(projects.lib.stove)
   api(projects.lib.stoveDashboardApi)

--- a/lib/stove-dashboard/build.gradle.kts
+++ b/lib/stove-dashboard/build.gradle.kts
@@ -26,6 +26,10 @@ tasks.named("compileKotlin") {
   dependsOn(generateDashboardVersionSource)
 }
 
+tasks.named("sourcesJar") {
+  dependsOn(generateDashboardVersionSource)
+}
+
 dependencies {
   api(projects.lib.stove)
   api(projects.lib.stoveDashboardApi)

--- a/lib/stove-dashboard/src/main/kotlin/com/trendyol/stove/dashboard/DashboardSystem.kt
+++ b/lib/stove-dashboard/src/main/kotlin/com/trendyol/stove/dashboard/DashboardSystem.kt
@@ -68,6 +68,11 @@ class DashboardSystem(
           .setTimestamp(now())
           .setAppName(options.appName)
           .addAllSystems(stove.activeSystems.values.filterIsInstance<Reports>().map { it.reportSystemName })
+          .apply {
+            StoveCompatibilityVersion.VALUE
+              .takeIf(String::isNotBlank)
+              ?.let(::setStoveVersion)
+          }
           .build()
       }
     )

--- a/lib/stove-dashboard/src/test/kotlin/com/trendyol/stove/dashboard/DashboardSystemTest.kt
+++ b/lib/stove-dashboard/src/test/kotlin/com/trendyol/stove/dashboard/DashboardSystemTest.kt
@@ -61,6 +61,7 @@ class DashboardSystemTest : FunSpec({
       }
       types.contains("RunStarted") shouldBe true
       received.first { it.hasRunStarted() }.runStarted.appName shouldBe "test-api"
+      received.first { it.hasRunStarted() }.runStarted.stoveVersion shouldBe StoveCompatibilityVersion.VALUE
       types.contains("TestStarted") shouldBe true
       types.contains("EntryRecorded") shouldBe true
     } finally {

--- a/tools/stove-cli/spa/src/App.tsx
+++ b/tools/stove-cli/spa/src/App.tsx
@@ -1,18 +1,31 @@
+import { VersionMismatchBanner } from "./components/VersionMismatchBanner";
 import { useAppData } from "./hooks/useAppData";
 import { Header } from "./layout/Header";
 import { Sidebar } from "./layout/Sidebar";
 import { TestDetail } from "./layout/TestDetail";
 
 export default function App() {
-  const { apps, activeApp, latestRun, tests, selectedTest, liveConnected, selectApp, selectTest } =
-    useAppData();
+  const {
+    apps,
+    activeApp,
+    latestRun,
+    tests,
+    selectedTest,
+    liveConnected,
+    mismatchedApps,
+    versionMismatchSummary,
+    selectApp,
+    selectTest,
+  } = useAppData();
 
   return (
     <div className="flex flex-col h-screen bg-stove-base text-[var(--stove-text)] font-sans">
       <Header />
+      {versionMismatchSummary ? <VersionMismatchBanner summary={versionMismatchSummary} /> : null}
       <div className="flex flex-1 overflow-hidden">
         <Sidebar
           apps={apps}
+          mismatchedApps={mismatchedApps}
           selectedApp={activeApp}
           onSelectApp={selectApp}
           run={latestRun}

--- a/tools/stove-cli/spa/src/api/client.ts
+++ b/tools/stove-cli/spa/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { AppSummary, Entry, Run, Snapshot, Span, Test } from "./types";
+import type { AppSummary, Entry, MetaResponse, Run, Snapshot, Span, Test } from "./types";
 
 const BASE = "/api/v1";
 const encodePath = (value: string) => encodeURIComponent(value);
@@ -15,6 +15,7 @@ async function del(url: string): Promise<void> {
 }
 
 export const api = {
+  getMeta: () => get<MetaResponse>("/meta"),
   getApps: () => get<AppSummary[]>("/apps"),
   getRuns: (app?: string) => get<Run[]>(app ? `/runs?app=${encodeURIComponent(app)}` : "/runs"),
   getRun: (runId: string) => get<Run | null>(`/runs/${encodePath(runId)}`),

--- a/tools/stove-cli/spa/src/api/live-cache.ts
+++ b/tools/stove-cli/spa/src/api/live-cache.ts
@@ -14,6 +14,7 @@ export function applyLiveDashboardEvent(queryClient: QueryClient, event: LiveDas
         passed: 0,
         failed: 0,
         duration_ms: null,
+        stove_version: event.payload.stove_version,
         systems: event.payload.systems,
       };
 
@@ -22,6 +23,7 @@ export function applyLiveDashboardEvent(queryClient: QueryClient, event: LiveDas
           app_name: event.payload.app_name,
           latest_run_id: event.run_id,
           latest_status: "RUNNING",
+          stove_version: event.payload.stove_version,
           total_runs: nextRunCount(apps, event.payload.app_name, event.run_id),
         }),
       );

--- a/tools/stove-cli/spa/src/api/types.ts
+++ b/tools/stove-cli/spa/src/api/types.ts
@@ -2,7 +2,12 @@ export interface AppSummary {
   app_name: string;
   latest_run_id: string;
   latest_status: string;
+  stove_version: string | null;
   total_runs: number;
+}
+
+export interface MetaResponse {
+  stove_cli_version: string;
 }
 
 export type LiveRecordId = number | string;
@@ -17,6 +22,7 @@ export interface Run {
   passed: number;
   failed: number;
   duration_ms: number | null;
+  stove_version: string | null;
   systems: string[];
 }
 
@@ -78,6 +84,7 @@ export interface Snapshot {
 export interface LiveRunStartedPayload {
   app_name: string;
   started_at: string;
+  stove_version: string | null;
   systems: string[];
 }
 

--- a/tools/stove-cli/spa/src/components/VersionMismatchBanner.tsx
+++ b/tools/stove-cli/spa/src/components/VersionMismatchBanner.tsx
@@ -1,0 +1,55 @@
+import {
+  buildVersionMismatchBannerModel,
+  type VersionMismatchSummary,
+} from "../utils/version-mismatch";
+
+interface VersionMismatchBannerProps {
+  summary: VersionMismatchSummary;
+}
+
+export function VersionMismatchBanner({ summary }: VersionMismatchBannerProps) {
+  const model = buildVersionMismatchBannerModel(summary);
+  const affectedApps = model.affectedApps.join(", ");
+
+  return (
+    <section className="border-b border-amber-500/30 bg-amber-100 text-amber-950 px-4 py-3">
+      <div className="flex items-start gap-3">
+        <span className="text-lg leading-none" aria-hidden="true">
+          !
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">{model.title}</p>
+          <p className="mt-1 text-xs leading-5">
+            Affected apps: <span className="font-medium">{affectedApps}</span>.
+            {model.switchHint ? ` ${model.switchHint}` : null}
+          </p>
+
+          {model.selectedAppName ? (
+            <div className="mt-3 rounded-md border border-amber-500/40 bg-white/60 px-3 py-3 text-xs leading-5">
+              <p className="font-semibold">
+                Selected app: <span className="font-mono">{model.selectedAppName}</span>
+              </p>
+              <p className="mt-1">
+                Runtime version:{" "}
+                <span className="font-mono">{model.runtimeVersion ?? "not reported"}</span>
+                {" · "}
+                CLI version: <span className="font-mono">{model.cliVersion}</span>
+              </p>
+              <div className="mt-2 space-y-1">
+                {model.remediationSteps.map((step) => (
+                  <p key={step.value}>
+                    {step.kind === "command" ? (
+                      <code className="font-mono break-all">{step.value}</code>
+                    ) : (
+                      step.value
+                    )}
+                  </p>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/tools/stove-cli/spa/src/hooks/useAppData.ts
+++ b/tools/stove-cli/spa/src/hooks/useAppData.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { applyLiveDashboardEvent, invalidateDashboardQueries } from "../api/live-cache";
 import { useSSE } from "../api/sse";
+import { summarizeVersionMismatches } from "../utils/version-mismatch";
 
 export function useAppData() {
   const queryClient = useQueryClient();
@@ -22,7 +23,14 @@ export function useAppData() {
     staleTime: liveConnected ? Number.POSITIVE_INFINITY : 0,
   });
 
+  const { data: meta } = useQuery({
+    queryKey: ["meta"],
+    queryFn: api.getMeta,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
   const activeApp = selectedApp ?? apps[0]?.app_name ?? null;
+  const cliVersion = meta?.stove_cli_version ?? null;
 
   const { data: runs = [] } = useQuery({
     queryKey: ["runs", activeApp],
@@ -56,14 +64,19 @@ export function useAppData() {
   }, [selectedTestId, tests]);
 
   const selectedTest = tests.find((test) => test.id === selectedTestId) ?? tests[0] ?? null;
+  const versionMismatchSummary = summarizeVersionMismatches(apps, cliVersion, activeApp);
+  const mismatchedApps = versionMismatchSummary?.affectedAppNames ?? [];
 
   return {
     apps,
     activeApp,
+    cliVersion,
     latestRun,
     tests,
     selectedTest,
     liveConnected,
+    mismatchedApps,
+    versionMismatchSummary,
     selectApp: (name: string) => {
       setSelectedApp(name);
       setSelectedTestId(null);

--- a/tools/stove-cli/spa/src/layout/Sidebar.tsx
+++ b/tools/stove-cli/spa/src/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import { TestListItem } from "./sidebar/TestListItem";
 
 interface SidebarProps {
   apps: AppSummary[];
+  mismatchedApps: string[];
   selectedApp: string | null;
   onSelectApp: (name: string) => void;
   run: Run | null;
@@ -20,6 +21,7 @@ interface SidebarProps {
 
 export function Sidebar({
   apps,
+  mismatchedApps,
   selectedApp,
   onSelectApp,
   run,
@@ -52,7 +54,12 @@ export function Sidebar({
 
   return (
     <aside className="w-80 shrink-0 border-r border-stove-border bg-stove-surface flex flex-col overflow-hidden">
-      <AppPicker apps={apps} selectedApp={selectedApp} onSelectApp={onSelectApp} />
+      <AppPicker
+        apps={apps}
+        mismatchedApps={mismatchedApps}
+        selectedApp={selectedApp}
+        onSelectApp={onSelectApp}
+      />
       {run && <RunSummary run={run} tests={tests} />}
       <TestFilters
         filter={filter}

--- a/tools/stove-cli/spa/src/layout/sidebar/AppPicker.tsx
+++ b/tools/stove-cli/spa/src/layout/sidebar/AppPicker.tsx
@@ -2,11 +2,14 @@ import type { AppSummary } from "../../api/types";
 
 interface AppPickerProps {
   apps: AppSummary[];
+  mismatchedApps: string[];
   selectedApp: string | null;
   onSelectApp: (name: string) => void;
 }
 
-export function AppPicker({ apps, selectedApp, onSelectApp }: AppPickerProps) {
+export function AppPicker({ apps, mismatchedApps, selectedApp, onSelectApp }: AppPickerProps) {
+  const mismatchedAppSet = new Set(mismatchedApps);
+
   return (
     <div className="p-3 border-b border-stove-border">
       <select
@@ -16,7 +19,9 @@ export function AppPicker({ apps, selectedApp, onSelectApp }: AppPickerProps) {
       >
         {apps.map((app) => (
           <option key={app.app_name} value={app.app_name}>
-            {app.app_name} ({app.total_runs} runs)
+            {app.app_name}
+            {mismatchedAppSet.has(app.app_name) ? " [mismatch]" : ""}
+            {` (${app.total_runs} runs)`}
           </option>
         ))}
       </select>

--- a/tools/stove-cli/spa/src/utils/version-mismatch.ts
+++ b/tools/stove-cli/spa/src/utils/version-mismatch.ts
@@ -1,0 +1,181 @@
+import type { AppSummary } from "../api/types";
+
+const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+const SWITCH_HINT = "Switch to a mismatched app to see exact remediation.";
+const CLI_UPGRADE_COMMAND = "brew upgrade Trendyol/trendyol-tap/stove";
+
+export type VersionMismatchKind = "runtime_older" | "cli_older" | "unknown";
+
+export interface VersionMismatch {
+  appName: string;
+  cliVersion: string;
+  runtimeVersion: string | null;
+  kind: VersionMismatchKind;
+}
+
+export interface VersionMismatchSummary {
+  cliVersion: string;
+  mismatches: VersionMismatch[];
+  affectedAppNames: string[];
+  selectedAppMismatch: VersionMismatch | null;
+}
+
+export interface VersionMismatchRemediationStep {
+  kind: "text" | "command";
+  value: string;
+}
+
+export interface VersionMismatchBannerModel {
+  title: string;
+  affectedApps: string[];
+  switchHint: string | null;
+  selectedAppName: string | null;
+  runtimeVersion: string | null;
+  cliVersion: string;
+  remediationSteps: VersionMismatchRemediationStep[];
+}
+
+export function compareVersions(
+  runtimeVersion: string | null | undefined,
+  cliVersion: string,
+): VersionMismatchKind | null {
+  const normalizedRuntime = normalizeVersion(runtimeVersion);
+  if (normalizedRuntime === cliVersion) {
+    return null;
+  }
+
+  if (!normalizedRuntime) {
+    return "unknown";
+  }
+
+  const runtimeTriplet = parseReleaseVersion(normalizedRuntime);
+  const cliTriplet = parseReleaseVersion(cliVersion);
+  if (!runtimeTriplet || !cliTriplet) {
+    return "unknown";
+  }
+
+  for (let index = 0; index < runtimeTriplet.length; index += 1) {
+    if (runtimeTriplet[index] < cliTriplet[index]) {
+      return "runtime_older";
+    }
+    if (runtimeTriplet[index] > cliTriplet[index]) {
+      return "cli_older";
+    }
+  }
+
+  return "unknown";
+}
+
+export function summarizeVersionMismatches(
+  apps: AppSummary[],
+  cliVersion: string | null,
+  selectedApp: string | null,
+): VersionMismatchSummary | null {
+  if (!cliVersion) {
+    return null;
+  }
+
+  const mismatches = apps
+    .map((app) => createVersionMismatch(app, cliVersion))
+    .filter((mismatch): mismatch is VersionMismatch => mismatch !== null);
+
+  if (mismatches.length === 0) {
+    return null;
+  }
+
+  const affectedAppNames = mismatches.map((mismatch) => mismatch.appName);
+
+  return {
+    cliVersion,
+    mismatches,
+    affectedAppNames,
+    selectedAppMismatch: mismatches.find((mismatch) => mismatch.appName === selectedApp) ?? null,
+  };
+}
+
+export function buildVersionMismatchBannerModel(
+  summary: VersionMismatchSummary,
+): VersionMismatchBannerModel {
+  const mismatchCount = summary.mismatches.length;
+  const selectedAppMismatch = summary.selectedAppMismatch;
+
+  return {
+    title: bannerTitle(mismatchCount),
+    affectedApps: summary.affectedAppNames,
+    switchHint: selectedAppMismatch ? null : SWITCH_HINT,
+    selectedAppName: selectedAppMismatch?.appName ?? null,
+    runtimeVersion: selectedAppMismatch?.runtimeVersion ?? null,
+    cliVersion: summary.cliVersion,
+    remediationSteps: selectedAppMismatch ? remediationStepsForMismatch(selectedAppMismatch) : [],
+  };
+}
+
+function createVersionMismatch(app: AppSummary, cliVersion: string): VersionMismatch | null {
+  const kind = compareVersions(app.stove_version, cliVersion);
+  if (!kind) {
+    return null;
+  }
+
+  return {
+    appName: app.app_name,
+    cliVersion,
+    runtimeVersion: normalizeVersion(app.stove_version),
+    kind,
+  };
+}
+
+function bannerTitle(mismatchCount: number): string {
+  return mismatchCount === 1
+    ? "A version mismatch was detected in the latest Stove dashboard run."
+    : `${mismatchCount} apps have a version mismatch in their latest Stove dashboard runs.`;
+}
+
+function normalizeVersion(version: string | null | undefined): string | null {
+  const normalized = version?.trim();
+  return normalized ? normalized : null;
+}
+
+function parseReleaseVersion(version: string): number[] | null {
+  const match = version.match(RELEASE_VERSION_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return match.slice(1).map(Number);
+}
+
+function remediationStepsForMismatch(mismatch: VersionMismatch): VersionMismatchRemediationStep[] {
+  if (mismatch.kind === "runtime_older") {
+    return [textStep(dependencyAlignmentMessage(mismatch.cliVersion))];
+  }
+
+  if (mismatch.kind === "cli_older") {
+    return [
+      textStep("Update stove-cli to match the runtime version:"),
+      commandStep(CLI_UPGRADE_COMMAND),
+      commandStep(installScriptCommand(mismatch.runtimeVersion!)),
+    ];
+  }
+
+  return [
+    textStep(
+      `This run comes from an older or non-standard Stove runtime. ${dependencyAlignmentMessage(mismatch.cliVersion)}`,
+    ),
+  ];
+}
+
+function dependencyAlignmentMessage(cliVersion: string): string {
+  return `Align the Stove BOM or all Stove test dependencies to ${cliVersion}.`;
+}
+
+function installScriptCommand(runtimeVersion: string): string {
+  return `curl -fsSL https://raw.githubusercontent.com/Trendyol/stove/main/tools/stove-cli/install.sh | sh -s -- --version ${runtimeVersion}`;
+}
+
+function textStep(value: string): VersionMismatchRemediationStep {
+  return { kind: "text", value };
+}
+
+function commandStep(value: string): VersionMismatchRemediationStep {
+  return { kind: "command", value };
+}

--- a/tools/stove-cli/spa/test/live-cache.test.mjs
+++ b/tools/stove-cli/spa/test/live-cache.test.mjs
@@ -16,6 +16,7 @@ test("applyLiveDashboardEvent updates run, test, and detail caches from live SSE
     payload: {
       app_name: "live-app",
       started_at: "2024-06-01T10:00:00Z",
+      stove_version: "0.23.2",
       systems: ["HTTP"],
     },
   });
@@ -97,9 +98,11 @@ test("applyLiveDashboardEvent updates run, test, and detail caches from live SSE
 
   assert.equal(apps.length, 1);
   assert.equal(apps[0].latest_run_id, "run-live");
+  assert.equal(apps[0].stove_version, "0.23.2");
 
   assert.equal(runs.length, 1);
   assert.equal(runs[0].status, "RUNNING");
+  assert.equal(runs[0].stove_version, "0.23.2");
 
   assert.equal(tests.length, 1);
   assert.equal(tests[0].status, "PASSED");

--- a/tools/stove-cli/spa/test/version-mismatch.test.mjs
+++ b/tools/stove-cli/spa/test/version-mismatch.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import createJiti from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+  buildVersionMismatchBannerModel,
+  compareVersions,
+  summarizeVersionMismatches,
+} = await jiti.import(
+  "../src/utils/version-mismatch.ts",
+);
+
+test("compareVersions detects exact matches, directional mismatches, and unknown cases", () => {
+  assert.equal(compareVersions("0.23.2", "0.23.2"), null);
+  assert.equal(compareVersions("0.23.0", "0.23.2"), "runtime_older");
+  assert.equal(compareVersions("0.23.3", "0.23.2"), "cli_older");
+  assert.equal(compareVersions(null, "0.23.2"), "unknown");
+  assert.equal(compareVersions("0.23.2-SNAPSHOT", "0.23.2"), "unknown");
+});
+
+test("summarizeVersionMismatches returns null when every latest app matches the CLI", () => {
+  const summary = summarizeVersionMismatches(
+    [
+      {
+        app_name: "alpha-api",
+        latest_run_id: "run-1",
+        latest_status: "PASSED",
+        stove_version: "0.23.2",
+        total_runs: 1,
+      },
+    ],
+    "0.23.2",
+    "alpha-api",
+  );
+
+  assert.equal(summary, null);
+});
+
+test("summarizeVersionMismatches captures selected-app mismatch and all affected apps", () => {
+  const summary = summarizeVersionMismatches(
+    [
+      {
+        app_name: "alpha-api",
+        latest_run_id: "run-1",
+        latest_status: "PASSED",
+        stove_version: "0.23.0",
+        total_runs: 1,
+      },
+      {
+        app_name: "beta-api",
+        latest_run_id: "run-2",
+        latest_status: "FAILED",
+        stove_version: "0.23.5",
+        total_runs: 1,
+      },
+    ],
+    "0.23.2",
+    "alpha-api",
+  );
+
+  assert.equal(summary.cliVersion, "0.23.2");
+  assert.equal(summary.mismatches.length, 2);
+  assert.deepEqual(summary.affectedAppNames, ["alpha-api", "beta-api"]);
+  assert.equal(summary.selectedAppMismatch.appName, "alpha-api");
+  assert.equal(summary.selectedAppMismatch.kind, "runtime_older");
+});
+
+test("buildVersionMismatchBannerModel returns dependency alignment guidance for older runtimes", () => {
+  const model = buildVersionMismatchBannerModel({
+    cliVersion: "0.23.2",
+    mismatches: [
+      {
+        appName: "alpha-api",
+        cliVersion: "0.23.2",
+        runtimeVersion: "0.23.0",
+        kind: "runtime_older",
+      },
+    ],
+    affectedAppNames: ["alpha-api"],
+    selectedAppMismatch: {
+      appName: "alpha-api",
+      cliVersion: "0.23.2",
+      runtimeVersion: "0.23.0",
+      kind: "runtime_older",
+    },
+  });
+
+  assert.equal(model.selectedAppName, "alpha-api");
+  assert.deepEqual(model.remediationSteps, [
+    {
+      kind: "text",
+      value: "Align the Stove BOM or all Stove test dependencies to 0.23.2.",
+    },
+  ]);
+});
+
+test("buildVersionMismatchBannerModel returns CLI upgrade commands when the runtime is newer", () => {
+  const model = buildVersionMismatchBannerModel({
+    cliVersion: "0.23.2",
+    mismatches: [
+      {
+        appName: "beta-api",
+        cliVersion: "0.23.2",
+        runtimeVersion: "0.23.5",
+        kind: "cli_older",
+      },
+    ],
+    affectedAppNames: ["beta-api"],
+    selectedAppMismatch: {
+      appName: "beta-api",
+      cliVersion: "0.23.2",
+      runtimeVersion: "0.23.5",
+      kind: "cli_older",
+    },
+  });
+
+  assert.equal(model.remediationSteps[0].kind, "text");
+  assert.equal(model.remediationSteps[1].kind, "command");
+  assert.equal(model.remediationSteps[1].value, "brew upgrade Trendyol/trendyol-tap/stove");
+  assert.equal(
+    model.remediationSteps[2].value,
+    "curl -fsSL https://raw.githubusercontent.com/Trendyol/stove/main/tools/stove-cli/install.sh | sh -s -- --version 0.23.5",
+  );
+});
+
+test("buildVersionMismatchBannerModel stays summary-only when another app mismatches", () => {
+  const model = buildVersionMismatchBannerModel({
+    cliVersion: "0.23.2",
+    mismatches: [
+      {
+        appName: "alpha-api",
+        cliVersion: "0.23.2",
+        runtimeVersion: "0.23.0",
+        kind: "runtime_older",
+      },
+      {
+        appName: "beta-api",
+        cliVersion: "0.23.2",
+        runtimeVersion: "0.23.5",
+        kind: "cli_older",
+      },
+    ],
+    affectedAppNames: ["alpha-api", "beta-api"],
+    selectedAppMismatch: null,
+  });
+
+  assert.deepEqual(model.affectedApps, ["alpha-api", "beta-api"]);
+  assert.equal(model.switchHint, "Switch to a mismatched app to see exact remediation.");
+  assert.deepEqual(model.remediationSteps, []);
+});
+
+test("buildVersionMismatchBannerModel returns legacy guidance for missing runtime versions", () => {
+  const model = buildVersionMismatchBannerModel({
+    cliVersion: "0.23.2",
+    mismatches: [
+      {
+        appName: "legacy-api",
+        cliVersion: "0.23.2",
+        runtimeVersion: null,
+        kind: "unknown",
+      },
+    ],
+    affectedAppNames: ["legacy-api"],
+    selectedAppMismatch: {
+      appName: "legacy-api",
+      cliVersion: "0.23.2",
+      runtimeVersion: null,
+      kind: "unknown",
+    },
+  });
+
+  assert.equal(model.runtimeVersion, null);
+  assert.equal(model.remediationSteps[0].kind, "text");
+  assert.match(model.remediationSteps[0].value, /older or non-standard Stove runtime/);
+});

--- a/tools/stove-cli/src/grpc/service.rs
+++ b/tools/stove-cli/src/grpc/service.rs
@@ -135,6 +135,7 @@ impl DashboardEventServiceImpl {
         LiveDashboardPayload::RunStarted(LiveRunStartedPayload {
           app_name: event.app_name.clone(),
           started_at: started_at.clone(),
+          stove_version: non_empty(&event.stove_version),
           systems: event.systems.clone(),
         }),
       ),
@@ -142,6 +143,7 @@ impl DashboardEventServiceImpl {
         run_id: run_id.to_string(),
         app_name: event.app_name.clone(),
         started_at,
+        stove_version: non_empty(&event.stove_version),
         systems: event.systems.clone(),
       },
       flush_immediately: false,
@@ -582,6 +584,7 @@ mod tests {
             timestamp: ts(1_704_067_200),
             app_name: "my-api".to_string(),
             systems: vec!["HTTP".to_string()],
+            stove_version: "0.23.1".to_string(),
           },
         )),
       })
@@ -613,6 +616,7 @@ mod tests {
           }),
           app_name: "product-api".to_string(),
           systems: vec!["HTTP".to_string(), "Kafka".to_string()],
+          stove_version: "0.23.2".to_string(),
         },
       )),
     };
@@ -623,6 +627,7 @@ mod tests {
     let runs = svc.repository.get_runs(None).unwrap();
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].app_name, "product-api");
+    assert_eq!(runs[0].stove_version.as_deref(), Some("0.23.2"));
   }
 
   #[tokio::test]
@@ -639,6 +644,7 @@ mod tests {
               nanos: 0,
             }),
             app_name: "test-app".to_string(),
+            stove_version: String::new(),
             systems: vec![],
           },
         )),

--- a/tools/stove-cli/src/http/routes/meta.rs
+++ b/tools/stove-cli/src/http/routes/meta.rs
@@ -1,0 +1,15 @@
+use axum::Json;
+use serde::Serialize;
+
+use crate::STOVE_CLI_VERSION;
+
+#[derive(Serialize)]
+pub struct MetaResponse {
+  pub stove_cli_version: &'static str,
+}
+
+pub async fn get_meta() -> Json<MetaResponse> {
+  Json(MetaResponse {
+    stove_cli_version: STOVE_CLI_VERSION,
+  })
+}

--- a/tools/stove-cli/src/http/routes/mod.rs
+++ b/tools/stove-cli/src/http/routes/mod.rs
@@ -1,9 +1,11 @@
+mod meta;
 mod runs;
 mod sse;
 mod static_files;
 mod tests;
 mod traces;
 
+pub use meta::*;
 pub use runs::*;
 pub use sse::*;
 pub use static_files::*;

--- a/tools/stove-cli/src/http/server.rs
+++ b/tools/stove-cli/src/http/server.rs
@@ -22,6 +22,7 @@ pub fn create_router(repository: Arc<Repository>, sse_manager: Arc<SseManager>) 
   };
 
   let api = Router::new()
+    .route("/meta", get(super::routes::get_meta))
     .route("/apps", get(super::routes::get_apps))
     .route("/runs", get(super::routes::get_runs))
     .route("/runs/{run_id}", get(super::routes::get_run))

--- a/tools/stove-cli/src/ingest.rs
+++ b/tools/stove-cli/src/ingest.rs
@@ -18,6 +18,7 @@ pub enum PersistedDashboardEvent {
     run_id: String,
     app_name: String,
     started_at: String,
+    stove_version: Option<String>,
     systems: Vec<String>,
   },
   RunEnded {
@@ -96,6 +97,7 @@ pub enum LiveDashboardPayload {
 pub struct LiveRunStartedPayload {
   pub app_name: String,
   pub started_at: String,
+  pub stove_version: Option<String>,
   pub systems: Vec<String>,
 }
 

--- a/tools/stove-cli/src/lib.rs
+++ b/tools/stove-cli/src/lib.rs
@@ -6,6 +6,8 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::redundant_closure_for_method_calls)]
 
+pub const STOVE_CLI_VERSION: &str = env!("STOVE_VERSION");
+
 pub mod config;
 pub mod error;
 pub mod grpc;

--- a/tools/stove-cli/src/storage/database.rs
+++ b/tools/stove-cli/src/storage/database.rs
@@ -6,10 +6,16 @@ use tracing::info;
 /// Versioned SQL migrations, embedded at compile time.
 /// Add new migrations by creating `V{N}__description.sql` in `src/storage/migrations/`.
 /// Once deployed, never modify an existing migration — append a new one instead.
-const MIGRATIONS: &[(&str, &str)] = &[(
-  "V1__initial_schema",
-  include_str!("migrations/V1__initial_schema.sql"),
-)];
+const MIGRATIONS: &[(&str, &str)] = &[
+  (
+    "V1__initial_schema",
+    include_str!("migrations/V1__initial_schema.sql"),
+  ),
+  (
+    "V2__run_stove_version",
+    include_str!("migrations/V2__run_stove_version.sql"),
+  ),
+];
 
 /// `SQLite` database wrapper with WAL mode and versioned schema migrations.
 pub struct Database {
@@ -141,6 +147,7 @@ static IN_MEMORY_DB_COUNTER: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
 mod tests {
   use super::*;
+  use tempfile::TempDir;
 
   #[test]
   fn open_in_memory_succeeds_and_creates_tables() {
@@ -175,6 +182,50 @@ mod tests {
         row.get(0)
       })
       .unwrap();
-    assert_eq!(version, 1);
+    assert_eq!(version, MIGRATIONS.len() as i64);
+  }
+
+  #[test]
+  fn open_upgrades_v1_database_with_run_stove_version_column() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("stove-v1.db");
+    let conn = Connection::open(&path).unwrap();
+
+    conn.execute_batch(MIGRATIONS[0].1).unwrap();
+    conn
+      .execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );",
+      )
+      .unwrap();
+    conn
+      .execute(
+        "INSERT INTO schema_migrations (version, name) VALUES (?1, ?2)",
+        rusqlite::params![1_i64, "V1__initial_schema"],
+      )
+      .unwrap();
+    drop(conn);
+
+    let db = Database::open(path.to_str().unwrap()).unwrap();
+    let stove_version_columns: i64 = db
+      .conn()
+      .query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('runs') WHERE name = 'stove_version'",
+        [],
+        |row| row.get(0),
+      )
+      .unwrap();
+    let schema_version: i64 = db
+      .conn()
+      .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
+        row.get(0)
+      })
+      .unwrap();
+
+    assert_eq!(stove_version_columns, 1);
+    assert_eq!(schema_version, MIGRATIONS.len() as i64);
   }
 }

--- a/tools/stove-cli/src/storage/migrations/V2__run_stove_version.sql
+++ b/tools/stove-cli/src/storage/migrations/V2__run_stove_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runs ADD COLUMN stove_version TEXT;

--- a/tools/stove-cli/src/storage/models.rs
+++ b/tools/stove-cli/src/storage/models.rs
@@ -81,6 +81,7 @@ pub struct AppSummary {
   pub app_name: String,
   pub latest_run_id: String,
   pub latest_status: RunStatus,
+  pub stove_version: Option<String>,
   pub total_runs: i32,
 }
 
@@ -96,6 +97,7 @@ pub struct Run {
   pub passed: i32,
   pub failed: i32,
   pub duration_ms: Option<i64>,
+  pub stove_version: Option<String>,
   pub systems: Vec<String>,
 }
 

--- a/tools/stove-cli/src/storage/repository.rs
+++ b/tools/stove-cli/src/storage/repository.rs
@@ -45,8 +45,26 @@ impl Repository {
     started_at: &str,
     systems: &[String],
   ) -> Result<()> {
+    self.save_run_start_with_version(run_id, app_name, started_at, None, systems)
+  }
+
+  pub fn save_run_start_with_version(
+    &self,
+    run_id: &str,
+    app_name: &str,
+    started_at: &str,
+    stove_version: Option<&str>,
+    systems: &[String],
+  ) -> Result<()> {
     let db = self.lock_write_db();
-    save_run_start_on(db.conn(), run_id, app_name, started_at, systems)?;
+    save_run_start_on(
+      db.conn(),
+      run_id,
+      app_name,
+      started_at,
+      stove_version,
+      systems,
+    )?;
     Ok(())
   }
 
@@ -155,7 +173,7 @@ impl Repository {
   pub fn get_apps(&self) -> Result<Vec<AppSummary>> {
     let db = self.lock_read_db();
     let mut stmt = db.conn().prepare(
-      "SELECT r.app_name, r.id, r.status, (SELECT COUNT(*) FROM runs r2 WHERE r2.app_name = r.app_name)
+      "SELECT r.app_name, r.id, r.status, r.stove_version, (SELECT COUNT(*) FROM runs r2 WHERE r2.app_name = r.app_name)
              FROM runs r
              WHERE r.id = (
                SELECT r3.id
@@ -172,7 +190,8 @@ impl Repository {
           app_name: row.get(0)?,
           latest_run_id: row.get(1)?,
           latest_status: parse_run_status(&row.get::<_, String>(2)?),
-          total_runs: row.get(3)?,
+          stove_version: row.get(3)?,
+          total_runs: row.get(4)?,
         })
       })?
       .filter_map(|r| r.ok())
@@ -286,8 +305,16 @@ fn apply_persisted_event(
       run_id,
       app_name,
       started_at,
+      stove_version,
       systems,
-    } => save_run_start_on(conn, run_id, app_name, started_at, systems),
+    } => save_run_start_on(
+      conn,
+      run_id,
+      app_name,
+      started_at,
+      stove_version.as_deref(),
+      systems,
+    ),
     PersistedDashboardEvent::RunEnded {
       run_id,
       ended_at,
@@ -344,12 +371,13 @@ fn save_run_start_on(
   run_id: &str,
   app_name: &str,
   started_at: &str,
+  stove_version: Option<&str>,
   systems: &[String],
 ) -> Result<()> {
   let systems_json = serde_json::to_string(systems)?;
   conn.execute(
-    "INSERT OR REPLACE INTO runs (id, app_name, started_at, systems) VALUES (?1, ?2, ?3, ?4)",
-    rusqlite::params![run_id, app_name, started_at, systems_json],
+    "INSERT OR REPLACE INTO runs (id, app_name, started_at, stove_version, systems) VALUES (?1, ?2, ?3, ?4, ?5)",
+    rusqlite::params![run_id, app_name, started_at, stove_version, systems_json],
   )?;
   Ok(())
 }
@@ -463,8 +491,7 @@ fn save_snapshot_on(
 
 // --- SQL column constants ---
 
-const RUN_COLUMNS: &str =
-  "id, app_name, started_at, ended_at, status, total_tests, passed, failed, duration_ms, systems";
+const RUN_COLUMNS: &str = "id, app_name, started_at, ended_at, status, total_tests, passed, failed, duration_ms, stove_version, systems";
 const SPAN_COLUMNS: &str = "id, run_id, trace_id, span_id, parent_span_id, operation_name, service_name, start_time_nanos, end_time_nanos, status, attributes, exception_type, exception_message, exception_stack_trace";
 
 // --- Row-mapping helpers ---
@@ -485,7 +512,7 @@ fn parse_test_status(s: &str) -> TestStatus {
 }
 
 fn run_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
-  let systems_json: String = row.get(9)?;
+  let systems_json: String = row.get(10)?;
   let systems: Vec<String> = serde_json::from_str(&systems_json).unwrap_or_default();
   Ok(Run {
     id: row.get(0)?,
@@ -497,6 +524,7 @@ fn run_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
     passed: row.get(6)?,
     failed: row.get(7)?,
     duration_ms: row.get(8)?,
+    stove_version: row.get(9)?,
     systems,
   })
 }
@@ -578,10 +606,11 @@ mod tests {
     let repo = test_repo();
 
     repo
-      .save_run_start(
+      .save_run_start_with_version(
         "run-1",
         "product-api",
         "2024-01-01T00:00:00Z",
+        Some("0.23.2"),
         &["HTTP".into(), "Kafka".into()],
       )
       .unwrap();
@@ -658,6 +687,7 @@ mod tests {
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].app_name, "product-api");
     assert_eq!(runs[0].status, RunStatus::Passed);
+    assert_eq!(runs[0].stove_version.as_deref(), Some("0.23.2"));
     assert_eq!(runs[0].systems, vec!["HTTP", "Kafka"]);
 
     let run = repo.get_run("run-1").unwrap().unwrap();
@@ -685,7 +715,37 @@ mod tests {
     let apps = repo.get_apps().unwrap();
     assert_eq!(apps.len(), 1);
     assert_eq!(apps[0].app_name, "product-api");
+    assert_eq!(apps[0].stove_version.as_deref(), Some("0.23.2"));
     assert_eq!(apps[0].total_runs, 1);
+  }
+
+  #[test]
+  fn latest_app_version_comes_from_latest_run() {
+    let repo = test_repo();
+    repo
+      .save_run_start_with_version(
+        "run-1",
+        "product-api",
+        "2024-01-01T00:00:00Z",
+        Some("0.23.0"),
+        &[],
+      )
+      .unwrap();
+    repo
+      .save_run_start_with_version(
+        "run-2",
+        "product-api",
+        "2024-01-02T00:00:00Z",
+        Some("0.23.2"),
+        &[],
+      )
+      .unwrap();
+
+    let apps = repo.get_apps().unwrap();
+
+    assert_eq!(apps.len(), 1);
+    assert_eq!(apps[0].latest_run_id, "run-2");
+    assert_eq!(apps[0].stove_version.as_deref(), Some("0.23.2"));
   }
 
   #[test]

--- a/tools/stove-cli/tests/api_e2e.rs
+++ b/tools/stove-cli/tests/api_e2e.rs
@@ -28,6 +28,16 @@ fn run_started_event(
   seconds: i64,
   nanos: i32,
 ) -> proto::DashboardEvent {
+  run_started_event_with_version(run_id, app_name, "", seconds, nanos)
+}
+
+fn run_started_event_with_version(
+  run_id: &str,
+  app_name: &str,
+  stove_version: &str,
+  seconds: i64,
+  nanos: i32,
+) -> proto::DashboardEvent {
   proto::DashboardEvent {
     run_id: run_id.to_string(),
     event: Some(proto::dashboard_event::Event::RunStarted(
@@ -35,6 +45,7 @@ fn run_started_event(
         timestamp: ts(seconds, nanos),
         app_name: app_name.to_string(),
         systems: vec!["HTTP".to_string(), "Kafka".to_string()],
+        stove_version: stove_version.to_string(),
       },
     )),
   }
@@ -235,6 +246,19 @@ async fn next_sse_data(
 }
 
 // ---------------------------------------------------------------------------
+// GET /api/v1/meta
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn meta_returns_cli_version() {
+  let server = TestServer::start().await;
+
+  let body = server.get_json("/meta").await;
+
+  assert_eq!(body["stove_cli_version"], stove::STOVE_CLI_VERSION);
+}
+
+// ---------------------------------------------------------------------------
 // GET /api/v1/apps
 // ---------------------------------------------------------------------------
 
@@ -257,6 +281,7 @@ async fn apps_returns_app_summaries() {
   assert_eq!(apps[0]["app_name"], "product-api");
   assert_eq!(apps[0]["latest_run_id"], "run-1");
   assert_eq!(apps[0]["latest_status"], "FAILED");
+  assert!(apps[0]["stove_version"].is_null());
   assert_eq!(apps[0]["total_runs"], 1);
 }
 
@@ -278,6 +303,31 @@ async fn apps_returns_multiple_apps() {
   assert!(names.contains(&"beta-api"));
 }
 
+#[tokio::test]
+async fn apps_return_latest_run_stove_version() {
+  let server = TestServer::start().await;
+  server.seed_run_at_with_version(
+    "run-old",
+    "product-api",
+    "2024-01-01T00:00:00Z",
+    Some("0.23.0"),
+    &[],
+  );
+  server.seed_run_at_with_version(
+    "run-new",
+    "product-api",
+    "2024-06-01T00:00:00Z",
+    Some("0.23.2"),
+    &[],
+  );
+
+  let body = server.get_json("/apps").await;
+  let apps = body.as_array().unwrap();
+
+  assert_eq!(apps[0]["latest_run_id"], "run-new");
+  assert_eq!(apps[0]["stove_version"], "0.23.2");
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/v1/runs
 // ---------------------------------------------------------------------------
@@ -297,11 +347,23 @@ async fn runs_returns_all_runs() {
   assert_eq!(runs[0]["passed"], 1);
   assert_eq!(runs[0]["failed"], 1);
   assert_eq!(runs[0]["duration_ms"], 10000);
+  assert!(runs[0]["stove_version"].is_null());
 
   let systems = runs[0]["systems"].as_array().unwrap();
   assert_eq!(systems.len(), 3);
   assert!(systems.contains(&Value::String("HTTP".into())));
   assert!(systems.contains(&Value::String("Kafka".into())));
+}
+
+#[tokio::test]
+async fn runs_return_stove_version() {
+  let server = TestServer::start().await;
+  server.seed_run_with_version("run-1", "product-api", "0.23.1");
+
+  let body = server.get_json("/runs").await;
+  let runs = body.as_array().unwrap();
+
+  assert_eq!(runs[0]["stove_version"], "0.23.1");
 }
 
 #[tokio::test]
@@ -1306,7 +1368,7 @@ async fn sse_stream_pushes_full_events_before_database_flush() {
 
   send_event(
     service.as_ref(),
-    run_started_event("run-live-sse", "live-sse-app", 1_704_067_200, 0),
+    run_started_event_with_version("run-live-sse", "live-sse-app", "0.23.2", 1_704_067_200, 0),
   )
   .await
   .unwrap();
@@ -1330,6 +1392,7 @@ async fn sse_stream_pushes_full_events_before_database_flush() {
   assert_eq!(first_event["run_id"], "run-live-sse");
   assert_eq!(first_event["event_type"], "run_started");
   assert_eq!(first_event["payload"]["app_name"], "live-sse-app");
+  assert_eq!(first_event["payload"]["stove_version"], "0.23.2");
 
   let second_event: Value =
     serde_json::from_str(&next_sse_data(&mut resp, &mut buffer).await.unwrap()).unwrap();

--- a/tools/stove-cli/tests/common/mod.rs
+++ b/tools/stove-cli/tests/common/mod.rs
@@ -80,12 +80,33 @@ impl TestServer {
     self.seed_run_at(run_id, app_name, "2024-06-01T10:00:00Z", &[]);
   }
 
+  pub fn seed_run_with_version(&self, run_id: &str, app_name: &str, stove_version: &str) {
+    self.seed_run_at_with_version(
+      run_id,
+      app_name,
+      "2024-06-01T10:00:00Z",
+      Some(stove_version),
+      &[],
+    );
+  }
+
   /// Start a run with explicit timestamp and systems.
   pub fn seed_run_at(&self, run_id: &str, app_name: &str, started_at: &str, systems: &[&str]) {
+    self.seed_run_at_with_version(run_id, app_name, started_at, None, systems);
+  }
+
+  pub fn seed_run_at_with_version(
+    &self,
+    run_id: &str,
+    app_name: &str,
+    started_at: &str,
+    stove_version: Option<&str>,
+    systems: &[&str],
+  ) {
     let systems: Vec<String> = systems.iter().map(|s| (*s).to_string()).collect();
     self
       .repo
-      .save_run_start(run_id, app_name, started_at, &systems)
+      .save_run_start_with_version(run_id, app_name, started_at, stove_version, &systems)
       .unwrap();
   }
 


### PR DESCRIPTION
- Added guidance on version alignment to multiple documentation files, including `getting-started.md` and `18-dashboard.md`.
- Clarified how mismatched versions can affect dashboard data.
- Introduced a `VersionMismatchBanner` component in the CLI UI to highlight version mismatches.