### PR TITLE
feat: add providedApplication and multiple systems (keyed) support

### DIFF
--- a/.claude/skills/stove/SKILL.md
+++ b/.claude/skills/stove/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stove
-description: Use when adding Stove e2e tests to a project, configuring Stove systems (HTTP, PostgreSQL, MySQL, MSSQL, Cassandra, MongoDB, Redis, Elasticsearch, Couchbase, Kafka, WireMock, gRPC, Dashboard), writing tests with the stove {} DSL, enabling OpenTelemetry tracing, writing AbstractProjectConfig, or extending Stove with custom systems.
+description: Use when adding Stove e2e tests to a project, configuring Stove systems (HTTP, PostgreSQL, MySQL, MSSQL, Cassandra, MongoDB, Redis, Elasticsearch, Couchbase, Kafka, WireMock, gRPC, Dashboard), writing tests with the stove {} DSL, enabling OpenTelemetry tracing, writing AbstractProjectConfig, extending Stove with custom systems, setting up smoke tests against remote/deployed applications (providedApplication), or registering multiple instances of the same system type (keyed systems with SystemKey).
 ---
 
 # Setting Up Stove E2E Tests
@@ -291,6 +291,66 @@ class OrderE2ETest : FunSpec({
     }
 })
 ```
+
+## Smoke testing with providedApplication
+
+Stove can test against **already-deployed** applications — any language, any framework. Use `providedApplication()` instead of a JVM runner. See [system-setup.md](system-setup.md#provided-application-smoke-testing) for full details.
+
+```kotlin
+Stove().with {
+    httpClient { HttpClientSystemOptions(baseUrl = "https://staging.myapp.com") }
+    postgresql(AppDb) {
+        PostgresqlOptions.provided(
+            jdbcUrl = "jdbc:postgresql://staging-db:5432/myapp",
+            cleanup = { ops -> ops.execute("DELETE FROM orders WHERE test = true") },
+            configureExposedConfiguration = { listOf() }  // no AUT to configure
+        )
+    }
+    providedApplication {
+        ProvidedApplicationOptions(
+            healthCheck = HealthCheckOptions(url = "https://staging.myapp.com/health")
+        )
+    }
+}.run()
+```
+
+Key points:
+- No JVM runner needed — the application is already running
+- Works with any language (Go, Python, .NET, Rust, Node.js, etc.)
+- `Bridge` (DI access) is **not available** — there's no local DI container
+- Use `cleanup` lambdas to manage test data on external infrastructure
+- Optional health check waits for the app to be ready before running tests
+
+## Keyed systems (multiple instances)
+
+Register multiple instances of the same system type using `SystemKey`. See [system-setup.md](system-setup.md#keyed-systems-multiple-instances) and [writing-tests.md](writing-tests.md#keyed-system-tests) for examples.
+
+```kotlin
+// Define keys as singleton objects
+object AppDb : SystemKey
+object AnalyticsDb : SystemKey
+object PaymentService : SystemKey
+object InventoryService : SystemKey
+
+Stove().with {
+    postgresql(AppDb) {
+        PostgresqlOptions(configureExposedConfiguration = { cfg ->
+            listOf("app.datasource.url=${cfg.jdbcUrl}")
+        })
+    }
+    postgresql(AnalyticsDb) {
+        PostgresqlOptions(configureExposedConfiguration = { cfg ->
+            listOf("analytics.datasource.url=${cfg.jdbcUrl}")
+        })
+    }
+    httpClient(PaymentService) {
+        HttpClientSystemOptions(baseUrl = "https://pay.internal")
+    }
+    springBoot(runner = { params -> run(params) })
+}.run()
+```
+
+All systems support keyed registration: PostgreSQL, MySQL, MSSQL, Cassandra, MongoDB, Redis, Elasticsearch, Couchbase, Kafka (core), WireMock, gRPC, gRPC Mock, HTTP. Each keyed instance gets its own container, port, state storage, and configuration.
 
 ## Writing custom Stove systems
 

--- a/.claude/skills/stove/system-setup.md
+++ b/.claude/skills/stove/system-setup.md
@@ -1,6 +1,8 @@
 # System Setup Reference
 
 ## Contents
+- [Provided Application (smoke testing)](#provided-application-smoke-testing)
+- [Keyed systems (multiple instances)](#keyed-systems-multiple-instances)
 - [HTTP Client](#http-client)
 - [PostgreSQL](#postgresql)
 - [MySQL](#mysql)
@@ -26,6 +28,152 @@
 - [Keep dependencies running](#keep-dependencies-running)
 
 All systems are configured inside `Stove().with { }`. The application runner goes last.
+
+## Provided Application (smoke testing)
+
+Use `providedApplication()` instead of a JVM runner to test against an already-deployed application. The application can be written in **any language** — Go, Python, .NET, Rust, Node.js, etc.
+
+```kotlin
+Stove().with {
+    httpClient {
+        HttpClientSystemOptions(baseUrl = "https://staging.myapp.com")
+    }
+    providedApplication {
+        ProvidedApplicationOptions(
+            healthCheck = HealthCheckOptions(
+                url = "https://staging.myapp.com/health",
+                retries = 10,
+                retryDelay = 1.seconds,
+                timeout = 30.seconds,
+                expectedStatusCodes = setOf(200)
+            )
+        )
+    }
+}.run()
+```
+
+Without health check (fire-and-forget):
+
+```kotlin
+providedApplication()  // No health check, no options
+```
+
+Combine with `.provided()` system options to connect to existing infrastructure:
+
+```kotlin
+Stove().with {
+    httpClient {
+        HttpClientSystemOptions(baseUrl = "https://staging.myapp.com")
+    }
+    postgresql(AppDb) {
+        PostgresqlOptions.provided(
+            jdbcUrl = "jdbc:postgresql://staging-db:5432/myapp",
+            cleanup = { ops -> ops.execute("DELETE FROM orders WHERE test_data = true") },
+            configureExposedConfiguration = { listOf() }
+        )
+    }
+    redis(CacheCluster) {
+        RedisOptions.provided(
+            host = "staging-redis", port = 6379,
+            configureExposedConfiguration = { listOf() }
+        )
+    }
+    providedApplication {
+        ProvidedApplicationOptions(
+            healthCheck = HealthCheckOptions(url = "https://staging.myapp.com/health")
+        )
+    }
+}.run()
+```
+
+**Important**: `Bridge` (DI access via `using<T>`) is **not available** with `providedApplication()` — there is no local DI container. Use `cleanup` lambdas to manage test data on external infrastructure.
+
+## Keyed systems (multiple instances)
+
+Register multiple instances of the same system type using `SystemKey`. Define keys as singleton objects:
+
+```kotlin
+object AppDb : SystemKey
+object AnalyticsDb : SystemKey
+object PaymentService : SystemKey
+object InventoryService : SystemKey
+```
+
+Use keys in registration:
+
+```kotlin
+Stove().with {
+    // Two separate PostgreSQL containers with independent configs
+    postgresql(AppDb) {
+        PostgresqlOptions(
+            databaseName = "appdb",
+            configureExposedConfiguration = { cfg ->
+                listOf("app.datasource.url=${cfg.jdbcUrl}")
+            }
+        ).migrations { register<AppSchemaMigration>() }
+    }
+    postgresql(AnalyticsDb) {
+        PostgresqlOptions(
+            databaseName = "analyticsdb",
+            configureExposedConfiguration = { cfg ->
+                listOf("analytics.datasource.url=${cfg.jdbcUrl}")
+            }
+        ).migrations { register<AnalyticsSchemaMigration>() }
+    }
+
+    // Two HTTP clients pointing to different services
+    httpClient(PaymentService) {
+        HttpClientSystemOptions(baseUrl = "https://pay.internal")
+    }
+    httpClient(InventoryService) {
+        HttpClientSystemOptions(baseUrl = "https://inventory.internal")
+    }
+
+    // Two WireMock instances for different external APIs
+    wiremock(PaymentService) {
+        WireMockSystemOptions(port = 0, configureExposedConfiguration = { cfg ->
+            listOf("payment.url=${cfg.baseUrl}")
+        })
+    }
+    wiremock(InventoryService) {
+        WireMockSystemOptions(port = 0, configureExposedConfiguration = { cfg ->
+            listOf("inventory.url=${cfg.baseUrl}")
+        })
+    }
+
+    springBoot(runner = { params -> run(params) })
+}.run()
+```
+
+All systems support keyed registration: PostgreSQL, MySQL, MSSQL, Cassandra, MongoDB, Redis, Elasticsearch, Couchbase, Kafka (core), WireMock, gRPC, gRPC Mock, HTTP.
+
+Each keyed instance gets:
+- Its own container with a unique dynamic port (no conflicts)
+- Independent `configureExposedConfiguration` — all configs are aggregated and passed to the AUT
+- Isolated state storage (separate lock files per key)
+- Its own `cleanup` lambda
+- Distinct reporting name (e.g., `"PostgreSQL [AppDb]"`)
+
+A single key can be shared across protocol types:
+
+```kotlin
+object PaymentService : SystemKey
+
+httpClient(PaymentService) { HttpClientSystemOptions(baseUrl = "...") }
+grpc(PaymentService) { GrpcSystemOptions(host = "...", port = 50051) }
+wiremock(PaymentService) { WireMockSystemOptions(...) }
+```
+
+Keyed systems work with both Testcontainers and `.provided()` (external) instances:
+
+```kotlin
+postgresql(AppDb) {
+    PostgresqlOptions.provided(
+        jdbcUrl = "jdbc:postgresql://staging-db:5432/app",
+        configureExposedConfiguration = { listOf() }
+    )
+}
+```
 
 ## HTTP Client
 

--- a/.claude/skills/stove/writing-tests.md
+++ b/.claude/skills/stove/writing-tests.md
@@ -17,6 +17,8 @@
 - [gRPC Client](#grpc-client)
 - [Bridge (DI access)](#bridge-di-access)
 - [Trace validation](#trace-validation)
+- [Keyed system tests](#keyed-system-tests)
+- [Smoke testing (providedApplication)](#smoke-testing-providedapplication)
 - [Multi-system test](#multi-system-test)
 - [Anti-patterns](#anti-patterns)
 
@@ -615,6 +617,104 @@ tracing {
     // Debugging
     println(renderTree())    // Hierarchical trace view
     println(renderSummary()) // Compact summary
+}
+```
+
+## Keyed system tests
+
+Access keyed systems by passing the `SystemKey` to the validation DSL:
+
+```kotlin
+// Given keys defined in setup:
+// object AppDb : SystemKey
+// object AnalyticsDb : SystemKey
+// object PaymentService : SystemKey
+
+test("should write to both databases") {
+    stove {
+        http {
+            postAndExpectBody<OrderResponse>(
+                uri = "/orders",
+                body = CreateOrderRequest("u1", 99.99).some()
+            ) { it.status shouldBe 201 }
+        }
+
+        // Assert against the app database
+        postgresql(AppDb) {
+            shouldQuery<OrderRow>(
+                query = "SELECT * FROM orders WHERE user_id = 'u1'",
+                mapper = { row -> OrderRow(row.string("id"), row.string("status")) }
+            ) { it.size shouldBe 1 }
+        }
+
+        // Assert against the analytics database
+        postgresql(AnalyticsDb) {
+            shouldQuery<AnalyticsRow>(
+                query = "SELECT * FROM events WHERE user_id = 'u1'",
+                mapper = { row -> AnalyticsRow(row.string("event_type")) }
+            ) { it.first().eventType shouldBe "ORDER_CREATED" }
+        }
+    }
+}
+
+// Keyed WireMock and HTTP
+test("should call payment and inventory services") {
+    stove {
+        wiremock(PaymentService) {
+            mockPost("/charge", 200, PaymentResult(true).some())
+        }
+        wiremock(InventoryService) {
+            mockGet("/stock/item-1", 200, StockResponse(10).some())
+        }
+
+        http {
+            postAndExpectBody<OrderResponse>("/orders", body = order.some()) {
+                it.status shouldBe 201
+            }
+        }
+    }
+}
+```
+
+All systems support keyed access: `postgresql(key)`, `mysql(key)`, `mssql(key)`, `cassandra(key)`, `mongodb(key)`, `redis(key)`, `elasticsearch(key)`, `couchbase(key)`, `kafka(key)`, `wiremock(key)`, `grpcMock(key)`, `grpc(key)`, `http(key)`.
+
+## Smoke testing (providedApplication)
+
+With `providedApplication()`, test a remote/deployed application without starting it locally. No `Bridge`/`using<T>` — only infrastructure assertions:
+
+```kotlin
+test("staging smoke test — order flow") {
+    stove {
+        val userId = "smoke-${UUID.randomUUID()}"
+
+        // Hit the remote API
+        http {
+            postAndExpectBody<OrderResponse>(
+                uri = "/api/orders",
+                body = CreateOrderRequest(userId, 49.99).some()
+            ) { response ->
+                response.status shouldBe 201
+            }
+        }
+
+        // Verify side effects in the remote database
+        postgresql(AppDb) {
+            shouldQuery<OrderRow>(
+                query = "SELECT * FROM orders WHERE user_id = '$userId'",
+                mapper = { row -> OrderRow(row.string("id"), row.string("status")) }
+            ) { orders ->
+                orders.size shouldBe 1
+                orders.first().status shouldBe "CONFIRMED"
+            }
+        }
+
+        // Verify Kafka event on the remote cluster
+        kafka {
+            shouldBePublished<OrderCreatedEvent>(10.seconds) {
+                actual.userId == userId
+            }
+        }
+    }
 }
 ```
 

--- a/docs/Components/19-provided-application.md
+++ b/docs/Components/19-provided-application.md
@@ -1,0 +1,154 @@
+# <span data-rn="underline" data-rn-color="#ff9800">Provided Application</span> (Black-Box Testing)
+
+Stove normally starts the application under test locally via a framework starter (`springBoot()`, `ktor()`, etc.). With `providedApplication()`, you can skip that entirely and <span data-rn="highlight" data-rn-color="#00968855" data-rn-duration="800">test against a remote, already-deployed application</span> --- regardless of what language or framework it's built with.
+
+## When to Use
+
+- **Staging/pre-production validation** --- verify deployed services before release
+- **Polyglot testing** --- the app can be Go, Python, .NET, Rust, Node.js, or anything else
+- **Microservice integration** --- test a service through its public API and verify side effects in databases, Kafka, and caches
+- **Smoke testing** --- run Stove tests as post-deployment checks in CI/CD
+
+## Configure
+
+`providedApplication()` replaces the framework starter (`springBoot()`, `ktor()`, etc.) in the `with` block. HTTP, databases, and other systems are configured separately as usual.
+
+```kotlin hl_lines="3 8-13"
+Stove().with {
+    // Your app's API --- configured via httpClient as usual
+    httpClient {
+        HttpClientSystemOptions(baseUrl = "https://staging.myapp.com")
+    }
+
+    // Signal: app is already running, don't start it
+    providedApplication {
+        ProvidedApplicationOptions(
+            healthCheck = HealthCheckOptions(
+                url = "https://staging.myapp.com/actuator/health"
+            )
+        )
+    }
+}.run()
+```
+
+### Health Check
+
+The optional health check verifies the remote application is reachable before tests run. If the check fails after all retries, Stove throws immediately with a clear error.
+
+```kotlin
+HealthCheckOptions(
+    url = "https://staging.myapp.com/health",   // Health endpoint URL
+    timeout = 30.seconds,                        // HTTP request timeout
+    retries = 10,                                // Number of retry attempts
+    retryDelay = 1.seconds,                      // Delay between retries
+    expectedStatusCodes = setOf(200)              // Status codes considered healthy
+)
+```
+
+### No Health Check
+
+If you're sure the app is up, skip the health check entirely:
+
+```kotlin
+providedApplication()  // No-op --- just satisfies the AUT requirement
+```
+
+## Complete Example
+
+```kotlin hl_lines="4 11-14 17-24 27"
+class TestConfig : AbstractProjectConfig() {
+    override suspend fun beforeProject() {
+        Stove().with {
+            // The app itself
+            httpClient {
+                HttpClientSystemOptions(baseUrl = "https://staging.myapp.com")
+            }
+
+            // Infrastructure the app connects to
+            postgresql {
+                PostgresqlOptions.provided(
+                    jdbcUrl = "jdbc:postgresql://staging-db:5432/myapp",
+                    host = "staging-db", port = 5432,
+                    configureExposedConfiguration = { emptyList() }
+                )
+            }
+
+            kafka {
+                KafkaSystemOptions.provided(
+                    bootstrapServers = "staging-kafka:9092",
+                    configureExposedConfiguration = { emptyList() }
+                )
+            }
+
+            // App is already deployed
+            providedApplication {
+                ProvidedApplicationOptions(
+                    healthCheck = HealthCheckOptions(
+                        url = "https://staging.myapp.com/actuator/health",
+                        timeout = 15.seconds
+                    )
+                )
+            }
+        }.run()
+    }
+
+    override suspend fun afterProject() = Stove.stop()
+}
+```
+
+## Writing Tests
+
+Tests are written exactly the same way --- the DSL doesn't change:
+
+```kotlin
+test("create order and verify side effects") {
+    stove {
+        http {
+            postAndExpectJson<OrderResponse>("/orders", body = request.some()) { order ->
+                order.id shouldNotBe null
+            }
+        }
+
+        postgresql {
+            shouldQuery<Order>("SELECT * FROM orders WHERE id = ?", listOf(orderId)) { rows ->
+                rows shouldHaveSize 1
+            }
+        }
+
+        kafka {
+            // Use consumer() to read directly from topics (no interceptor needed)
+            consumer<String, OrderCreatedEvent>("orders.output", readOnly = true) { record ->
+                record.value().orderId shouldBe orderId
+            }
+        }
+    }
+}
+```
+
+## Limitations
+
+| Feature | Available? | Notes |
+|---------|-----------|-------|
+| HTTP/gRPC assertions | Yes | Via `httpClient {}` and `grpc {}` |
+| Database queries | Yes | Via `postgresql {}`, `mongodb {}`, etc. |
+| Kafka publish + consumer | Yes | `publish()` and `consumer()` work directly |
+| Kafka `shouldBeConsumed` | No | Requires interceptor bridge inside the app |
+| `using<T> {}` (Bridge) | No | Remote app's DI container is not accessible |
+
+!!! warning "Bridge Not Supported"
+    `using<MyService> { }` accesses the application's DI container, which is only possible when the app runs in the same JVM. With `providedApplication()`, calling `using<T>` throws a clear error explaining this.
+
+## Suggested Source Set
+
+For projects that have both local e2e tests and black-box tests against deployed apps:
+
+```
+my-service/
+  src/
+    main/           # Application code
+    test/            # Unit tests
+    test-e2e/        # Stove e2e tests (app started locally)
+    test-blackbox/   # Stove black-box tests (providedApplication)
+```
+
+See also: [Multiple Systems](20-multiple-systems.md) for testing against multiple named service instances.

--- a/docs/Components/20-multiple-systems.md
+++ b/docs/Components/20-multiple-systems.md
@@ -1,0 +1,195 @@
+# <span data-rn="underline" data-rn-color="#ff9800">Multiple Systems</span>
+
+By default, Stove registers one instance per system type --- one PostgreSQL, one Kafka, one HTTP client. With multiple systems, you can register <span data-rn="highlight" data-rn-color="#00968855" data-rn-duration="800">multiple instances of the same system type</span>, each identified by a typed key.
+
+## When to Use
+
+- **Microservice integration** --- call multiple services, each with its own HTTP client or gRPC stub
+- **Multiple databases** --- verify state in separate PostgreSQL or MongoDB instances
+- **Multi-cluster Kafka** --- publish/consume from different Kafka clusters
+- **Cross-service verification** --- after calling your app, check that dependent services received the right data
+
+## Define Keys
+
+Keys are Kotlin singleton objects implementing `SystemKey`:
+
+```kotlin
+object OrderService : SystemKey
+object PaymentService : SystemKey
+object AppDb : SystemKey
+object AnalyticsDb : SystemKey
+```
+
+!!! tip "Why Objects Instead of Strings?"
+    Kotlin objects give you compile-time safety, IDE autocomplete, and refactor-safe references. Typos become compile errors. The same key can be reused across protocols --- `httpClient(PaymentService)` and `grpc(PaymentService)` both refer to the same logical service.
+
+## Configure
+
+Pass the key as the first argument to any system DSL function:
+
+```kotlin hl_lines="3 8 13 18"
+Stove().with {
+    // Default HTTP client --- your app
+    httpClient {
+        HttpClientSystemOptions(baseUrl = "https://myapp.staging.com")
+    }
+
+    // Keyed HTTP clients --- dependent services
+    httpClient(OrderService) {
+        HttpClientSystemOptions(baseUrl = "https://order.internal.com")
+    }
+    httpClient(PaymentService) {
+        HttpClientSystemOptions(baseUrl = "https://payment.internal.com")
+    }
+
+    // Keyed databases
+    postgresql(AppDb) {
+        PostgresqlOptions.provided(
+            jdbcUrl = "jdbc:postgresql://staging-db:5432/myapp",
+            host = "staging-db", port = 5432,
+            configureExposedConfiguration = { emptyList() }
+        )
+    }
+    postgresql(AnalyticsDb) {
+        PostgresqlOptions.provided(
+            jdbcUrl = "jdbc:postgresql://analytics-db:5432/analytics",
+            host = "analytics-db", port = 5432,
+            configureExposedConfiguration = { emptyList() }
+        )
+    }
+
+    providedApplication()
+}.run()
+```
+
+## Write Tests
+
+Pass the key to the validation DSL:
+
+```kotlin hl_lines="5 12 19 26"
+test("create order, verify across services and databases") {
+    stove {
+        // Call the app (default HTTP --- no key)
+        http {
+            postAndExpectJson<OrderResponse>("/orders", body = request.some()) { order ->
+                order.id shouldNotBe null
+            }
+        }
+
+        // Verify order service received the order
+        http(OrderService) {
+            getResponse("/api/orders/$orderId") { resp ->
+                resp.status shouldBe 200
+            }
+        }
+
+        // Verify payment was processed
+        http(PaymentService) {
+            getResponse("/api/payments?orderId=$orderId") { resp ->
+                resp.status shouldBe 200
+            }
+        }
+
+        // Verify in app's database
+        postgresql(AppDb) {
+            shouldQuery<Order>("SELECT * FROM orders WHERE id = ?", listOf(orderId)) { rows ->
+                rows shouldHaveSize 1
+            }
+        }
+
+        // Verify analytics event landed
+        postgresql(AnalyticsDb) {
+            shouldQuery<AnalyticsEvent>("SELECT * FROM events WHERE order_id = ?", listOf(orderId)) { events ->
+                events.first().type shouldBe "ORDER_CREATED"
+            }
+        }
+    }
+}
+```
+
+## Supported Systems
+
+All multi-instance dependency systems support keyed registration:
+
+| Category | Systems |
+|----------|---------|
+| **Databases** | PostgreSQL, MySQL, MSSQL, MongoDB, Cassandra, Couchbase, Redis, Elasticsearch |
+| **Protocol clients** | HTTP Client, gRPC |
+| **Messaging** | Kafka |
+| **Mocking** | WireMock, gRPC Mock |
+
+Single-instance systems (Bridge, Tracing, Dashboard) and framework starters (`springBoot()`, `ktor()`) do **not** support keyed registration --- there is only one application under test.
+
+!!! info "Spring Kafka"
+    The Spring Kafka starter (`stove-spring-kafka`) does not support keyed instances because it is tied to a single Spring application context. Use the standalone `stove-kafka` module if you need multiple Kafka instances.
+
+## Default and Keyed Coexist
+
+Default (unkeyed) and keyed instances of the same type are independent:
+
+```kotlin
+// Registration
+httpClient { HttpClientSystemOptions(baseUrl = "https://myapp.com") }      // default
+httpClient(OrderService) { HttpClientSystemOptions(baseUrl = "https://order.internal.com") }  // keyed
+
+// Validation
+http { /* hits myapp.com */ }              // default
+http(OrderService) { /* hits order.internal.com */ }  // keyed
+```
+
+## Reporting
+
+Keyed systems produce distinguishable names in reports and traces:
+
+```
+HTTP > GET /orders                          # default
+HTTP [OrderService] > GET /api/orders/123   # keyed
+HTTP [PaymentService] > GET /api/payments   # keyed
+PostgreSQL [AppDb] > shouldQuery > SELECT   # keyed
+PostgreSQL [AnalyticsDb] > shouldQuery      # keyed
+```
+
+## Error Handling
+
+If you pass a key that wasn't registered, you get a clear runtime error:
+
+```
+SystemNotRegisteredException: HttpSystem was not registered.
+No HttpSystem registered with key 'OrderService'
+```
+
+## Combining with Provided Application
+
+Keyed systems and `providedApplication()` are designed to work together for full black-box testing:
+
+```kotlin hl_lines="2-4 7-14 17"
+Stove().with {
+    // Your app's API
+    httpClient { HttpClientSystemOptions(baseUrl = "https://staging.myapp.com") }
+
+    // Dependent services and infrastructure
+    httpClient(OrderService) { HttpClientSystemOptions(baseUrl = "https://order.internal.com") }
+    postgresql(AppDb) {
+        PostgresqlOptions.provided(
+            jdbcUrl = "jdbc:postgresql://staging-db:5432/myapp",
+            host = "staging-db", port = 5432,
+            configureExposedConfiguration = { emptyList() }
+        )
+    }
+    kafka {
+        KafkaSystemOptions.provided(
+            bootstrapServers = "staging-kafka:9092",
+            configureExposedConfiguration = { emptyList() }
+        )
+    }
+
+    // App already running
+    providedApplication {
+        ProvidedApplicationOptions(
+            healthCheck = HealthCheckOptions(url = "https://staging.myapp.com/health")
+        )
+    }
+}.run()
+```
+
+See also: [Provided Application](19-provided-application.md) for testing against deployed apps.

--- a/docs/Components/index.md
+++ b/docs/Components/index.md
@@ -30,6 +30,10 @@ Most teams start with 2 to 4 components, not the whole catalog.
 
     Add [Dashboard](18-dashboard.md) for a real-time web dashboard that shows every test interaction, distributed trace, and system snapshot across runs.
 
+-   **Testing a deployed service (any language)**
+
+    Use [Provided Application](19-provided-application.md) with [HTTP Client](05-http.md) and your databases. Add [Multiple Systems](20-multiple-systems.md) if you need to verify multiple dependent services.
+
 </div>
 
 ## Common Starting Sets
@@ -41,6 +45,7 @@ Most teams start with 2 to 4 components, not the whole catalog.
 | External provider integration | `stove-http` + `stove-wiremock` |
 | gRPC service | `stove-grpc` + `stove-grpc-mock` |
 | Stateful service with caching | your database + `stove-redis` |
+| Deployed service (any language) | `stove-http` + your databases + `providedApplication()` |
 
 ## Available Components
 
@@ -62,6 +67,8 @@ Most teams start with 2 to 4 components, not the whole catalog.
 | [Bridge](10-bridge.md) | Built-in | Access to application's DI container |
 | [Tracing](15-tracing.md) | `stove-tracing` | Execution tracing with OpenTelemetry for failure diagnostics |
 | [Provided Instances](11-provided-instances.md) | Built-in | Connect to existing infrastructure instead of containers |
+| [Provided Application](19-provided-application.md) | Built-in | Test against a remote, already-deployed application (any language) |
+| [Multiple Systems](20-multiple-systems.md) | Built-in | Register multiple instances of the same system type with typed keys |
 | [Reporting](13-reporting.md) | `stove-extensions-kotest` or `stove-extensions-junit` | Rich failure reports with execution context |
 | [Dashboard](18-dashboard.md) | `stove-dashboard` + [CLI](https://github.com/Trendyol/stove/tree/main/tools/stove-cli) | Real-time web dashboard for test observability |
 
@@ -152,6 +159,8 @@ stove {
 | Component | Use Case |
 |-----------|----------|
 | [Bridge](10-bridge.md) | Access application beans and services directly (supported by Spring, Ktor, and Micronaut starters) |
+| [Provided Application](19-provided-application.md) | Test against a remote app without starting it locally --- any language, any framework |
+| [Multiple Systems](20-multiple-systems.md) | Register multiple named instances of the same system type (e.g., two PostgreSQL databases) |
 | [Reporting](13-reporting.md) | Detailed execution reports and failure diagnostics |
 | [Tracing](15-tracing.md) | <span data-rn="highlight" data-rn-color="#00968855" data-rn-duration="800">Execution tracing with full call chain visibility on failure</span> |
 | [Dashboard](18-dashboard.md) | Real-time web dashboard for browsing test runs, traces, and system snapshots |
@@ -325,6 +334,8 @@ test("should process order end-to-end") {
 - [Cassandra](17-cassandra.md) - Wide-column NoSQL database with CQL support
 - [Bridge](10-bridge.md) - Direct access to application beans
 - [Provided Instances](11-provided-instances.md) - Use external infrastructure
+- [Provided Application](19-provided-application.md) - Test against a deployed app (any language)
+- [Multiple Systems](20-multiple-systems.md) - Multiple named instances of the same system type
 - [Reporting](13-reporting.md) - Detailed execution reports and failure diagnostics
 - [Tracing](15-tracing.md) - <span data-rn="underline" data-rn-color="#009688">Execution tracing with OpenTelemetry for full call chain visibility</span>
 - [Dashboard](18-dashboard.md) - Real-time web dashboard for browsing test runs, traces, and snapshots

--- a/lib/stove-cassandra/api/stove-cassandra.api
+++ b/lib/stove-cassandra/api/stove-cassandra.api
@@ -23,12 +23,15 @@ public final class com/trendyol/stove/cassandra/CassandraContainerOptions : com/
 }
 
 public final class com/trendyol/stove/cassandra/CassandraContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/cassandra/CassandraSystemOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;)Lcom/trendyol/stove/cassandra/CassandraContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/cassandra/CassandraContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;ILjava/lang/Object;)Lcom/trendyol/stove/cassandra/CassandraContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;Ljava/lang/String;)Lcom/trendyol/stove/cassandra/CassandraContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/cassandra/CassandraContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/cassandra/CassandraSystemOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/cassandra/CassandraContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/cassandra/CassandraSystemOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -118,6 +121,8 @@ public final class com/trendyol/stove/cassandra/CassandraSystemOptions$Companion
 
 public final class com/trendyol/stove/cassandra/OptionsKt {
 	public static final fun cassandra-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun cassandra-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun cassandra-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun cassandra-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-cassandra/src/main/kotlin/com/trendyol/stove/cassandra/CassandraSystem.kt
+++ b/lib/stove-cassandra/src/main/kotlin/com/trendyol/stove/cassandra/CassandraSystem.kt
@@ -109,11 +109,11 @@ class CassandraSystem internal constructor(
   @PublishedApi
   internal lateinit var cqlSession: CqlSession
 
-  override val reportSystemName: String = "Cassandra"
+  override val reportSystemName: String = "Cassandra" + (context.keyName?.let { " [$it]" } ?: "")
   private lateinit var exposedConfiguration: CassandraExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<CassandraExposedConfiguration> =
-    stove.createStateStorage<CassandraExposedConfiguration, CassandraSystem>()
+    stove.createStateStorage<CassandraExposedConfiguration, CassandraSystem>(context.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-cassandra/src/main/kotlin/com/trendyol/stove/cassandra/Options.kt
+++ b/lib/stove-cassandra/src/main/kotlin/com/trendyol/stove/cassandra/Options.kt
@@ -21,7 +21,8 @@ data class CassandraExposedConfiguration(
 @StoveDsl
 data class CassandraContext(
   val runtime: SystemRuntime,
-  val options: CassandraSystemOptions
+  val options: CassandraSystemOptions,
+  val keyName: String? = null
 )
 
 open class StoveCassandraContainer(
@@ -47,9 +48,23 @@ internal fun Stove.withCassandra(
   return this
 }
 
+internal fun Stove.withCassandra(
+  key: SystemKey,
+  options: CassandraSystemOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, CassandraSystem(this, CassandraContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.cassandra(): CassandraSystem =
   getOrNone<CassandraSystem>().getOrElse {
     throw SystemNotRegisteredException(CassandraSystem::class)
+  }
+
+internal fun Stove.cassandra(key: SystemKey): CassandraSystem =
+  getOrNone<CassandraSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(CassandraSystem::class, "No CassandraSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -103,6 +118,35 @@ fun WithDsl.cassandra(
   return stove.withCassandra(options, runtime)
 }
 
+fun WithDsl.cassandra(
+  key: SystemKey,
+  configure: () -> CassandraSystemOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedCassandraSystemOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.imageWithTag,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveCassandraContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withCassandra(key, options, runtime)
+}
+
 suspend fun ValidationDsl.cassandra(
   validation: @CassandraDsl suspend CassandraSystem.() -> Unit
 ): Unit = validation(this.stove.cassandra())
+
+suspend fun ValidationDsl.cassandra(
+  key: SystemKey,
+  validation: @CassandraDsl suspend CassandraSystem.() -> Unit
+): Unit = validation(this.stove.cassandra(key))

--- a/lib/stove-couchbase/api/stove-couchbase.api
+++ b/lib/stove-couchbase/api/stove-couchbase.api
@@ -23,14 +23,17 @@ public final class com/trendyol/stove/couchbase/CouchbaseContainerOptions : com/
 }
 
 public final class com/trendyol/stove/couchbase/CouchbaseContext {
-	public fun <init> (Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;)V
+	public fun <init> (Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/testcontainers/couchbase/BucketDefinition;
 	public final fun component2 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component3 ()Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;
-	public final fun copy (Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;)Lcom/trendyol/stove/couchbase/CouchbaseContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/couchbase/CouchbaseContext;Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;ILjava/lang/Object;)Lcom/trendyol/stove/couchbase/CouchbaseContext;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;Ljava/lang/String;)Lcom/trendyol/stove/couchbase/CouchbaseContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/couchbase/CouchbaseContext;Lorg/testcontainers/couchbase/BucketDefinition;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/couchbase/CouchbaseContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBucket ()Lorg/testcontainers/couchbase/BucketDefinition;
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/couchbase/CouchbaseSystemOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -112,6 +115,8 @@ public final class com/trendyol/stove/couchbase/CouchbaseSystemOptions$Companion
 
 public final class com/trendyol/stove/couchbase/OptionsKt {
 	public static final fun couchbase-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun couchbase-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun couchbase-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun couchbase-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-couchbase/src/main/kotlin/com/trendyol/stove/couchbase/CouchbaseSystem.kt
+++ b/lib/stove-couchbase/src/main/kotlin/com/trendyol/stove/couchbase/CouchbaseSystem.kt
@@ -165,10 +165,12 @@ class CouchbaseSystem internal constructor(
   @PublishedApi
   internal lateinit var collection: Collection
 
+  override val reportSystemName: String = "Couchbase" + (context.keyName?.let { " [$it]" } ?: "")
+
   private lateinit var exposedConfiguration: CouchbaseExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<CouchbaseExposedConfiguration> =
-    stove.createStateStorage<CouchbaseExposedConfiguration, CouchbaseSystem>()
+    stove.createStateStorage<CouchbaseExposedConfiguration, CouchbaseSystem>(context.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-couchbase/src/main/kotlin/com/trendyol/stove/couchbase/Options.kt
+++ b/lib/stove-couchbase/src/main/kotlin/com/trendyol/stove/couchbase/Options.kt
@@ -122,7 +122,8 @@ typealias CouchbaseMigration = DatabaseMigration<Cluster>
 data class CouchbaseContext(
   val bucket: BucketDefinition,
   val runtime: SystemRuntime,
-  val options: CouchbaseSystemOptions
+  val options: CouchbaseSystemOptions,
+  val keyName: String? = null
 )
 
 @StoveDsl
@@ -146,9 +147,27 @@ internal fun Stove.withCouchbase(
   return this
 }
 
+internal fun Stove.withCouchbase(
+  key: SystemKey,
+  options: CouchbaseSystemOptions,
+  runtime: SystemRuntime
+): Stove {
+  val bucketDefinition = BucketDefinition(options.defaultBucket)
+  this.getOrRegister(
+    key,
+    CouchbaseSystem(this, CouchbaseContext(bucketDefinition, runtime, options, keyName = keyDisplayName(key)))
+  )
+  return this
+}
+
 internal fun Stove.couchbase(): CouchbaseSystem =
   getOrNone<CouchbaseSystem>().getOrElse {
     throw SystemNotRegisteredException(CouchbaseSystem::class)
+  }
+
+internal fun Stove.couchbase(key: SystemKey): CouchbaseSystem =
+  getOrNone<CouchbaseSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(CouchbaseSystem::class, "No CouchbaseSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -206,6 +225,38 @@ fun WithDsl.couchbase(
   return stove.withCouchbase(options, runtime)
 }
 
+fun WithDsl.couchbase(
+  key: SystemKey,
+  configure: @StoveDsl () -> CouchbaseSystemOptions
+): Stove {
+  val options = configure()
+  val bucketDefinition = BucketDefinition(options.defaultBucket)
+
+  val runtime: SystemRuntime = if (options is ProvidedCouchbaseSystemOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      imageName = options.containerOptions.imageWithTag,
+      registry = options.containerOptions.registry,
+      compatibleSubstitute = options.containerOptions.compatibleSubstitute
+    ) { dockerImageName ->
+      options.containerOptions
+        .useContainerFn(dockerImageName)
+        .withBucket(bucketDefinition)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveCouchbaseContainer }
+        .apply(options.containerOptions.containerFn)
+    }
+  }
+
+  return stove.withCouchbase(key, options, runtime)
+}
+
 suspend fun ValidationDsl.couchbase(
   validation: @CouchbaseDsl suspend CouchbaseSystem.() -> Unit
 ): Unit = validation(this.stove.couchbase())
+
+suspend fun ValidationDsl.couchbase(
+  key: SystemKey,
+  validation: @CouchbaseDsl suspend CouchbaseSystem.() -> Unit
+): Unit = validation(this.stove.couchbase(key))

--- a/lib/stove-elasticsearch/api/stove-elasticsearch.api
+++ b/lib/stove-elasticsearch/api/stove-elasticsearch.api
@@ -69,12 +69,15 @@ public final class com/trendyol/stove/elasticsearch/ElasticSearchExposedConfigur
 }
 
 public final class com/trendyol/stove/elasticsearch/ElasticsearchContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;)Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;ILjava/lang/Object;)Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;Ljava/lang/String;)Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/elasticsearch/ElasticsearchContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/elasticsearch/ElasticsearchSystemOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -148,6 +151,8 @@ public final class com/trendyol/stove/elasticsearch/ElasticsearchSystemOptions$C
 
 public final class com/trendyol/stove/elasticsearch/ExtensionsKt {
 	public static final fun elasticsearch-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun elasticsearch-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun elasticsearch-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun elasticsearch-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/ElasticsearchSystem.kt
+++ b/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/ElasticsearchSystem.kt
@@ -169,10 +169,12 @@ class ElasticsearchSystem internal constructor(
   @PublishedApi
   internal lateinit var esClient: ElasticsearchClient
 
+  override val reportSystemName: String = "Elasticsearch" + (context.keyName?.let { " [$it]" } ?: "")
+
   private lateinit var exposedConfiguration: ElasticSearchExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<ElasticSearchExposedConfiguration> =
-    stove.createStateStorage<ElasticSearchExposedConfiguration, ElasticsearchSystem>()
+    stove.createStateStorage<ElasticSearchExposedConfiguration, ElasticsearchSystem>(context.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/Extensions.kt
+++ b/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/Extensions.kt
@@ -14,9 +14,23 @@ internal fun Stove.withElasticsearch(
   return this
 }
 
+internal fun Stove.withElasticsearch(
+  key: SystemKey,
+  options: ElasticsearchSystemOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, ElasticsearchSystem(this, ElasticsearchContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.elasticsearch(): ElasticsearchSystem =
   getOrNone<ElasticsearchSystem>().getOrElse {
     throw SystemNotRegisteredException(ElasticsearchSystem::class)
+  }
+
+internal fun Stove.elasticsearch(key: SystemKey): ElasticsearchSystem =
+  getOrNone<ElasticsearchSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(ElasticsearchSystem::class, "No ElasticsearchSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -72,5 +86,35 @@ fun WithDsl.elasticsearch(
   return stove.withElasticsearch(options, runtime)
 }
 
+fun WithDsl.elasticsearch(
+  key: SystemKey,
+  configure: @StoveDsl () -> ElasticsearchSystemOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedElasticsearchSystemOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      imageName = options.container.imageWithTag,
+      registry = options.container.registry,
+      compatibleSubstitute = options.container.compatibleSubstitute
+    ) { dockerImageName -> StoveElasticSearchContainer(dockerImageName) }
+      .apply {
+        addExposedPorts(*options.container.exposedPorts.toIntArray())
+        withPassword(options.container.password)
+        if (options.container.disableSecurity) {
+          withEnv("xpack.security.enabled", "false")
+        }
+        withReuse(stove.keepDependenciesRunning)
+        options.container.containerFn(this)
+      }
+  }
+  return stove.withElasticsearch(key, options, runtime)
+}
+
 suspend fun ValidationDsl.elasticsearch(validation: @ElasticDsl suspend ElasticsearchSystem.() -> Unit): Unit =
   validation(this.stove.elasticsearch())
+
+suspend fun ValidationDsl.elasticsearch(key: SystemKey, validation: @ElasticDsl suspend ElasticsearchSystem.() -> Unit): Unit =
+  validation(this.stove.elasticsearch(key))

--- a/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/Options.kt
+++ b/lib/stove-elasticsearch/src/main/kotlin/com/trendyol/stove/elasticsearch/Options.kt
@@ -129,7 +129,8 @@ data class ElasticSearchExposedConfiguration(
 @StoveDsl
 data class ElasticsearchContext(
   val runtime: SystemRuntime,
-  val options: ElasticsearchSystemOptions
+  val options: ElasticsearchSystemOptions,
+  val keyName: String? = null
 )
 
 open class StoveElasticSearchContainer(

--- a/lib/stove-grpc-mock/api/stove-grpc-mock.api
+++ b/lib/stove-grpc-mock/api/stove-grpc-mock.api
@@ -77,6 +77,8 @@ public final class com/trendyol/stove/testing/grpcmock/GrpcMockSystemOptions : c
 
 public final class com/trendyol/stove/testing/grpcmock/GrpcMockSystemOptionsKt {
 	public static final fun grpcMock-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun grpcMock-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun grpcMock-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun grpcMock-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
+++ b/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
@@ -93,7 +93,7 @@ class GrpcMockSystem internal constructor(
   ExposesConfiguration,
   Reports {
   private val logger = LoggerFactory.getLogger(javaClass)
-  override val reportSystemName: String = "gRPC Mock"
+  override val reportSystemName: String = "gRPC Mock" + (ctx.keyName?.let { " [$it]" } ?: "")
 
   private val stubs = ConcurrentHashMap<String, MutableList<Pair<StubKey, StubDefinition>>>()
   private val requestLog: Cache<String, ReceivedRequest> = Caffeine

--- a/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystemOptions.kt
+++ b/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystemOptions.kt
@@ -61,7 +61,8 @@ internal data class GrpcMockContext(
   val afterStubMatched: AfterStubMatched,
   val onRequestReceived: OnRequestReceived,
   val serverBuilder: (ServerBuilder<*>) -> ServerBuilder<*>,
-  val configureExposedConfiguration: (GrpcMockExposedConfiguration) -> List<String>
+  val configureExposedConfiguration: (GrpcMockExposedConfiguration) -> List<String>,
+  val keyName: String? = null
 )
 
 internal fun Stove.withGrpcMock(options: GrpcMockSystemOptions): Stove =
@@ -82,6 +83,25 @@ internal fun Stove.grpcMock(): GrpcMockSystem = getOrNone<GrpcMockSystem>().getO
   throw SystemNotRegisteredException(GrpcMockSystem::class)
 }
 
+internal fun Stove.withGrpcMock(key: SystemKey, options: GrpcMockSystemOptions): Stove =
+  GrpcMockSystem(
+    stove = this,
+    GrpcMockContext(
+      options.port,
+      options.removeStubAfterRequestMatched,
+      options.afterStubMatched,
+      options.onRequestReceived,
+      options.serverBuilder,
+      options.configureExposedConfiguration,
+      keyName = keyDisplayName(key)
+    )
+  ).also { getOrRegister(key, it) }
+    .let { this }
+
+internal fun Stove.grpcMock(key: SystemKey): GrpcMockSystem = getOrNone<GrpcMockSystem>(key).getOrElse {
+  throw SystemNotRegisteredException(GrpcMockSystem::class, "No GrpcMockSystem registered with key '${keyDisplayName(key)}'")
+}
+
 /**
  * Registers the native gRPC mock system with Stove.
  *
@@ -96,6 +116,12 @@ internal fun Stove.grpcMock(): GrpcMockSystem = getOrNone<GrpcMockSystem>().getO
  */
 fun WithDsl.grpcMock(configure: @StoveDsl () -> GrpcMockSystemOptions): Stove =
   this.stove.withGrpcMock(configure())
+
+/**
+ * Registers a keyed gRPC mock system with Stove.
+ */
+fun WithDsl.grpcMock(key: SystemKey, configure: @StoveDsl () -> GrpcMockSystemOptions): Stove =
+  this.stove.withGrpcMock(key, configure())
 
 /**
  * Access the gRPC mock system for stub configuration in tests.
@@ -114,7 +140,12 @@ fun WithDsl.grpcMock(configure: @StoveDsl () -> GrpcMockSystemOptions): Stove =
  */
 suspend fun ValidationDsl.grpcMock(
   validation: @GrpcMockDsl suspend GrpcMockSystem.() -> Unit
-): Stove {
-  validation(stove.grpcMock())
-  return stove
-}
+): Unit = validation(stove.grpcMock())
+
+/**
+ * Access a keyed gRPC mock system for stub configuration in tests.
+ */
+suspend fun ValidationDsl.grpcMock(
+  key: SystemKey,
+  validation: @GrpcMockDsl suspend GrpcMockSystem.() -> Unit
+): Unit = validation(stove.grpcMock(key))

--- a/lib/stove-grpc/api/stove-grpc.api
+++ b/lib/stove-grpc/api/stove-grpc.api
@@ -3,7 +3,8 @@ public abstract interface annotation class com/trendyol/stove/grpc/GrpcDsl : jav
 
 public final class com/trendyol/stove/grpc/GrpcSystem : com/trendyol/stove/reporting/Reports, com/trendyol/stove/system/abstractions/PluggedSystem {
 	public static final field Companion Lcom/trendyol/stove/grpc/GrpcSystem$Companion;
-	public fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/grpc/GrpcSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/grpc/GrpcSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/grpc/GrpcSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun channelWithMetadata (Ljava/util/Map;)Lio/grpc/Channel;
 	public fun close ()V
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -28,6 +29,8 @@ public final class com/trendyol/stove/grpc/GrpcSystem$Companion {
 
 public final class com/trendyol/stove/grpc/GrpcSystemKt {
 	public static final fun grpc-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun grpc-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun grpc-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun grpc-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-grpc/src/main/kotlin/com/trendyol/stove/grpc/GrpcSystem.kt
+++ b/lib/stove-grpc/src/main/kotlin/com/trendyol/stove/grpc/GrpcSystem.kt
@@ -98,11 +98,12 @@ import java.util.concurrent.TimeUnit
 @GrpcDsl
 class GrpcSystem(
   override val stove: Stove,
-  @PublishedApi internal val options: GrpcSystemOptions
+  @PublishedApi internal val options: GrpcSystemOptions,
+  private val keyName: String? = null
 ) : PluggedSystem, Reports {
   private val lazyGrpcChannel = lazy { options.createChannel(options.host, options.port) }
 
-  override val reportSystemName: String = "gRPC"
+  override val reportSystemName: String = "gRPC" + (keyName?.let { " [$it]" } ?: "")
 
   private val lazyWireClientResources = lazy { options.createWireClient(options.host, options.port) }
 
@@ -347,8 +348,17 @@ internal fun Stove.withGrpc(options: GrpcSystemOptions): Stove {
   return this
 }
 
+internal fun Stove.withGrpc(key: SystemKey, options: GrpcSystemOptions): Stove {
+  this.getOrRegister(key, GrpcSystem(this, options, keyName = keyDisplayName(key)))
+  return this
+}
+
 internal fun Stove.grpc(): GrpcSystem = getOrNone<GrpcSystem>().getOrElse {
   throw SystemNotRegisteredException(GrpcSystem::class)
+}
+
+internal fun Stove.grpc(key: SystemKey): GrpcSystem = getOrNone<GrpcSystem>(key).getOrElse {
+  throw SystemNotRegisteredException(GrpcSystem::class, "No GrpcSystem registered with key '${keyDisplayName(key)}'")
 }
 
 /**
@@ -370,6 +380,24 @@ fun WithDsl.grpc(configure: @StoveDsl () -> GrpcSystemOptions): Stove =
   this.stove.withGrpc(configure())
 
 /**
+ * Registers a keyed gRPC client system for testing multiple gRPC services.
+ *
+ * ```kotlin
+ * Stove().with {
+ *     grpc(PaymentService) {
+ *         GrpcSystemOptions(host = "localhost", port = 50051)
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying this gRPC client instance.
+ * @param configure Configuration block returning [GrpcSystemOptions].
+ * @return The test system for fluent chaining.
+ */
+fun WithDsl.grpc(key: SystemKey, configure: @StoveDsl () -> GrpcSystemOptions): Stove =
+  this.stove.withGrpc(key, configure())
+
+/**
  * Executes gRPC assertions within the validation DSL.
  *
  * ```kotlin
@@ -387,3 +415,24 @@ fun WithDsl.grpc(configure: @StoveDsl () -> GrpcSystemOptions): Stove =
 suspend fun ValidationDsl.grpc(
   validation: @GrpcDsl suspend GrpcSystem.() -> Unit
 ): Unit = validation(this.stove.grpc())
+
+/**
+ * Executes gRPC assertions against a keyed gRPC client within the validation DSL.
+ *
+ * ```kotlin
+ * stove {
+ *     grpc(PaymentService) {
+ *         channel<PaymentServiceStub> {
+ *             processPayment(request).status shouldBe "OK"
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying the gRPC client instance.
+ * @param validation The gRPC assertion block.
+ */
+suspend fun ValidationDsl.grpc(
+  key: SystemKey,
+  validation: @GrpcDsl suspend GrpcSystem.() -> Unit
+): Unit = validation(this.stove.grpc(key))

--- a/lib/stove-http/api/stove-http.api
+++ b/lib/stove-http/api/stove-http.api
@@ -29,7 +29,8 @@ public abstract interface annotation class com/trendyol/stove/http/HttpDsl : jav
 
 public final class com/trendyol/stove/http/HttpSystem : com/trendyol/stove/reporting/Reports, com/trendyol/stove/system/abstractions/PluggedSystem {
 	public static final field Companion Lcom/trendyol/stove/http/HttpSystem$Companion;
-	public fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/http/HttpClientSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/http/HttpClientSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/http/HttpClientSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun buildWebSocketUrl (Ljava/lang/String;)Ljava/lang/String;
 	public fun close ()V
 	public final fun configureRequest (Lio/ktor/client/request/HttpRequestBuilder;Ljava/lang/String;Ljava/util/Map;Larrow/core/Option;)V
@@ -79,6 +80,8 @@ public final class com/trendyol/stove/http/HttpSystem$Companion$HeaderConstants 
 
 public final class com/trendyol/stove/http/HttpSystemKt {
 	public static final fun http-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun http-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun httpClient-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun httpClient-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-http/src/main/kotlin/com/trendyol/stove/http/HttpSystem.kt
+++ b/lib/stove-http/src/main/kotlin/com/trendyol/stove/http/HttpSystem.kt
@@ -109,8 +109,17 @@ internal fun Stove.withHttpClient(options: HttpClientSystemOptions): Stove {
   return this
 }
 
+internal fun Stove.withHttpClient(key: SystemKey, options: HttpClientSystemOptions): Stove {
+  this.getOrRegister(key, HttpSystem(this, options, keyName = keyDisplayName(key)))
+  return this
+}
+
 internal fun Stove.http(): HttpSystem = getOrNone<HttpSystem>().getOrElse {
   throw SystemNotRegisteredException(HttpSystem::class)
+}
+
+internal fun Stove.http(key: SystemKey): HttpSystem = getOrNone<HttpSystem>(key).getOrElse {
+  throw SystemNotRegisteredException(HttpSystem::class, "No HttpSystem registered with key '${keyDisplayName(key)}'")
 }
 
 /**
@@ -132,6 +141,24 @@ fun WithDsl.httpClient(configure: @StoveDsl () -> HttpClientSystemOptions): Stov
   this.stove.withHttpClient(configure())
 
 /**
+ * Registers a keyed HTTP client system for testing multiple HTTP services.
+ *
+ * ```kotlin
+ * Stove().with {
+ *     httpClient(PaymentService) {
+ *         HttpClientSystemOptions(baseUrl = "https://payment.internal.com")
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying this HTTP client instance.
+ * @param configure Configuration block returning [HttpClientSystemOptions].
+ * @return The test system for fluent chaining.
+ */
+fun WithDsl.httpClient(key: SystemKey, configure: @StoveDsl () -> HttpClientSystemOptions): Stove =
+  this.stove.withHttpClient(key, configure())
+
+/**
  * Executes HTTP assertions within the validation DSL.
  *
  * ```kotlin
@@ -149,6 +176,27 @@ fun WithDsl.httpClient(configure: @StoveDsl () -> HttpClientSystemOptions): Stov
 suspend fun ValidationDsl.http(
   validation: @HttpDsl suspend HttpSystem.() -> Unit
 ): Unit = validation(this.stove.http())
+
+/**
+ * Executes HTTP assertions against a keyed HTTP client within the validation DSL.
+ *
+ * ```kotlin
+ * stove {
+ *     http(PaymentService) {
+ *         get<Payment>("/payments/123") { payment ->
+ *             payment.amount shouldBe 99.99
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying the HTTP client instance.
+ * @param validation The HTTP assertion block.
+ */
+suspend fun ValidationDsl.http(
+  key: SystemKey,
+  validation: @HttpDsl suspend HttpSystem.() -> Unit
+): Unit = validation(this.stove.http(key))
 
 /**
  * HTTP client system for testing REST APIs.
@@ -292,13 +340,14 @@ suspend fun ValidationDsl.http(
 @HttpDsl
 class HttpSystem(
   override val stove: Stove,
-  @PublishedApi internal val options: HttpClientSystemOptions
+  @PublishedApi internal val options: HttpClientSystemOptions,
+  private val keyName: String? = null
 ) : PluggedSystem,
   Reports {
   @PublishedApi
   internal val ktorHttpClient: io.ktor.client.HttpClient = options.createClient(options.baseUrl)
 
-  override val reportSystemName: String = "HTTP"
+  override val reportSystemName: String = "HTTP" + (keyName?.let { " [$it]" } ?: "")
 
   /**
    * Performs a GET request and asserts on the bodiless response.

--- a/lib/stove-kafka/api/stove-kafka.api
+++ b/lib/stove-kafka/api/stove-kafka.api
@@ -207,12 +207,15 @@ public final class com/trendyol/stove/kafka/KafkaContainerOptions$Companion {
 }
 
 public final class com/trendyol/stove/kafka/KafkaContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/kafka/KafkaSystemOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;)Lcom/trendyol/stove/kafka/KafkaContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/kafka/KafkaContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/KafkaContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;Ljava/lang/String;)Lcom/trendyol/stove/kafka/KafkaContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/kafka/KafkaContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/kafka/KafkaSystemOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/KafkaContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/kafka/KafkaSystemOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -221,6 +224,8 @@ public final class com/trendyol/stove/kafka/KafkaContext {
 
 public final class com/trendyol/stove/kafka/KafkaContextKt {
 	public static final fun kafka-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun kafka-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun kafka-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun kafka-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 
@@ -303,14 +308,15 @@ public final class com/trendyol/stove/kafka/KafkaSystemKt {
 
 public class com/trendyol/stove/kafka/KafkaSystemOptions : com/trendyol/stove/database/migrations/SupportsMigrations, com/trendyol/stove/system/abstractions/ConfiguresExposedConfiguration, com/trendyol/stove/system/abstractions/SystemOptions {
 	public static final field Companion Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;
-	public fun <init> (ZLcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (ZLcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lkotlin/jvm/functions/Function2;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZLcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lkotlin/jvm/functions/Function2;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getBridgeGrpcServerPort ()I
 	public fun getCleanup ()Lkotlin/jvm/functions/Function2;
 	public fun getConfigureExposedConfiguration ()Lkotlin/jvm/functions/Function1;
 	public fun getContainerOptions ()Lcom/trendyol/stove/kafka/KafkaContainerOptions;
 	public fun getListenPublishedMessagesFromStove ()Z
 	public fun getMigrationCollection ()Lcom/trendyol/stove/database/migrations/MigrationCollection;
+	public fun getProperties ()Ljava/util/Map;
 	public fun getSerde ()Lcom/trendyol/stove/serialization/StoveSerde;
 	public fun getTopicSuffixes ()Lcom/trendyol/stove/kafka/TopicSuffixes;
 	public fun getUseEmbeddedKafka ()Z
@@ -320,13 +326,13 @@ public class com/trendyol/stove/kafka/KafkaSystemOptions : com/trendyol/stove/da
 }
 
 public final class com/trendyol/stove/kafka/KafkaSystemOptions$Companion {
-	public final fun provided (Ljava/lang/String;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
-	public static synthetic fun provided$default (Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;Ljava/lang/String;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
+	public final fun provided (Ljava/lang/String;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Ljava/util/Map;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
+	public static synthetic fun provided$default (Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;Ljava/lang/String;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Ljava/util/Map;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
 }
 
 public final class com/trendyol/stove/kafka/ProvidedKafkaSystemOptions : com/trendyol/stove/kafka/KafkaSystemOptions, com/trendyol/stove/system/abstractions/ProvidedSystemOptions {
-	public fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Lcom/trendyol/stove/kafka/TopicSuffixes;ZILcom/trendyol/stove/serialization/StoveSerde;Lorg/apache/kafka/common/serialization/Serializer;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;
 	public fun getProvidedConfig ()Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;
 	public synthetic fun getProvidedConfig ()Lcom/trendyol/stove/system/abstractions/ExposedConfiguration;

--- a/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaContext.kt
+++ b/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaContext.kt
@@ -8,11 +8,16 @@ import com.trendyol.stove.system.annotations.StoveDsl
 
 data class KafkaContext(
   val runtime: SystemRuntime,
-  val options: KafkaSystemOptions
+  val options: KafkaSystemOptions,
+  val keyName: String? = null
 )
 
 internal fun Stove.kafka(): KafkaSystem = getOrNone<KafkaSystem>().getOrElse {
   throw SystemNotRegisteredException(KafkaSystem::class)
+}
+
+internal fun Stove.kafka(key: SystemKey): KafkaSystem = getOrNone<KafkaSystem>(key).getOrElse {
+  throw SystemNotRegisteredException(KafkaSystem::class, "No KafkaSystem registered with key '${keyDisplayName(key)}'")
 }
 
 internal fun Stove.withKafka(
@@ -23,9 +28,23 @@ internal fun Stove.withKafka(
   return this
 }
 
+internal fun Stove.withKafka(
+  key: SystemKey,
+  options: KafkaSystemOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, KafkaSystem(this, KafkaContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 suspend fun ValidationDsl.kafka(
   validation: @StoveDsl suspend KafkaSystem.() -> Unit
 ): Unit = validation(this.stove.kafka())
+
+suspend fun ValidationDsl.kafka(
+  key: SystemKey,
+  validation: @StoveDsl suspend KafkaSystem.() -> Unit
+): Unit = validation(this.stove.kafka(key))
 
 /**
  * Configures Kafka system.
@@ -86,6 +105,50 @@ fun WithDsl.kafka(
     }
   }
   return stove.withKafka(options, runtime)
+}
+
+/**
+ * Configures a keyed Kafka system for testing multiple Kafka instances.
+ *
+ * ```kotlin
+ * Stove().with {
+ *     kafka(PaymentKafka) {
+ *         KafkaSystemOptions(
+ *             configureExposedConfiguration = { cfg -> listOf(...) }
+ *         )
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying this Kafka instance.
+ * @param configure Configuration block returning [KafkaSystemOptions].
+ * @return The test system for fluent chaining.
+ */
+fun WithDsl.kafka(
+  key: SystemKey,
+  configure: () -> KafkaSystemOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = when {
+    options is ProvidedKafkaSystemOptions -> ProvidedRuntime
+
+    options.useEmbeddedKafka -> EmbeddedKafkaRuntime
+
+    else -> withProvidedRegistry(
+      options.containerOptions.imageWithTag,
+      options.containerOptions.registry,
+      options.containerOptions.compatibleSubstitute
+    ) { dockerImageName ->
+      options.containerOptions
+        .useContainerFn(dockerImageName)
+        .withExposedPorts(*options.containerOptions.ports.toTypedArray())
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveKafkaContainer }
+        .apply(options.containerOptions.containerFn)
+    }
+  }
+  return stove.withKafka(key, options, runtime)
 }
 
 /**

--- a/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
+++ b/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
@@ -178,6 +178,7 @@ class KafkaSystem(
   AfterRunAware,
   BeforeRunAware,
   Reports {
+  override val reportSystemName: String = "Kafka" + (context.keyName?.let { " [$it]" } ?: "")
   override fun snapshot(): SystemSnapshot {
     val currentTestId = reporter.currentTestId()
     val store = sink.store
@@ -245,7 +246,7 @@ class KafkaSystem(
   internal lateinit var sink: StoveMessageSink
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<KafkaExposedConfiguration> =
-    stove.createStateStorage<KafkaExposedConfiguration, KafkaSystem>()
+    stove.createStateStorage<KafkaExposedConfiguration, KafkaSystem>(context.keyName)
 
   override suspend fun beforeRun() {
     stoveSerdeRef = context.options.serde
@@ -663,6 +664,7 @@ class KafkaSystem(
     autoCreateTopics: Boolean,
     groupId: String
   ): Properties = Properties().apply {
+    putAll(context.options.properties)
     this[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = exposedConfiguration.bootstrapServers
     this[ConsumerConfig.GROUP_ID_CONFIG] = groupId
     this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = autoOffsetReset
@@ -673,6 +675,7 @@ class KafkaSystem(
 
   private fun createPublisher(config: KafkaExposedConfiguration): KafkaProducer<String, Any> = KafkaProducer(
     buildMap {
+      putAll(context.options.properties)
       put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServers)
       put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java.name)
       put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, context.options.valueSerializer::class.java.name)
@@ -685,10 +688,11 @@ class KafkaSystem(
   )
 
   private fun createAdminClient(config: KafkaExposedConfiguration): Admin = Admin.create(
-    mapOf<String, Any>(
-      AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to config.bootstrapServers,
-      AdminClientConfig.CLIENT_ID_CONFIG to "stove-kafka-admin-client"
-    ).toProperties()
+    buildMap {
+      putAll(context.options.properties)
+      put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServers)
+      put(AdminClientConfig.CLIENT_ID_CONFIG, "stove-kafka-admin-client")
+    }.toProperties()
   )
 
   private suspend fun startGrpcServer(): Server {

--- a/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystemOptions.kt
+++ b/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystemOptions.kt
@@ -57,6 +57,20 @@ open class KafkaSystemOptions(
    */
   open val cleanup: suspend (Admin) -> Unit = {},
   /**
+   * Additional Kafka client properties applied to all internal clients (admin, producer, consumer).
+   * Use this to pass security configs (SASL_SSL, truststore, etc.) when connecting to a secured cluster.
+   *
+   * Example:
+   * ```kotlin
+   * properties = mapOf(
+   *   "security.protocol" to "SASL_SSL",
+   *   "sasl.mechanism" to "PLAIN",
+   *   "sasl.jaas.config" to "...PlainLoginModule required username=\"user\" password=\"pass\";"
+   * )
+   * ```
+   */
+  open val properties: Map<String, Any> = emptyMap(),
+  /**
    * The options for the Kafka system that is exposed to the application.
    */
   override val configureExposedConfiguration: (KafkaExposedConfiguration) -> List<String>
@@ -87,6 +101,7 @@ open class KafkaSystemOptions(
       bridgeGrpcServerPort: Int = stoveKafkaBridgePortDefault.toInt(),
       serde: StoveSerde<Any, ByteArray> = stoveSerdeRef,
       valueSerializer: Serializer<Any> = StoveKafkaValueSerializer(),
+      properties: Map<String, Any> = emptyMap(),
       runMigrations: Boolean = true,
       cleanup: suspend (Admin) -> Unit = {},
       configureExposedConfiguration: (KafkaExposedConfiguration) -> List<String>
@@ -100,6 +115,7 @@ open class KafkaSystemOptions(
       bridgeGrpcServerPort = bridgeGrpcServerPort,
       serde = serde,
       valueSerializer = valueSerializer,
+      properties = properties,
       runMigrations = runMigrations,
       cleanup = cleanup,
       configureExposedConfiguration = configureExposedConfiguration
@@ -122,6 +138,7 @@ class ProvidedKafkaSystemOptions(
   bridgeGrpcServerPort: Int = stoveKafkaBridgePortDefault.toInt(),
   serde: StoveSerde<Any, ByteArray> = stoveSerdeRef,
   valueSerializer: Serializer<Any> = StoveKafkaValueSerializer(),
+  properties: Map<String, Any> = emptyMap(),
   cleanup: suspend (Admin) -> Unit = {},
   /**
    * Whether to run migrations on the external instance.
@@ -136,6 +153,7 @@ class ProvidedKafkaSystemOptions(
   serde = serde,
   valueSerializer = valueSerializer,
   containerOptions = KafkaContainerOptions(),
+  properties = properties,
   cleanup = cleanup,
   configureExposedConfiguration = configureExposedConfiguration
 ),

--- a/lib/stove-mongodb/api/stove-mongodb.api
+++ b/lib/stove-mongodb/api/stove-mongodb.api
@@ -54,12 +54,15 @@ public abstract interface annotation class com/trendyol/stove/mongodb/MongoDsl :
 }
 
 public final class com/trendyol/stove/mongodb/MongodbContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/mongodb/MongodbSystemOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;)Lcom/trendyol/stove/mongodb/MongodbContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/mongodb/MongodbContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;ILjava/lang/Object;)Lcom/trendyol/stove/mongodb/MongodbContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;Ljava/lang/String;)Lcom/trendyol/stove/mongodb/MongodbContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/mongodb/MongodbContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mongodb/MongodbSystemOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/mongodb/MongodbContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/mongodb/MongodbSystemOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -167,6 +170,8 @@ public final class com/trendyol/stove/mongodb/ObjectIdSerializer : com/fasterxml
 
 public final class com/trendyol/stove/mongodb/OptionsKt {
 	public static final fun mongodb-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mongodb-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mongodb-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun mongodb-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-mongodb/src/main/kotlin/com/trendyol/stove/mongodb/MongodbSystem.kt
+++ b/lib/stove-mongodb/src/main/kotlin/com/trendyol/stove/mongodb/MongodbSystem.kt
@@ -158,11 +158,11 @@ class MongodbSystem internal constructor(
   @PublishedApi
   internal lateinit var mongoClient: MongoClient
 
-  override val reportSystemName: String = "MongoDB"
+  override val reportSystemName: String = "MongoDB" + (context.keyName?.let { " [$it]" } ?: "")
   private lateinit var exposedConfiguration: MongodbExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<MongodbExposedConfiguration> =
-    stove.createStateStorage<MongodbExposedConfiguration, MongodbSystem>()
+    stove.createStateStorage<MongodbExposedConfiguration, MongodbSystem>(context.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-mongodb/src/main/kotlin/com/trendyol/stove/mongodb/Options.kt
+++ b/lib/stove-mongodb/src/main/kotlin/com/trendyol/stove/mongodb/Options.kt
@@ -19,7 +19,8 @@ data class MongodbExposedConfiguration(
 @StoveDsl
 data class MongodbContext(
   val runtime: SystemRuntime,
-  val options: MongodbSystemOptions
+  val options: MongodbSystemOptions,
+  val keyName: String? = null
 )
 
 open class StoveMongoContainer(
@@ -55,9 +56,23 @@ internal fun Stove.withMongodb(
   return this
 }
 
+internal fun Stove.withMongodb(
+  key: SystemKey,
+  options: MongodbSystemOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, MongodbSystem(this, MongodbContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.mongodb(): MongodbSystem =
   getOrNone<MongodbSystem>().getOrElse {
     throw SystemNotRegisteredException(MongodbSystem::class)
+  }
+
+internal fun Stove.mongodb(key: SystemKey): MongodbSystem =
+  getOrNone<MongodbSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(MongodbSystem::class, "No MongodbSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -109,6 +124,35 @@ fun WithDsl.mongodb(
   return stove.withMongodb(options, runtime)
 }
 
+fun WithDsl.mongodb(
+  key: SystemKey,
+  configure: () -> MongodbSystemOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedMongodbSystemOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.imageWithTag,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveMongoContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withMongodb(key, options, runtime)
+}
+
 suspend fun ValidationDsl.mongodb(
   validation: @MongoDsl suspend MongodbSystem.() -> Unit
 ): Unit = validation(this.stove.mongodb())
+
+suspend fun ValidationDsl.mongodb(
+  key: SystemKey,
+  validation: @MongoDsl suspend MongodbSystem.() -> Unit
+): Unit = validation(this.stove.mongodb(key))

--- a/lib/stove-mssql/api/stove-mssql.api
+++ b/lib/stove-mssql/api/stove-mssql.api
@@ -1,10 +1,13 @@
 public final class com/trendyol/stove/mssql/MsSqlContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/mssql/MsSqlOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;)Lcom/trendyol/stove/mssql/MsSqlContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/mssql/MsSqlContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;ILjava/lang/Object;)Lcom/trendyol/stove/mssql/MsSqlContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;Ljava/lang/String;)Lcom/trendyol/stove/mssql/MsSqlContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/mssql/MsSqlContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/mssql/MsSqlOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/mssql/MsSqlContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/mssql/MsSqlOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -34,6 +37,8 @@ public final class com/trendyol/stove/mssql/MsSqlOptions$Companion {
 
 public final class com/trendyol/stove/mssql/MsSqlOptionsKt {
 	public static final fun mssql-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mssql-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mssql-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun mssql-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-mssql/src/main/kotlin/com/trendyol/stove/mssql/MsSqlOptions.kt
+++ b/lib/stove-mssql/src/main/kotlin/com/trendyol/stove/mssql/MsSqlOptions.kt
@@ -164,7 +164,8 @@ typealias MsSqlMigration = DatabaseMigration<SqlMigrationContext>
 @StoveDsl
 data class MsSqlContext(
   val runtime: SystemRuntime,
-  val options: MsSqlOptions
+  val options: MsSqlOptions,
+  val keyName: String? = null
 )
 
 internal fun Stove.withMsSql(
@@ -175,9 +176,23 @@ internal fun Stove.withMsSql(
   return this
 }
 
+internal fun Stove.withMsSql(
+  key: SystemKey,
+  options: MsSqlOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, MsSqlSystem(this, MsSqlContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.mssql(): MsSqlSystem =
   getOrNone<MsSqlSystem>().getOrElse {
     throw SystemNotRegisteredException(MsSqlSystem::class)
+  }
+
+internal fun Stove.mssql(key: SystemKey): MsSqlSystem =
+  getOrNone<MsSqlSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(MsSqlSystem::class, "No MsSqlSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -243,6 +258,40 @@ fun WithDsl.mssql(
   return stove.withMsSql(options, runtime)
 }
 
+fun WithDsl.mssql(
+  key: SystemKey,
+  configure: () -> MsSqlOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedMsSqlOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.imageWithTag,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .acceptLicense()
+        .withEnv("MSSQL_USER", options.userName)
+        .withEnv("MSSQL_SA_PASSWORD", options.password)
+        .withEnv("MSSQL_DB", options.databaseName)
+        .withPassword(options.password)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveMsSqlContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withMsSql(key, options, runtime)
+}
+
 suspend fun ValidationDsl.mssql(
   validation: @StoveDsl suspend MsSqlSystem.() -> Unit
 ): Unit = validation(this.stove.mssql())
+
+suspend fun ValidationDsl.mssql(
+  key: SystemKey,
+  validation: @StoveDsl suspend MsSqlSystem.() -> Unit
+): Unit = validation(this.stove.mssql(key))

--- a/lib/stove-mssql/src/main/kotlin/com/trendyol/stove/mssql/MsSqlSystem.kt
+++ b/lib/stove-mssql/src/main/kotlin/com/trendyol/stove/mssql/MsSqlSystem.kt
@@ -23,12 +23,12 @@ class MsSqlSystem internal constructor(
   @PublishedApi
   internal lateinit var sqlOperations: NativeSqlOperations
 
-  override val reportSystemName: String = "MSSQL"
+  override val reportSystemName: String = "MSSQL" + (mssqlContext.keyName?.let { " [$it]" } ?: "")
 
   private lateinit var exposedConfiguration: RelationalDatabaseExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<RelationalDatabaseExposedConfiguration> =
-    stove.createStateStorage<RelationalDatabaseExposedConfiguration, MsSqlSystem>()
+    stove.createStateStorage<RelationalDatabaseExposedConfiguration, MsSqlSystem>(mssqlContext.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-mysql/api/stove-mysql.api
+++ b/lib/stove-mysql/api/stove-mysql.api
@@ -86,6 +86,8 @@ public final class com/trendyol/stove/mysql/MySqlSystem$Companion {
 public final class com/trendyol/stove/mysql/OptionsKt {
 	public static final field DEFAULT_MYSQL_IMAGE_NAME Ljava/lang/String;
 	public static final fun mysql-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mysql-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun mysql-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun mysql-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-mysql/src/main/kotlin/com/trendyol/stove/mysql/MySqlSystem.kt
+++ b/lib/stove-mysql/src/main/kotlin/com/trendyol/stove/mysql/MySqlSystem.kt
@@ -26,12 +26,12 @@ class MySqlSystem internal constructor(
   @PublishedApi
   internal lateinit var sqlOperations: NativeSqlOperations
 
-  override val reportSystemName: String = "MySQL"
+  override val reportSystemName: String = "MySQL" + (mysqlContext.keyName?.let { " [$it]" } ?: "")
 
   private lateinit var exposedConfiguration: RelationalDatabaseExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<RelationalDatabaseExposedConfiguration> =
-    stove.createStateStorage<RelationalDatabaseExposedConfiguration, MySqlSystem>()
+    stove.createStateStorage<RelationalDatabaseExposedConfiguration, MySqlSystem>(mysqlContext.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-mysql/src/main/kotlin/com/trendyol/stove/mysql/Options.kt
+++ b/lib/stove-mysql/src/main/kotlin/com/trendyol/stove/mysql/Options.kt
@@ -144,7 +144,8 @@ typealias MySqlMigration = DatabaseMigration<MySqlMigrationContext>
 
 internal class MySqlContext(
   val runtime: SystemRuntime,
-  val options: MySqlOptions
+  val options: MySqlOptions,
+  val keyName: String? = null
 )
 
 internal fun Stove.withMySql(
@@ -155,9 +156,23 @@ internal fun Stove.withMySql(
   return this
 }
 
+internal fun Stove.withMySql(
+  key: SystemKey,
+  options: MySqlOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, MySqlSystem(this, MySqlContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.mysql(): MySqlSystem =
   getOrNone<MySqlSystem>().getOrElse {
     throw SystemNotRegisteredException(MySqlSystem::class)
+  }
+
+internal fun Stove.mysql(key: SystemKey): MySqlSystem =
+  getOrNone<MySqlSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(MySqlSystem::class, "No MySqlSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -216,5 +231,35 @@ fun WithDsl.mysql(
   return stove.withMySql(options, runtime)
 }
 
+fun WithDsl.mysql(
+  key: SystemKey,
+  configure: () -> MySqlOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedMySqlOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.imageWithTag,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .withDatabaseName(options.databaseName)
+        .withUsername(options.username)
+        .withPassword(options.password)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveMySqlContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withMySql(key, options, runtime)
+}
+
 suspend fun ValidationDsl.mysql(validation: @StoveDsl suspend MySqlSystem.() -> Unit): Unit =
   validation(this.stove.mysql())
+
+suspend fun ValidationDsl.mysql(key: SystemKey, validation: @StoveDsl suspend MySqlSystem.() -> Unit): Unit =
+  validation(this.stove.mysql(key))

--- a/lib/stove-postgres/api/stove-postgres.api
+++ b/lib/stove-postgres/api/stove-postgres.api
@@ -1,6 +1,8 @@
 public final class com/trendyol/stove/postgres/OptionsKt {
 	public static final field DEFAULT_POSTGRES_IMAGE_NAME Ljava/lang/String;
 	public static final fun postgresql-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun postgresql-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun postgresql-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun postgresql-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-postgres/src/main/kotlin/com/trendyol/stove/postgres/Options.kt
+++ b/lib/stove-postgres/src/main/kotlin/com/trendyol/stove/postgres/Options.kt
@@ -141,7 +141,8 @@ typealias PostgresqlMigration = DatabaseMigration<PostgresSqlMigrationContext>
 
 internal class PostgresqlContext(
   val runtime: SystemRuntime,
-  val options: PostgresqlOptions
+  val options: PostgresqlOptions,
+  val keyName: String? = null
 )
 
 internal fun Stove.withPostgresql(
@@ -152,9 +153,23 @@ internal fun Stove.withPostgresql(
   return this
 }
 
+internal fun Stove.withPostgresql(
+  key: SystemKey,
+  options: PostgresqlOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, PostgresqlSystem(this, PostgresqlContext(runtime, options, keyName = keyDisplayName(key))))
+  return this
+}
+
 internal fun Stove.postgresql(): PostgresqlSystem =
   getOrNone<PostgresqlSystem>().getOrElse {
     throw SystemNotRegisteredException(PostgresqlSystem::class)
+  }
+
+internal fun Stove.postgresql(key: SystemKey): PostgresqlSystem =
+  getOrNone<PostgresqlSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(PostgresqlSystem::class, "No PostgresqlSystem registered with key '${keyDisplayName(key)}'")
   }
 
 /**
@@ -213,5 +228,35 @@ fun WithDsl.postgresql(
   return stove.withPostgresql(options, runtime)
 }
 
+fun WithDsl.postgresql(
+  key: SystemKey,
+  configure: () -> PostgresqlOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedPostgresqlOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.imageWithTag,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .withDatabaseName(options.databaseName)
+        .withUsername(options.username)
+        .withPassword(options.password)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StovePostgresqlContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withPostgresql(key, options, runtime)
+}
+
 suspend fun ValidationDsl.postgresql(validation: @StoveDsl suspend PostgresqlSystem.() -> Unit): Unit =
   validation(this.stove.postgresql())
+
+suspend fun ValidationDsl.postgresql(key: SystemKey, validation: @StoveDsl suspend PostgresqlSystem.() -> Unit): Unit =
+  validation(this.stove.postgresql(key))

--- a/lib/stove-postgres/src/main/kotlin/com/trendyol/stove/postgres/PostgresqlSystem.kt
+++ b/lib/stove-postgres/src/main/kotlin/com/trendyol/stove/postgres/PostgresqlSystem.kt
@@ -159,12 +159,12 @@ class PostgresqlSystem internal constructor(
   @PublishedApi
   internal lateinit var sqlOperations: NativeSqlOperations
 
-  override val reportSystemName: String = "PostgreSQL"
+  override val reportSystemName: String = "PostgreSQL" + (postgresContext.keyName?.let { " [$it]" } ?: "")
 
   private lateinit var exposedConfiguration: RelationalDatabaseExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<RelationalDatabaseExposedConfiguration> =
-    stove.createStateStorage<RelationalDatabaseExposedConfiguration, PostgresqlSystem>()
+    stove.createStateStorage<RelationalDatabaseExposedConfiguration, PostgresqlSystem>(postgresContext.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-redis/api/stove-redis.api
+++ b/lib/stove-redis/api/stove-redis.api
@@ -33,12 +33,15 @@ public final class com/trendyol/stove/redis/RedisContainerOptions : com/trendyol
 }
 
 public final class com/trendyol/stove/redis/RedisContext {
-	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;)V
+	public fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public final fun component2 ()Lcom/trendyol/stove/redis/RedisOptions;
-	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;)Lcom/trendyol/stove/redis/RedisContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/redis/RedisContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;ILjava/lang/Object;)Lcom/trendyol/stove/redis/RedisContext;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;Ljava/lang/String;)Lcom/trendyol/stove/redis/RedisContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/redis/RedisContext;Lcom/trendyol/stove/system/abstractions/SystemRuntime;Lcom/trendyol/stove/redis/RedisOptions;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/redis/RedisContext;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/trendyol/stove/redis/RedisOptions;
 	public final fun getRuntime ()Lcom/trendyol/stove/system/abstractions/SystemRuntime;
 	public fun hashCode ()I
@@ -98,6 +101,8 @@ public final class com/trendyol/stove/redis/RedisOptions$Companion {
 
 public final class com/trendyol/stove/redis/RedisOptionsKt {
 	public static final fun redis-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun redis-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun redis-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun redis-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 

--- a/lib/stove-redis/src/main/kotlin/com/trendyol/stove/redis/RedisOptions.kt
+++ b/lib/stove-redis/src/main/kotlin/com/trendyol/stove/redis/RedisOptions.kt
@@ -148,7 +148,8 @@ data class RedisExposedConfiguration(
 @StoveDsl
 data class RedisContext(
   val runtime: SystemRuntime,
-  val options: RedisOptions
+  val options: RedisOptions,
+  val keyName: String? = null
 )
 
 /**
@@ -204,11 +205,43 @@ fun WithDsl.redis(
   return stove.withRedis(options, runtime)
 }
 
+fun WithDsl.redis(
+  key: SystemKey,
+  configure: () -> RedisOptions
+): Stove {
+  val options = configure()
+
+  val runtime: SystemRuntime = if (options is ProvidedRedisOptions) {
+    ProvidedRuntime
+  } else {
+    withProvidedRegistry(
+      options.container.image,
+      options.container.registry,
+      options.container.compatibleSubstitute
+    ) { dockerImageName ->
+      options.container
+        .useContainerFn(dockerImageName)
+        .withCommand("redis-server", "--requirepass", options.password)
+        .withReuse(stove.keepDependenciesRunning)
+        .let { c -> c as StoveRedisContainer }
+        .apply(options.container.containerFn)
+    }
+  }
+  return stove.withRedis(key, options, runtime)
+}
+
 suspend fun ValidationDsl.redis(validation: suspend RedisSystem.() -> Unit): Unit = validation(this.stove.redis())
+
+suspend fun ValidationDsl.redis(key: SystemKey, validation: suspend RedisSystem.() -> Unit): Unit = validation(this.stove.redis(key))
 
 internal fun Stove.redis(): RedisSystem =
   getOrNone<RedisSystem>().getOrElse {
     throw SystemNotRegisteredException(RedisSystem::class)
+  }
+
+internal fun Stove.redis(key: SystemKey): RedisSystem =
+  getOrNone<RedisSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(RedisSystem::class, "No RedisSystem registered with key '${keyDisplayName(key)}'")
   }
 
 internal fun Stove.withRedis(
@@ -216,5 +249,14 @@ internal fun Stove.withRedis(
   runtime: SystemRuntime
 ): Stove {
   getOrRegister(RedisSystem(this, RedisContext(runtime, options)))
+  return this
+}
+
+internal fun Stove.withRedis(
+  key: SystemKey,
+  options: RedisOptions,
+  runtime: SystemRuntime
+): Stove {
+  getOrRegister(key, RedisSystem(this, RedisContext(runtime, options, keyName = keyDisplayName(key))))
   return this
 }

--- a/lib/stove-redis/src/main/kotlin/com/trendyol/stove/redis/RedisSystem.kt
+++ b/lib/stove-redis/src/main/kotlin/com/trendyol/stove/redis/RedisSystem.kt
@@ -132,10 +132,12 @@ class RedisSystem(
   Reports {
   private lateinit var client: RedisClient
 
+  override val reportSystemName: String = "Redis" + (context.keyName?.let { " [$it]" } ?: "")
+
   private lateinit var exposedConfiguration: RedisExposedConfiguration
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val state: StateStorage<RedisExposedConfiguration> =
-    stove.createStateStorage<RedisExposedConfiguration, RedisSystem>()
+    stove.createStateStorage<RedisExposedConfiguration, RedisSystem>(context.keyName)
 
   override suspend fun run() {
     exposedConfiguration = obtainExposedConfiguration()

--- a/lib/stove-wiremock/api/stove-wiremock.api
+++ b/lib/stove-wiremock/api/stove-wiremock.api
@@ -4,6 +4,8 @@ public final class com/trendyol/stove/wiremock/ExtensionsKt {
 
 public final class com/trendyol/stove/wiremock/OptionsKt {
 	public static final fun wiremock-JSkDyPw (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun wiremock-QljV9L8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun wiremock-SscbJ7Y (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/abstractions/SystemKey;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 	public static final fun wiremock-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/Stove;
 }
 
@@ -15,7 +17,8 @@ public final class com/trendyol/stove/wiremock/StubBehaviourBuilder {
 }
 
 public final class com/trendyol/stove/wiremock/WireMockContext {
-	public fun <init> (IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
+	public synthetic fun <init> (IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Z
 	public final fun component3 ()Lkotlin/jvm/functions/Function2;
@@ -23,13 +26,15 @@ public final class com/trendyol/stove/wiremock/WireMockContext {
 	public final fun component5 ()Lcom/trendyol/stove/serialization/StoveSerde;
 	public final fun component6 ()Lkotlin/jvm/functions/Function1;
 	public final fun component7 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/wiremock/WireMockContext;
-	public static synthetic fun copy$default (Lcom/trendyol/stove/wiremock/WireMockContext;IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/wiremock/WireMockContext;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;)Lcom/trendyol/stove/wiremock/WireMockContext;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/wiremock/WireMockContext;IZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/trendyol/stove/serialization/StoveSerde;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)Lcom/trendyol/stove/wiremock/WireMockContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAfterRequest ()Lkotlin/jvm/functions/Function2;
 	public final fun getAfterStubRemoved ()Lkotlin/jvm/functions/Function2;
 	public final fun getConfigure ()Lkotlin/jvm/functions/Function1;
 	public final fun getConfigureExposedConfiguration ()Lkotlin/jvm/functions/Function1;
+	public final fun getKeyName ()Ljava/lang/String;
 	public final fun getPort ()I
 	public final fun getRemoveStubAfterRequestMatched ()Z
 	public final fun getSerde ()Lcom/trendyol/stove/serialization/StoveSerde;

--- a/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/Options.kt
+++ b/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/Options.kt
@@ -81,7 +81,8 @@ data class WireMockContext(
   val afterRequest: AfterRequestHandler,
   val serde: StoveSerde<Any, ByteArray>,
   val configure: WireMockConfiguration.() -> WireMockConfiguration,
-  val configureExposedConfiguration: (WireMockExposedConfiguration) -> List<String>
+  val configureExposedConfiguration: (WireMockExposedConfiguration) -> List<String>,
+  val keyName: String? = null
 )
 
 internal fun Stove.withWireMock(options: WireMockSystemOptions = WireMockSystemOptions()): Stove =
@@ -99,14 +100,74 @@ internal fun Stove.withWireMock(options: WireMockSystemOptions = WireMockSystemO
   ).also { getOrRegister(it) }
     .let { this }
 
+internal fun Stove.withWireMock(key: SystemKey, options: WireMockSystemOptions = WireMockSystemOptions()): Stove =
+  WireMockSystem(
+    stove = this,
+    WireMockContext(
+      options.port,
+      options.removeStubAfterRequestMatched,
+      options.afterStubRemoved,
+      options.afterRequest,
+      options.serde,
+      options.configure,
+      options.configureExposedConfiguration,
+      keyName = keyDisplayName(key)
+    )
+  ).also { getOrRegister(key, it) }
+    .let { this }
+
 internal fun Stove.wiremock(): WireMockSystem =
   getOrNone<WireMockSystem>().getOrElse {
     throw SystemNotRegisteredException(WireMockSystem::class)
+  }
+
+internal fun Stove.wiremock(key: SystemKey): WireMockSystem =
+  getOrNone<WireMockSystem>(key).getOrElse {
+    throw SystemNotRegisteredException(WireMockSystem::class, "No WireMockSystem registered with key '${keyDisplayName(key)}'")
   }
 
 fun WithDsl.wiremock(
   configure: @StoveDsl () -> WireMockSystemOptions
 ): Stove = this.stove.withWireMock(configure())
 
+/**
+ * Registers a keyed WireMock system for testing multiple external service mocks.
+ *
+ * ```kotlin
+ * Stove().with {
+ *     wiremock(PaymentGateway) {
+ *         WireMockSystemOptions(port = 0, configureExposedConfiguration = { cfg -> listOf(...) })
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying this WireMock instance.
+ * @param configure Configuration block returning [WireMockSystemOptions].
+ * @return The test system for fluent chaining.
+ */
+fun WithDsl.wiremock(
+  key: SystemKey,
+  configure: @StoveDsl () -> WireMockSystemOptions
+): Stove = this.stove.withWireMock(key, configure())
+
 suspend fun ValidationDsl.wiremock(validation: @WiremockDsl suspend WireMockSystem.() -> Unit): Unit =
   validation(this.stove.wiremock())
+
+/**
+ * Executes WireMock assertions against a keyed WireMock instance within the validation DSL.
+ *
+ * ```kotlin
+ * stove {
+ *     wiremock(PaymentGateway) {
+ *         mockGet(url = "/status", statusCode = 200)
+ *     }
+ * }
+ * ```
+ *
+ * @param key The [SystemKey] identifying the WireMock instance.
+ * @param validation The WireMock assertion block.
+ */
+suspend fun ValidationDsl.wiremock(
+  key: SystemKey,
+  validation: @WiremockDsl suspend WireMockSystem.() -> Unit
+): Unit = validation(this.stove.wiremock(key))

--- a/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
+++ b/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
@@ -187,6 +187,7 @@ class WireMockSystem(
   RunAware,
   ExposesConfiguration,
   Reports {
+  override val reportSystemName: String = "WireMock" + (ctx.keyName?.let { " [$it]" } ?: "")
   private val stubLog: Cache<UUID, StubMapping> = Caffeine.newBuilder().build()
   private lateinit var exposedConfiguration: WireMockExposedConfiguration
 

--- a/lib/stove/api/stove.api
+++ b/lib/stove/api/stove.api
@@ -765,6 +765,7 @@ public abstract class com/trendyol/stove/system/BridgeSystem : com/trendyol/stov
 	public fun <init> (Lcom/trendyol/stove/system/Stove;)V
 	public fun afterRun (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
+	public final fun ensureContextInitialized ()V
 	public fun executeWithReuseCheck (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun get (Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public fun getByType (Lkotlin/reflect/KType;)Ljava/lang/Object;
@@ -782,6 +783,26 @@ public final class com/trendyol/stove/system/BridgeSystemKt {
 	public static final fun bridge (Lcom/trendyol/stove/system/Stove;)Lcom/trendyol/stove/system/BridgeSystem;
 	public static final fun bridge-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/BridgeSystem;)Lcom/trendyol/stove/system/Stove;
 	public static final fun withBridgeSystem (Lcom/trendyol/stove/system/Stove;Lcom/trendyol/stove/system/BridgeSystem;)Lcom/trendyol/stove/system/Stove;
+}
+
+public final class com/trendyol/stove/system/HealthCheckOptions {
+	public synthetic fun <init> (Ljava/lang/String;JIJLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JIJLjava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-UwyO8pc ()J
+	public final fun component3 ()I
+	public final fun component4-UwyO8pc ()J
+	public final fun component5 ()Ljava/util/Set;
+	public final fun copy-7Q0yyfQ (Ljava/lang/String;JIJLjava/util/Set;)Lcom/trendyol/stove/system/HealthCheckOptions;
+	public static synthetic fun copy-7Q0yyfQ$default (Lcom/trendyol/stove/system/HealthCheckOptions;Ljava/lang/String;JIJLjava/util/Set;ILjava/lang/Object;)Lcom/trendyol/stove/system/HealthCheckOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpectedStatusCodes ()Ljava/util/Set;
+	public final fun getRetries ()I
+	public final fun getRetryDelay-UwyO8pc ()J
+	public final fun getTimeout-UwyO8pc ()J
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/trendyol/stove/system/PortFinder {
@@ -804,6 +825,30 @@ public final class com/trendyol/stove/system/PropertiesFile {
 public final class com/trendyol/stove/system/PropertiesFile$Companion {
 }
 
+public final class com/trendyol/stove/system/ProvidedApplicationOptions {
+	public fun <init> ()V
+	public fun <init> (Lcom/trendyol/stove/system/HealthCheckOptions;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/system/HealthCheckOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/trendyol/stove/system/HealthCheckOptions;
+	public final fun copy (Lcom/trendyol/stove/system/HealthCheckOptions;)Lcom/trendyol/stove/system/ProvidedApplicationOptions;
+	public static synthetic fun copy$default (Lcom/trendyol/stove/system/ProvidedApplicationOptions;Lcom/trendyol/stove/system/HealthCheckOptions;ILjava/lang/Object;)Lcom/trendyol/stove/system/ProvidedApplicationOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHealthCheck ()Lcom/trendyol/stove/system/HealthCheckOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/trendyol/stove/system/ProvidedApplicationUnderTest : com/trendyol/stove/system/abstractions/ApplicationUnderTest {
+	public fun <init> (Lcom/trendyol/stove/system/ProvidedApplicationOptions;)V
+	public fun start (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/trendyol/stove/system/ProvidedApplicationUnderTestKt {
+	public static final fun providedApplication-ypJx7X8 (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;)Lcom/trendyol/stove/system/abstractions/ReadyStove;
+	public static synthetic fun providedApplication-ypJx7X8$default (Lcom/trendyol/stove/system/Stove;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/trendyol/stove/system/abstractions/ReadyStove;
+}
+
 public final class com/trendyol/stove/system/ReportingDsl {
 	public fun <init> (Lcom/trendyol/stove/system/StoveOptionsDsl;)V
 	public final fun disabled ()Lcom/trendyol/stove/system/StoveOptionsDsl;
@@ -820,6 +865,7 @@ public final class com/trendyol/stove/system/Stove : com/trendyol/stove/system/a
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addReportListener (Lcom/trendyol/stove/reporting/ReportEventListener;)V
+	public final fun allRegisteredSystems ()Ljava/util/Collection;
 	public final fun allSystems ()Ljava/util/Collection;
 	public final fun applicationUnderTest (Lcom/trendyol/stove/system/abstractions/ApplicationUnderTest;)Lcom/trendyol/stove/system/Stove;
 	public final fun applicationUnderTestContext ()Ljava/lang/Object;
@@ -827,6 +873,7 @@ public final class com/trendyol/stove/system/Stove : com/trendyol/stove/system/a
 	public final fun endTest ()V
 	public final fun getActiveSystems ()Ljava/util/Map;
 	public final fun getKeepDependenciesRunning ()Z
+	public final fun getKeyedSystems ()Ljava/util/Map;
 	public final fun getOptions ()Lcom/trendyol/stove/system/StoveOptions;
 	public final fun getRunMigrationsAlways ()Z
 	public final fun recordReport (Lcom/trendyol/stove/reporting/ReportEntry;)V
@@ -1006,6 +1053,7 @@ public abstract interface class com/trendyol/stove/system/abstractions/StateStor
 public abstract interface class com/trendyol/stove/system/abstractions/StateStorageFactory {
 	public static final field Companion Lcom/trendyol/stove/system/abstractions/StateStorageFactory$Companion;
 	public fun DefaultStateStorage (Lcom/trendyol/stove/system/StoveOptions;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lcom/trendyol/stove/system/abstractions/StateStorage;
+	public fun createWithKey (Lcom/trendyol/stove/system/StoveOptions;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/trendyol/stove/system/abstractions/StateStorage;
 	public abstract fun invoke (Lcom/trendyol/stove/system/StoveOptions;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lcom/trendyol/stove/system/abstractions/StateStorage;
 }
 
@@ -1015,6 +1063,7 @@ public final class com/trendyol/stove/system/abstractions/StateStorageFactory$Co
 
 public final class com/trendyol/stove/system/abstractions/StateStorageFactory$DefaultImpls {
 	public static fun DefaultStateStorage (Lcom/trendyol/stove/system/abstractions/StateStorageFactory;Lcom/trendyol/stove/system/StoveOptions;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lcom/trendyol/stove/system/abstractions/StateStorage;
+	public static fun createWithKey (Lcom/trendyol/stove/system/abstractions/StateStorageFactory;Lcom/trendyol/stove/system/StoveOptions;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/trendyol/stove/system/abstractions/StateStorage;
 }
 
 public final class com/trendyol/stove/system/abstractions/StateWithProcess {
@@ -1034,12 +1083,20 @@ public final class com/trendyol/stove/system/abstractions/SystemConfigurationExc
 	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;)V
 }
 
+public abstract interface class com/trendyol/stove/system/abstractions/SystemKey {
+}
+
+public final class com/trendyol/stove/system/abstractions/SystemKeyKt {
+	public static final fun keyDisplayName (Lcom/trendyol/stove/system/abstractions/SystemKey;)Ljava/lang/String;
+}
+
 public final class com/trendyol/stove/system/abstractions/SystemNotInitializedException : java/lang/Throwable {
 	public fun <init> (Lkotlin/reflect/KClass;)V
 }
 
 public final class com/trendyol/stove/system/abstractions/SystemNotRegisteredException : java/lang/Throwable {
-	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class com/trendyol/stove/system/abstractions/SystemOptions {

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/BridgeSystem.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/BridgeSystem.kt
@@ -58,6 +58,19 @@ abstract class BridgeSystem<T : Any>(
   }
 
   /**
+   * Checks that the application context has been initialized.
+   * Throws with a clear error message if it hasn't (e.g., when using providedApplication()).
+   */
+  @PublishedApi
+  internal fun ensureContextInitialized() {
+    check(::ctx.isInitialized) {
+      "BridgeSystem context is not initialized. " +
+        "Ensure a JVM starter (springBoot/ktor/micronaut) is configured and Stove.run() has been called. " +
+        "Note: providedApplication() does not support Bridge because the remote application's DI container is not accessible."
+    }
+  }
+
+  /**
    * Resolves a bean of the specified type from the application context.
    * Uses KType to preserve generic type information (e.g., List<PaymentService>).
    *
@@ -76,6 +89,7 @@ abstract class BridgeSystem<T : Any>(
    */
   @Suppress("TooGenericExceptionCaught")
   suspend inline fun <reified D : Any> using(block: suspend D.() -> Unit) {
+    ensureContextInitialized()
     val beanName = D::class.simpleName ?: "Unknown"
     val metadata = mapOf("type" to (D::class.qualifiedName ?: ""))
 
@@ -180,6 +194,7 @@ suspend inline fun <
   > ValidationDsl.using(
   crossinline validation: suspend (T1, T2) -> Unit
 ): Unit = stove.bridge().let { bridge ->
+  bridge.ensureContextInitialized()
   val name1 = T1::class.simpleName ?: "Unknown"
   val name2 = T2::class.simpleName ?: "Unknown"
   val beanNames = "$name1, $name2"
@@ -229,6 +244,7 @@ suspend inline fun <
   > ValidationDsl.using(
   crossinline validation: suspend (T1, T2, T3) -> Unit
 ): Unit = stove.bridge().let { bridge ->
+  bridge.ensureContextInitialized()
   val name1 = T1::class.simpleName ?: "Unknown"
   val name2 = T2::class.simpleName ?: "Unknown"
   val name3 = T3::class.simpleName ?: "Unknown"
@@ -282,6 +298,7 @@ suspend inline fun <
   > ValidationDsl.using(
   crossinline validation: suspend (T1, T2, T3, T4) -> Unit
 ): Unit = stove.bridge().let { bridge ->
+  bridge.ensureContextInitialized()
   val name1 = T1::class.simpleName ?: "Unknown"
   val name2 = T2::class.simpleName ?: "Unknown"
   val name3 = T3::class.simpleName ?: "Unknown"
@@ -339,6 +356,7 @@ suspend inline fun <
   > ValidationDsl.using(
   crossinline validation: suspend (T1, T2, T3, T4, T5) -> Unit
 ): Unit = stove.bridge().let { bridge ->
+  bridge.ensureContextInitialized()
   val name1 = T1::class.simpleName ?: "Unknown"
   val name2 = T2::class.simpleName ?: "Unknown"
   val name3 = T3::class.simpleName ?: "Unknown"

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/ProvidedApplicationUnderTest.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/ProvidedApplicationUnderTest.kt
@@ -1,0 +1,162 @@
+package com.trendyol.stove.system
+
+import com.trendyol.stove.system.abstractions.*
+import com.trendyol.stove.system.annotations.StoveDsl
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+private const val DEFAULT_HEALTH_CHECK_RETRIES = 10
+private const val HTTP_OK = 200
+
+/**
+ * Options for health-checking a remote application before running tests.
+ *
+ * @param url The health check endpoint URL (e.g., "https://staging.myapp.com/actuator/health").
+ * @param timeout Maximum time to wait for the health check to succeed.
+ * @param retries Number of retry attempts before giving up.
+ * @param retryDelay Delay between retry attempts.
+ * @param expectedStatusCodes HTTP status codes considered healthy.
+ */
+data class HealthCheckOptions(
+  val url: String,
+  val timeout: Duration = 30.seconds,
+  val retries: Int = DEFAULT_HEALTH_CHECK_RETRIES,
+  val retryDelay: Duration = 1.seconds,
+  val expectedStatusCodes: Set<Int> = setOf(HTTP_OK)
+) {
+  init {
+    require(url.isNotBlank()) { "Health check URL must not be blank" }
+    require(retries > 0) { "retries must be positive, got $retries" }
+    require(timeout.isPositive()) { "timeout must be positive, got $timeout" }
+    require(!retryDelay.isNegative()) { "retryDelay must not be negative, got $retryDelay" }
+  }
+}
+
+/**
+ * Options for [ProvidedApplicationUnderTest].
+ *
+ * @param healthCheck Optional health check configuration. If provided, Stove will verify
+ *                    the remote application is reachable before running tests.
+ */
+data class ProvidedApplicationOptions(
+  val healthCheck: HealthCheckOptions? = null
+)
+
+/**
+ * A no-op [ApplicationUnderTest] for testing against already-deployed remote applications.
+ *
+ * Use this when the application under test is already running (e.g., deployed to staging/dev)
+ * and you want to write Stove tests against it without starting it locally.
+ *
+ * The application can be written in **any language** (Go, Python, .NET, Rust, Node.js, etc.)
+ * as long as it exposes HTTP/gRPC and uses infrastructure Stove can connect to.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * Stove().with {
+ *     httpClient {
+ *         HttpClientSystemOptions(baseUrl = "https://staging.myapp.com")
+ *     }
+ *     providedApplication {
+ *         ProvidedApplicationOptions(
+ *             healthCheck = HealthCheckOptions(
+ *                 url = "https://staging.myapp.com/actuator/health"
+ *             )
+ *         )
+ *     }
+ * }.run()
+ * ```
+ *
+ * @see ProvidedApplicationOptions
+ * @see HealthCheckOptions
+ */
+@StoveDsl
+class ProvidedApplicationUnderTest(
+  private val options: ProvidedApplicationOptions
+) : ApplicationUnderTest<Unit> {
+  private val logger = LoggerFactory.getLogger(javaClass)
+
+  override suspend fun start(configurations: List<String>) {
+    options.healthCheck?.let { performHealthCheck(it) }
+  }
+
+  override suspend fun stop(): Unit = Unit
+
+  private suspend fun performHealthCheck(healthCheck: HealthCheckOptions) {
+    val client = HttpClient.newBuilder()
+      .connectTimeout(java.time.Duration.ofMillis(healthCheck.timeout.inWholeMilliseconds))
+      .build()
+
+    val request = HttpRequest.newBuilder()
+      .uri(URI.create(healthCheck.url))
+      .GET()
+      .timeout(java.time.Duration.ofMillis(healthCheck.timeout.inWholeMilliseconds))
+      .build()
+
+    var lastException: Exception? = null
+    repeat(healthCheck.retries) { attempt ->
+      try {
+        val response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).await()
+        if (response.statusCode() in healthCheck.expectedStatusCodes) {
+          logger.info("Health check passed for ${healthCheck.url} (status: ${response.statusCode()})")
+          return
+        }
+        lastException = RuntimeException(
+          "Health check returned unexpected status ${response.statusCode()} from ${healthCheck.url}"
+        )
+        logger.warn("Health check attempt ${attempt + 1}/${healthCheck.retries} failed: status ${response.statusCode()}")
+      } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        lastException = e
+        logger.warn("Health check attempt ${attempt + 1}/${healthCheck.retries} failed: ${e.message}")
+      }
+
+      if (attempt < healthCheck.retries - 1) {
+        delay(healthCheck.retryDelay.inWholeMilliseconds)
+      }
+    }
+
+    throw IllegalStateException(
+      "Health check failed after ${healthCheck.retries} attempts for ${healthCheck.url}",
+      lastException
+    )
+  }
+}
+
+/**
+ * Registers a no-op application under test for testing against a remote/already-deployed application.
+ *
+ * HTTP and other system configurations are done separately via their own DSL functions
+ * (`httpClient { }`, `kafka { }`, etc.). This function only signals that the application
+ * is already running and should not be started by Stove.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * Stove().with {
+ *     httpClient { HttpClientSystemOptions(baseUrl = "https://staging.myapp.com") }
+ *     postgresql(AppDb) { PostgresqlOptions.provided(jdbcUrl = "jdbc:...") }
+ *     providedApplication {
+ *         ProvidedApplicationOptions(
+ *             healthCheck = HealthCheckOptions(url = "https://staging.myapp.com/health")
+ *         )
+ *     }
+ * }.run()
+ * ```
+ *
+ * @param configure Configuration block for [ProvidedApplicationOptions]. Defaults to no health check.
+ * @return [ReadyStove] to chain with `.run()`.
+ */
+fun WithDsl.providedApplication(
+  configure: () -> ProvidedApplicationOptions = { ProvidedApplicationOptions() }
+): ReadyStove {
+  this.stove.applicationUnderTest(ProvidedApplicationUnderTest(configure()))
+  return this.stove
+}

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/Stove.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/Stove.kt
@@ -91,6 +91,9 @@ class Stove(
   @PublishedApi
   internal val activeSystems: MutableMap<KClass<*>, PluggedSystem> = mutableMapOf()
 
+  @PublishedApi
+  internal val keyedSystems: MutableMap<Pair<KClass<*>, SystemKey>, PluggedSystem> = mutableMapOf()
+
   private lateinit var applicationUnderTest: ApplicationUnderTest<*>
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
@@ -100,17 +103,24 @@ class Stove(
   internal val reporter: StoveReporter = StoveReporter(isEnabled = options.reportingEnabled)
 
   /**
+   * Returns all registered systems from both default and keyed registrations.
+   * This is the single source of truth used by lifecycle, reporting, and cleanup.
+   */
+  fun allRegisteredSystems(): Collection<PluggedSystem> =
+    activeSystems.values + keyedSystems.values
+
+  /**
    * Returns all registered systems that implement the given type.
-   * Use this instead of accessing [activeSystems] directly.
+   * Includes both default and keyed systems.
    */
   inline fun <reified T> systemsOf(): List<T> =
-    activeSystems.values.filterIsInstance<T>()
+    allRegisteredSystems().filterIsInstance<T>()
 
   /**
    * Returns a read-only snapshot of all registered systems.
    */
   fun allSystems(): Collection<PluggedSystem> =
-    activeSystems.values.toList()
+    allRegisteredSystems()
 
   /**
    * Whether dependencies (containers) should be kept running after tests complete.
@@ -129,6 +139,28 @@ class Stove(
    */
   inline fun <reified TState : ExposedConfiguration, reified TSystem : PluggedSystem> createStateStorage(): StateStorage<TState> =
     options.createStateStorage<TState, TSystem>()
+
+  /**
+   * Creates a keyed state storage for the given system and configuration types.
+   * The key name is included in the storage path to prevent collisions.
+   */
+  inline fun <reified TState : ExposedConfiguration, reified TSystem : PluggedSystem> createStateStorage(
+    key: SystemKey
+  ): StateStorage<TState> =
+    options.stateStorageFactory.createWithKey(options, TSystem::class, TState::class, keyDisplayName(key))
+
+  /**
+   * Creates a state storage with an optional key name for disambiguation.
+   * When keyName is null, behaves identically to the no-arg version.
+   */
+  inline fun <reified TState : ExposedConfiguration, reified TSystem : PluggedSystem> createStateStorage(
+    keyName: String?
+  ): StateStorage<TState> =
+    if (keyName != null) {
+      options.stateStorageFactory.createWithKey(options, TSystem::class, TState::class, keyName)
+    } else {
+      options.createStateStorage<TState, TSystem>()
+    }
 
   /**
    * Registers a listener to receive report events.
@@ -235,24 +267,25 @@ class Stove(
    */
   override suspend fun run() {
     coroutineScope {
-      val beforeRunAwareSystems = activeSystems.map { it.value }.filterIsInstance<BeforeRunAware>()
-      val runAwareSystems = activeSystems.map { it.value }.filterIsInstance<RunAware>()
+      val allSystems = allRegisteredSystems()
 
-      beforeRunAwareSystems.map { async(context = Dispatchers.IO) { it.beforeRun() } }.awaitAll()
-      runAwareSystems.map { async(context = Dispatchers.IO) { it.run() } }.awaitAll()
+      allSystems.filterIsInstance<BeforeRunAware>()
+        .map { async(context = Dispatchers.IO) { it.beforeRun() } }.awaitAll()
+
+      allSystems.filterIsInstance<RunAware>()
+        .map { async(context = Dispatchers.IO) { it.run() } }.awaitAll()
 
       val dependencyConfigurations =
-        activeSystems
-          .map { it.value }
+        allSystems
           .filterIsInstance<ExposesConfiguration>()
           .flatMap { it.configuration() }
 
       applicationUnderTestContext = applicationUnderTest.start(dependencyConfigurations)
 
-      val afterRunAwareSystems = activeSystems.map { it.value }.filterIsInstance<AfterRunAware>()
-      afterRunAwareSystems.map { async(context = Dispatchers.IO) { it.afterRun() } }.awaitAll()
+      allSystems.filterIsInstance<AfterRunAware>()
+        .map { async(context = Dispatchers.IO) { it.afterRun() } }.awaitAll()
 
-      activeSystems.forEach { cleanup.add { it.value.close() } }
+      // Cleanup is handled by registerForDispose — no duplication here
       cleanup.add { applicationUnderTest.stop() }
     }
 
@@ -305,9 +338,28 @@ class Stove(
   } as T
 
   /**
+   * Gets or registers a keyed [PluggedSystem]. Multiple instances of the same system type
+   * can coexist when registered with different [SystemKey]s.
+   *
+   * @see SystemKey
+   */
+  inline fun <reified T : PluggedSystem> getOrRegister(
+    key: SystemKey,
+    system: T
+  ): T = keyedSystems.getOrPut(T::class to key) {
+    registerForDispose(system)
+  } as T
+
+  /**
    * Gets the registered system or returns [None]
    */
   inline fun <reified T : PluggedSystem> getOrNone(): Option<T> = activeSystems.getOrNone(T::class).map { it as T }
+
+  /**
+   * Gets the keyed registered system or returns [None]
+   */
+  inline fun <reified T : PluggedSystem> getOrNone(key: SystemKey): Option<T> =
+    keyedSystems.getOrNone(T::class to key).map { it as T }
 
   fun <T : AutoCloseable> registerForDispose(closeable: T): T {
     cleanup.add { closeable.close() }

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/Exceptions.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/Exceptions.kt
@@ -6,9 +6,11 @@ import kotlin.reflect.KClass
  * @author Oguzhan Soykan
  */
 class SystemNotRegisteredException(
-  system: KClass<*>
+  system: KClass<*>,
+  detail: String? = null
 ) : Throwable(
-  "${system.simpleName} was not registered. Make sure that you registered your service on TestSystem"
+  "${system.simpleName} was not registered. " +
+    (detail ?: "Make sure that you registered your service on TestSystem")
 )
 
 /**

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/StateStorage.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/StateStorage.kt
@@ -20,12 +20,31 @@ interface StateStorage<TState> {
 interface StateStorageFactory {
   operator fun <T : Any> invoke(options: StoveOptions, system: KClass<*>, state: KClass<T>): StateStorage<T>
 
+  /**
+   * Creates a state storage with an optional key name to prevent collisions
+   * when multiple instances of the same system type are registered.
+   * Default implementation delegates to [invoke], ignoring the key.
+   */
+  fun <T : Any> createWithKey(
+    options: StoveOptions,
+    system: KClass<*>,
+    state: KClass<T>,
+    keyName: String?
+  ): StateStorage<T> = invoke(options, system, state)
+
   companion object {
     fun Default(): StateStorageFactory = DefaultStateStorageFactory()
 
     private fun DefaultStateStorageFactory(): StateStorageFactory = object : StateStorageFactory {
       override fun <T : Any> invoke(options: StoveOptions, system: KClass<*>, state: KClass<T>): StateStorage<T> =
         DefaultStateStorage(options, system, state)
+
+      override fun <T : Any> createWithKey(
+        options: StoveOptions,
+        system: KClass<*>,
+        state: KClass<T>,
+        keyName: String?
+      ): StateStorage<T> = FileSystemStorage(options, system, state, keyName)
     }
   }
 
@@ -50,7 +69,8 @@ data class StateWithProcess<TState : Any>(
 internal class FileSystemStorage<TState : Any>(
   val options: StoveOptions,
   val system: KClass<*>,
-  private val state: KClass<TState>
+  private val state: KClass<TState>,
+  private val keyName: String? = null
 ) : StateStorage<TState> {
   private val folderForSystem =
     Paths.get(
@@ -58,7 +78,11 @@ internal class FileSystemStorage<TState : Any>(
       "com.trendyol.stove"
     )
 
-  private val pathForSystem: Path = folderForSystem.resolve("stove-e2e-${system.simpleName!!.lowercase(Locale.getDefault())}.lock")
+  private val pathForSystem: Path = folderForSystem.resolve(
+    "stove-e2e-${system.simpleName!!.lowercase(Locale.ROOT)}" +
+      (keyName?.let { "-${it.replace(UNSAFE_FILENAME_CHARS, "-").lowercase(Locale.ROOT)}" } ?: "") +
+      ".lock"
+  )
   private val j = StoveSerde.jackson.default
   private val l: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/SystemKey.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/system/abstractions/SystemKey.kt
@@ -1,0 +1,40 @@
+package com.trendyol.stove.system.abstractions
+
+/**
+ * Marker interface for typed keys used to register and look up multiple instances of the same system type.
+ *
+ * Define keys as singleton objects:
+ * ```kotlin
+ * object PaymentService : SystemKey
+ * object OrderService : SystemKey
+ * object AnalyticsDb : SystemKey
+ * ```
+ *
+ * Use keys in registration and validation DSLs:
+ * ```kotlin
+ * // Registration
+ * httpClient(PaymentService) { HttpClientSystemOptions(baseUrl = "https://pay.internal") }
+ *
+ * // Validation
+ * http(PaymentService) { get<Payment>("/payments") { ... } }
+ * ```
+ *
+ * A single key can be shared across protocols:
+ * ```kotlin
+ * httpClient(PaymentService) { ... }
+ * grpc(PaymentService) { ... }
+ * ```
+ *
+ * @see com.trendyol.stove.system.Stove.getOrRegister
+ */
+interface SystemKey
+
+internal val UNSAFE_FILENAME_CHARS = Regex("[^a-zA-Z0-9._-]")
+
+/**
+ * Returns a display-safe, filesystem-safe name for a [SystemKey],
+ * with fallbacks for anonymous classes.
+ */
+fun keyDisplayName(key: SystemKey): String =
+  (key::class.simpleName ?: key::class.qualifiedName ?: "anonymous-key-${System.identityHashCode(key)}")
+    .replace(UNSAFE_FILENAME_CHARS, "-")

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/BridgeSystemGuardTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/BridgeSystemGuardTest.kt
@@ -1,0 +1,63 @@
+package com.trendyol.stove.system
+
+import com.trendyol.stove.reporting.StoveTestContext
+import com.trendyol.stove.system.abstractions.PluggedSystem
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KClass
+
+class BridgeSystemGuardTest :
+  FunSpec({
+    test("using throws when context is not initialized") {
+      val stove = Stove()
+      val bridge = UninitializedBridgeSystem(stove)
+      stove.getOrRegister<BridgeSystem<TestCtx>>(bridge)
+      stove.reporter.startTest(StoveTestContext("test-id", "test-name", "spec"))
+
+      val error = shouldThrow<IllegalStateException> {
+        runBlocking {
+          ValidationDsl(stove).using<TestBean> { }
+        }
+      }
+
+      error.message shouldContain "BridgeSystem context is not initialized"
+      error.message shouldContain "providedApplication()"
+    }
+
+    test("using works after context is initialized") {
+      val stove = Stove()
+      val bean = TestBean("hello")
+      val bridge = UninitializedBridgeSystem(stove, mapOf(TestBean::class to bean))
+      stove.getOrRegister<BridgeSystem<TestCtx>>(bridge)
+
+      // Initialize context
+      runBlocking { bridge.afterRun(TestCtx()) }
+
+      stove.reporter.startTest(StoveTestContext("test-id", "test-name", "spec"))
+
+      runBlocking {
+        ValidationDsl(stove).using<TestBean> {
+          value shouldBe "hello"
+        }
+      }
+    }
+  })
+
+private data class TestBean(val value: String)
+
+private class TestCtx
+
+private class UninitializedBridgeSystem(
+  override val stove: Stove,
+  private val beans: Map<KClass<*>, Any> = emptyMap()
+) : BridgeSystem<TestCtx>(stove),
+  PluggedSystem {
+  override fun then(): Stove = stove
+
+  @Suppress("UNCHECKED_CAST")
+  override fun <D : Any> get(klass: KClass<D>): D =
+    beans[klass] as? D ?: error("Missing bean for ${klass.simpleName}")
+}

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/BridgeSystemTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/BridgeSystemTest.kt
@@ -16,6 +16,7 @@ class BridgeSystemTest :
       val serviceA = ServiceA("initial")
       val bridge = TestBridgeSystem(stove, mapOf(ServiceA::class to serviceA))
       stove.getOrRegister<BridgeSystem<TestContext>>(bridge)
+      runBlocking { bridge.afterRun(TestContext()) }
 
       stove.reporter.startTest(StoveTestContext("test-id", "test-name", "spec"))
 
@@ -37,6 +38,7 @@ class BridgeSystemTest :
       val serviceA = ServiceA("initial")
       val bridge = TestBridgeSystem(stove, mapOf(ServiceA::class to serviceA))
       stove.getOrRegister<BridgeSystem<TestContext>>(bridge)
+      runBlocking { bridge.afterRun(TestContext()) }
 
       stove.reporter.startTest(StoveTestContext("test-id", "test-name", "spec"))
 
@@ -67,6 +69,7 @@ class BridgeSystemTest :
         )
       )
       stove.getOrRegister<BridgeSystem<TestContext>>(bridge)
+      runBlocking { bridge.afterRun(TestContext()) }
 
       stove.reporter.startTest(StoveTestContext("test-id", "test-name", "spec"))
 

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/KeyedSystemTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/KeyedSystemTest.kt
@@ -1,0 +1,212 @@
+package com.trendyol.stove.system
+
+import arrow.core.None
+import arrow.core.Some
+import com.trendyol.stove.system.abstractions.*
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import kotlinx.coroutines.runBlocking
+
+private object KeyA : SystemKey
+
+private object KeyB : SystemKey
+
+class KeyedSystemTest :
+  FunSpec({
+    test("keyed getOrRegister stores and returns system") {
+      val stove = Stove()
+      val system = KeyedTestSystem(stove)
+
+      val registered = stove.getOrRegister(KeyA, system)
+
+      registered shouldBeSameInstanceAs system
+    }
+
+    test("keyed getOrRegister returns existing instance for same key") {
+      val stove = Stove()
+      val system1 = KeyedTestSystem(stove)
+      val system2 = KeyedTestSystem(stove)
+
+      val first = stove.getOrRegister(KeyA, system1)
+      val second = stove.getOrRegister(KeyA, system2)
+
+      first shouldBeSameInstanceAs second
+      first shouldBeSameInstanceAs system1
+    }
+
+    test("different keys for same type store different instances") {
+      val stove = Stove()
+      val systemA = KeyedTestSystem(stove)
+      val systemB = KeyedTestSystem(stove)
+
+      val registeredA = stove.getOrRegister(KeyA, systemA)
+      val registeredB = stove.getOrRegister(KeyB, systemB)
+
+      registeredA shouldBeSameInstanceAs systemA
+      registeredB shouldBeSameInstanceAs systemB
+      registeredA shouldBe systemA
+      registeredB shouldBe systemB
+    }
+
+    test("keyed getOrNone returns None when not registered") {
+      val stove = Stove()
+
+      stove.getOrNone<KeyedTestSystem>(KeyA) shouldBe None
+    }
+
+    test("keyed getOrNone returns Some when registered") {
+      val stove = Stove()
+      val system = KeyedTestSystem(stove)
+      stove.getOrRegister(KeyA, system)
+
+      val result = stove.getOrNone<KeyedTestSystem>(KeyA)
+
+      result shouldBe Some(system)
+    }
+
+    test("keyed and default systems coexist independently") {
+      val stove = Stove()
+      val defaultSystem = KeyedTestSystem(stove)
+      val keyedSystem = KeyedTestSystem(stove)
+
+      stove.getOrRegister(defaultSystem)
+      stove.getOrRegister(KeyA, keyedSystem)
+
+      stove.getOrNone<KeyedTestSystem>() shouldBe Some(defaultSystem)
+      stove.getOrNone<KeyedTestSystem>(KeyA) shouldBe Some(keyedSystem)
+    }
+
+    test("allRegisteredSystems includes both default and keyed systems") {
+      val stove = Stove()
+      val defaultSystem = KeyedTestSystem(stove)
+      val keyedSystemA = KeyedTestSystem(stove)
+      val keyedSystemB = KeyedTestSystem(stove)
+
+      stove.getOrRegister(defaultSystem)
+      stove.getOrRegister(KeyA, keyedSystemA)
+      stove.getOrRegister(KeyB, keyedSystemB)
+
+      val all = stove.allRegisteredSystems()
+      all shouldHaveSize 3
+      all.shouldContainAll(defaultSystem, keyedSystemA, keyedSystemB)
+    }
+
+    test("systemsOf returns matching systems from both maps") {
+      val stove = Stove()
+      val defaultSystem = KeyedLifecycleSystem(stove)
+      val keyedSystem = KeyedLifecycleSystem(stove)
+
+      stove.getOrRegister(defaultSystem)
+      stove.getOrRegister(KeyA, keyedSystem)
+
+      val runAwareSystems = stove.systemsOf<RunAware>()
+      runAwareSystems shouldHaveSize 2
+    }
+
+    test("allSystems returns all registered systems") {
+      val stove = Stove()
+      val system1 = KeyedTestSystem(stove)
+      val system2 = KeyedTestSystem(stove)
+
+      stove.getOrRegister(system1)
+      stove.getOrRegister(KeyA, system2)
+
+      stove.allSystems() shouldHaveSize 2
+    }
+
+    test("keyed systems participate in run lifecycle") {
+      val stove = Stove()
+      val defaultSystem = KeyedLifecycleSystem(stove)
+      val keyedSystem = KeyedLifecycleSystem(stove)
+      val app = KeyedTestApp()
+
+      stove.getOrRegister(defaultSystem)
+      stove.getOrRegister(KeyA, keyedSystem)
+      stove.applicationUnderTest(app)
+
+      runBlocking { stove.run() }
+
+      defaultSystem.beforeRunCalled shouldBe true
+      defaultSystem.runCalled shouldBe true
+      defaultSystem.afterRunCalled shouldBe true
+
+      keyedSystem.beforeRunCalled shouldBe true
+      keyedSystem.runCalled shouldBe true
+      keyedSystem.afterRunCalled shouldBe true
+
+      app.started shouldBe true
+      app.receivedConfigs shouldHaveSize 2
+    }
+
+    test("keyed systems contribute configurations") {
+      val stove = Stove()
+      val defaultSystem = KeyedLifecycleSystem(stove, configValue = "default.config=true")
+      val keyedSystem = KeyedLifecycleSystem(stove, configValue = "keyed.config=true")
+      val app = KeyedTestApp()
+
+      stove.getOrRegister(defaultSystem)
+      stove.getOrRegister(KeyA, keyedSystem)
+      stove.applicationUnderTest(app)
+
+      runBlocking { stove.run() }
+
+      app.receivedConfigs.shouldContainAll("default.config=true", "keyed.config=true")
+    }
+  })
+
+private class KeyedTestSystem(
+  override val stove: Stove
+) : PluggedSystem {
+  override fun then(): Stove = stove
+
+  override fun close() = Unit
+}
+
+private class KeyedTestApp : ApplicationUnderTest<String> {
+  var started: Boolean = false
+  var receivedConfigs: List<String> = emptyList()
+
+  override suspend fun start(configurations: List<String>): String {
+    started = true
+    receivedConfigs = configurations
+    return "context"
+  }
+
+  override suspend fun stop() = Unit
+}
+
+private class KeyedLifecycleSystem(
+  override val stove: Stove,
+  private val configValue: String = "system.config=true"
+) : PluggedSystem,
+  BeforeRunAware,
+  RunAware,
+  AfterRunAware,
+  ExposesConfiguration {
+  var beforeRunCalled: Boolean = false
+  var runCalled: Boolean = false
+  var afterRunCalled: Boolean = false
+
+  override suspend fun beforeRun() {
+    beforeRunCalled = true
+  }
+
+  override suspend fun run() {
+    runCalled = true
+  }
+
+  override suspend fun stop() = Unit
+
+  override suspend fun afterRun() {
+    afterRunCalled = true
+  }
+
+  override fun configuration(): List<String> = listOf(configValue)
+
+  override fun then(): Stove = stove
+
+  override fun close() = Unit
+}

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/ProvidedApplicationUnderTestTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/ProvidedApplicationUnderTestTest.kt
@@ -1,0 +1,70 @@
+package com.trendyol.stove.system
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration.Companion.milliseconds
+
+class ProvidedApplicationUnderTestTest :
+  FunSpec({
+    test("start with no health check is a no-op") {
+      val aut = ProvidedApplicationUnderTest(ProvidedApplicationOptions())
+
+      runBlocking { aut.start(listOf("some.config=true")) }
+      // No exception — success
+    }
+
+    test("stop is a no-op") {
+      val aut = ProvidedApplicationUnderTest(ProvidedApplicationOptions())
+
+      runBlocking { aut.stop() }
+      // No exception — success
+    }
+
+    test("configurations are ignored") {
+      val aut = ProvidedApplicationUnderTest(ProvidedApplicationOptions())
+
+      runBlocking {
+        aut.start(
+          listOf(
+            "database.host=localhost",
+            "kafka.bootstrap=localhost:9092"
+          )
+        )
+      }
+      // No exception — configs silently ignored
+    }
+
+    test("health check fails with unreachable URL") {
+      val aut = ProvidedApplicationUnderTest(
+        ProvidedApplicationOptions(
+          healthCheck = HealthCheckOptions(
+            url = "http://localhost:1/nonexistent-health",
+            retries = 2,
+            retryDelay = 50.milliseconds,
+            timeout = 500.milliseconds
+          )
+        )
+      )
+
+      val error = shouldThrow<IllegalStateException> {
+        runBlocking { aut.start(emptyList()) }
+      }
+
+      error.message shouldContain "Health check failed after 2 attempts"
+      error.message shouldContain "nonexistent-health"
+    }
+
+    test("provided application integrates with Stove lifecycle") {
+      val stove = Stove()
+      stove.applicationUnderTest(
+        ProvidedApplicationUnderTest(ProvidedApplicationOptions())
+      )
+
+      runBlocking { stove.run() }
+
+      Stove.instanceInitialized() shouldBe true
+    }
+  })

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/abstractions/StateStorageKeyTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/abstractions/StateStorageKeyTest.kt
@@ -1,0 +1,107 @@
+package com.trendyol.stove.system.abstractions
+
+import com.trendyol.stove.system.StoveOptions
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Paths
+
+class StateStorageKeyTest :
+  FunSpec({
+    test("FileSystemStorage without key uses original path format") {
+      val options = StoveOptions()
+      val storage = FileSystemStorage<TestConfig>(options, TestSystem::class, TestConfig::class)
+      val expectedPath = Paths.get(
+        System.getProperty("java.io.tmpdir"),
+        "com.trendyol.stove",
+        "stove-e2e-testsystem.lock"
+      )
+
+      // Access via reflection to verify path — the class is internal
+      val pathField = storage.javaClass.getDeclaredField("pathForSystem")
+      pathField.isAccessible = true
+      val path = pathField.get(storage) as java.nio.file.Path
+
+      path shouldBe expectedPath
+    }
+
+    test("FileSystemStorage with key includes key in path") {
+      val options = StoveOptions()
+      val storage = FileSystemStorage<TestConfig>(options, TestSystem::class, TestConfig::class, keyName = "AppDb")
+      val expectedPath = Paths.get(
+        System.getProperty("java.io.tmpdir"),
+        "com.trendyol.stove",
+        "stove-e2e-testsystem-appdb.lock"
+      )
+
+      val pathField = storage.javaClass.getDeclaredField("pathForSystem")
+      pathField.isAccessible = true
+      val path = pathField.get(storage) as java.nio.file.Path
+
+      path shouldBe expectedPath
+    }
+
+    test("different keys produce different lock file paths") {
+      val options = StoveOptions()
+      val storageA = FileSystemStorage<TestConfig>(options, TestSystem::class, TestConfig::class, keyName = "AppDb")
+      val storageB =
+        FileSystemStorage<TestConfig>(options, TestSystem::class, TestConfig::class, keyName = "AnalyticsDb")
+
+      val pathField = FileSystemStorage::class.java.getDeclaredField("pathForSystem")
+      pathField.isAccessible = true
+
+      val pathA = pathField.get(storageA) as java.nio.file.Path
+      val pathB = pathField.get(storageB) as java.nio.file.Path
+
+      pathA shouldNotBe pathB
+      pathA.toString() shouldContain "appdb"
+      pathB.toString() shouldContain "analyticsdb"
+    }
+
+    test("StateStorageFactory createWithKey default delegates to invoke") {
+      var invokedWithSystem: Class<*>? = null
+      val factory = object : StateStorageFactory {
+        override fun <T : Any> invoke(
+          options: StoveOptions,
+          system: kotlin.reflect.KClass<*>,
+          state: kotlin.reflect.KClass<T>
+        ): StateStorage<T> {
+          invokedWithSystem = system.java
+          return FileSystemStorage(options, system, state)
+        }
+      }
+
+      factory.createWithKey(StoveOptions(), TestSystem::class, TestConfig::class, "SomeKey")
+
+      invokedWithSystem shouldBe TestSystem::class.java
+    }
+
+    test("DefaultStateStorageFactory createWithKey passes keyName to FileSystemStorage") {
+      val factory = StateStorageFactory.Default()
+      val storage = factory.createWithKey(StoveOptions(), TestSystem::class, TestConfig::class, "MyKey")
+
+      val pathField = storage.javaClass.getDeclaredField("pathForSystem")
+      pathField.isAccessible = true
+      val path = pathField.get(storage) as java.nio.file.Path
+
+      path.toString() shouldContain "mykey"
+    }
+
+    test("DefaultStateStorageFactory createWithKey with null key behaves like no key") {
+      val factory = StateStorageFactory.Default()
+      val storage = factory.createWithKey(StoveOptions(), TestSystem::class, TestConfig::class, null)
+
+      val pathField = storage.javaClass.getDeclaredField("pathForSystem")
+      pathField.isAccessible = true
+      val path = pathField.get(storage) as java.nio.file.Path
+
+      path.fileName.toString() shouldBe "stove-e2e-testsystem.lock"
+      path.fileName.toString() shouldNotContain "-null"
+    }
+  })
+
+private class TestSystem
+
+private data class TestConfig(val value: String = "test") : ExposedConfiguration

--- a/lib/stove/src/test/kotlin/com/trendyol/stove/system/abstractions/SystemKeyTest.kt
+++ b/lib/stove/src/test/kotlin/com/trendyol/stove/system/abstractions/SystemKeyTest.kt
@@ -1,0 +1,37 @@
+package com.trendyol.stove.system.abstractions
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldMatch
+import io.kotest.matchers.string.shouldNotContain
+
+private object PaymentService : SystemKey
+
+private object OrderService : SystemKey
+
+class SystemKeyTest :
+  FunSpec({
+    test("keyDisplayName returns simpleName for named objects") {
+      keyDisplayName(PaymentService) shouldBe "PaymentService"
+      keyDisplayName(OrderService) shouldBe "OrderService"
+    }
+
+    test("keyDisplayName sanitizes invalid filename characters") {
+      val anonymousKey = object : SystemKey {}
+      val name = keyDisplayName(anonymousKey)
+      name shouldNotContain "<"
+      name shouldNotContain ">"
+      name shouldNotContain "/"
+      name shouldNotContain "\\"
+      name shouldMatch Regex("[a-zA-Z0-9._-]+")
+    }
+
+    test("different SystemKey objects have different classes") {
+      PaymentService::class shouldNotBe OrderService::class
+    }
+
+    test("same SystemKey object always returns same class") {
+      PaymentService::class shouldBe PaymentService::class
+    }
+  })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ nav:
     - MySQL: Components/16-mysql.md
     - Cassandra: Components/17-cassandra.md
     - Dashboard: Components/18-dashboard.md
+    - Provided Application: Components/19-provided-application.md
+    - Multiple Systems: Components/20-multiple-systems.md
   - Writing Custom Systems: writing-custom-systems.md
   - Best Practices: best-practices.md
   - Troubleshooting: troubleshooting.md

--- a/starters/spring/stove-spring-kafka/api/stove-spring-kafka.api
+++ b/starters/spring/stove-spring-kafka/api/stove-spring-kafka.api
@@ -128,8 +128,8 @@ public final class com/trendyol/stove/kafka/KafkaSystem$Companion {
 
 public class com/trendyol/stove/kafka/KafkaSystemOptions : com/trendyol/stove/database/migrations/SupportsMigrations, com/trendyol/stove/system/abstractions/ConfiguresExposedConfiguration, com/trendyol/stove/system/abstractions/SystemOptions {
 	public static final field Companion Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaContainerOptions;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCleanup ()Lkotlin/jvm/functions/Function2;
 	public fun getConfigureExposedConfiguration ()Lkotlin/jvm/functions/Function1;
 	public fun getContainerOptions ()Lcom/trendyol/stove/kafka/KafkaContainerOptions;
@@ -137,6 +137,7 @@ public class com/trendyol/stove/kafka/KafkaSystemOptions : com/trendyol/stove/da
 	public fun getMigrationCollection ()Lcom/trendyol/stove/database/migrations/MigrationCollection;
 	public fun getOps ()Lcom/trendyol/stove/kafka/KafkaOps;
 	public fun getPorts ()Ljava/util/List;
+	public fun getProperties ()Ljava/util/Map;
 	public fun getRegistry ()Ljava/lang/String;
 	public synthetic fun migrations (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/database/migrations/SupportsMigrations;
 	public fun migrations (Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/kafka/KafkaSystemOptions;
@@ -144,8 +145,8 @@ public class com/trendyol/stove/kafka/KafkaSystemOptions : com/trendyol/stove/da
 
 public final class com/trendyol/stove/kafka/KafkaSystemOptions$Companion {
 	public final fun getDEFAULT_KAFKA_PORTS ()Ljava/util/List;
-	public final fun provided (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
-	public static synthetic fun provided$default (Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
+	public final fun provided (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Ljava/util/Map;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
+	public static synthetic fun provided$default (Lcom/trendyol/stove/kafka/KafkaSystemOptions$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Ljava/util/Map;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/trendyol/stove/kafka/ProvidedKafkaSystemOptions;
 }
 
 public final class com/trendyol/stove/kafka/KafkaTemplateCompatibilityKt {
@@ -169,8 +170,8 @@ public final class com/trendyol/stove/kafka/OptionsKt {
 }
 
 public final class com/trendyol/stove/kafka/ProvidedKafkaSystemOptions : com/trendyol/stove/kafka/KafkaSystemOptions, com/trendyol/stove/system/abstractions/ProvidedSystemOptions {
-	public fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Ljava/util/Map;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;Ljava/lang/String;Ljava/util/List;Lcom/trendyol/stove/kafka/FallbackTemplateSerde;Lcom/trendyol/stove/kafka/KafkaOps;Lkotlin/jvm/functions/Function2;Ljava/util/Map;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConfig ()Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;
 	public fun getProvidedConfig ()Lcom/trendyol/stove/kafka/KafkaExposedConfiguration;
 	public synthetic fun getProvidedConfig ()Lcom/trendyol/stove/system/abstractions/ExposedConfiguration;

--- a/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
+++ b/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
@@ -360,10 +360,13 @@ class KafkaSystem(
 
   private fun createAdminClient(
     exposedConfiguration: KafkaExposedConfiguration
-  ): Admin = mapOf<String, Any>(
-    AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to exposedConfiguration.bootstrapServers,
-    AdminClientConfig.CLIENT_ID_CONFIG to "stove-kafka-admin-client"
-  ).let { Admin.create(it) }
+  ): Admin = Admin.create(
+    buildMap {
+      putAll(context.options.properties)
+      put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, exposedConfiguration.bootstrapServers)
+      put(AdminClientConfig.CLIENT_ID_CONFIG, "stove-kafka-admin-client")
+    }
+  )
 
   private fun createKafkaTemplate(
     context: ApplicationContext,
@@ -398,11 +401,12 @@ class KafkaSystem(
 
   private fun createFallbackTemplate(exposedConfiguration: KafkaExposedConfiguration): KafkaTemplate<Any, Any> {
     val producerFactory = DefaultKafkaProducerFactory<Any, Any>(
-      mapOf(
-        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to exposedConfiguration.bootstrapServers,
-        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to context.options.fallbackSerde.keySerializer::class.java,
-        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to context.options.fallbackSerde.valueSerializer::class.java
-      )
+      buildMap {
+        putAll(context.options.properties)
+        put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, exposedConfiguration.bootstrapServers)
+        put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, context.options.fallbackSerde.keySerializer::class.java)
+        put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, context.options.fallbackSerde.valueSerializer::class.java)
+      }
     )
     val fallbackTemplate = KafkaTemplate(producerFactory).also {
       it.setProducerListener(getInterceptor())

--- a/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/Options.kt
+++ b/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/Options.kt
@@ -97,6 +97,20 @@ open class KafkaSystemOptions(
    */
   open val cleanup: suspend (Admin) -> Unit = {},
   /**
+   * Additional Kafka client properties applied to all internal clients (admin, fallback producer).
+   * Use this to pass security configs (SASL_SSL, truststore, etc.) when connecting to a secured cluster.
+   *
+   * Example:
+   * ```kotlin
+   * properties = mapOf(
+   *   "security.protocol" to "SASL_SSL",
+   *   "sasl.mechanism" to "PLAIN",
+   *   "sasl.jaas.config" to "...PlainLoginModule required username=\"user\" password=\"pass\";"
+   * )
+   * ```
+   */
+  open val properties: Map<String, Any> = emptyMap(),
+  /**
    * The configuration of the Kafka settings that is exposed to the Application Under Test(AUT).
    */
   override val configureExposedConfiguration: (KafkaExposedConfiguration) -> List<String>
@@ -127,6 +141,7 @@ open class KafkaSystemOptions(
       ports: List<Int> = DEFAULT_KAFKA_PORTS,
       fallbackSerde: FallbackTemplateSerde = FallbackTemplateSerde(),
       ops: KafkaOps = defaultKafkaOps(),
+      properties: Map<String, Any> = emptyMap(),
       runMigrations: Boolean = true,
       cleanup: suspend (Admin) -> Unit = {},
       configureExposedConfiguration: (KafkaExposedConfiguration) -> List<String>
@@ -136,6 +151,7 @@ open class KafkaSystemOptions(
       ports = ports,
       fallbackSerde = fallbackSerde,
       ops = ops,
+      properties = properties,
       runMigrations = runMigrations,
       cleanup = cleanup,
       configureExposedConfiguration = configureExposedConfiguration
@@ -158,6 +174,7 @@ class ProvidedKafkaSystemOptions(
   fallbackSerde: FallbackTemplateSerde = FallbackTemplateSerde(),
   ops: KafkaOps = defaultKafkaOps(),
   cleanup: suspend (Admin) -> Unit = {},
+  properties: Map<String, Any> = emptyMap(),
   /**
    * Whether to run migrations on the external instance.
    */
@@ -170,6 +187,7 @@ class ProvidedKafkaSystemOptions(
   containerOptions = KafkaContainerOptions(),
   ops = ops,
   cleanup = cleanup,
+  properties = properties,
   configureExposedConfiguration = configureExposedConfiguration
 ),
   ProvidedSystemOptions<KafkaExposedConfiguration> {


### PR DESCRIPTION
# feat: add providedApplication() and multiple systems support

## Summary

Two interconnected features for testing against remote/deployed applications and registering multiple instances of the same system type.

### `providedApplication()` — Black-Box Testing

A no-op `ApplicationUnderTest` that replaces framework starters (`springBoot()`, `ktor()`) when the app is already deployed. The application under test can be written in **any language** — Go, Python, .NET, Rust, Node.js — as long as it exposes HTTP/gRPC and uses infrastructure Stove can connect to.

```kotlin
Stove().with {
    httpClient { HttpClientSystemOptions(baseUrl = "https://staging.myapp.com") }
    postgresql(AppDb) { PostgresqlOptions.provided(jdbcUrl = "jdbc:...") }
    providedApplication {
        ProvidedApplicationOptions(
            healthCheck = HealthCheckOptions(url = "https://staging.myapp.com/health")
        )
    }
}.run()
```

- Optional health check with retry/backoff using JDK `HttpClient` (no Ktor dependency in core)
- Uses `sendAsync().await()` and `delay()` — fully coroutine-friendly, no `Thread.sleep`
- `BridgeSystem.using<T>()` throws a clear error explaining why Bridge is unsupported with remote apps
- Guard added to **all** `using()` overloads (1-arg through 5-arg)

### `SystemKey` — Multiple System Instances

Typed keys for registering multiple instances of the same system type. Keys are Kotlin singleton objects — compile-time safe, IDE-discoverable, refactor-friendly.

```kotlin
object OrderService : SystemKey
object PaymentService : SystemKey
object AppDb : SystemKey

Stove().with {
    httpClient { HttpClientSystemOptions(baseUrl = "https://myapp.com") }
    httpClient(OrderService) { HttpClientSystemOptions(baseUrl = "https://order.internal.com") }
    postgresql(AppDb) { PostgresqlOptions.provided(...) }
    providedApplication()
}.run()

// Tests
stove {
    http { postAndExpectJson<OrderResponse>("/orders", ...) { ... } }
    http(OrderService) { getResponse("/api/orders/$id") { ... } }
    postgresql(AppDb) { shouldQuery<Order>("SELECT ...") { ... } }
}
```

## Core Changes

### `Stove.kt`
- `keyedSystems: MutableMap<Pair<KClass<*>, KClass<*>>, PluggedSystem>` — parallel map alongside `activeSystems` for zero breaking changes
- `allRegisteredSystems()` — single source of truth combining both maps, used by lifecycle/reporting/cleanup
- `getOrRegister(key, system)` / `getOrNone<T>(key)` — keyed registration and lookup
- `run()` uses `allRegisteredSystems()` for all lifecycle phases
- `createStateStorage(keyName: String?)` — key-aware state storage to prevent lock file collisions

### `BridgeSystem.kt`
- `ensureContextInitialized()` — `@PublishedApi internal` non-inline guard (avoids inline/protected access conflict)
- Called from all `using()` overloads (1-arg through 5-arg) before resolving beans

### `StateStorage.kt`
- `StateStorageFactory.createWithKey()` — backward-compatible extension with default delegation
- `FileSystemStorage` includes key name in lock file path: `stove-e2e-postgresqlsystem-appdb.lock`

### Context-based `keyName`
- `keyName` lives in context objects (e.g., `PostgresqlContext`, `KafkaContext`, `WireMockContext`) — not on system constructors
- Systems read `reportSystemName` from their context: `"PostgreSQL [AppDb]"`, `"Kafka [PaymentKafka]"`
- HTTP and gRPC keep `keyName` on constructor (no context object — options are user-facing)

### Reporting
- Keyed systems produce distinguishable names: `PostgreSQL [AppDb]` vs `PostgreSQL [AnalyticsDb]`
- Default (unkeyed) systems report unchanged: `PostgreSQL`, `HTTP`, etc.

## Systems with Keyed DSL Support

| Category | Systems |
|----------|---------|
| **Databases** | PostgreSQL, MySQL, MSSQL, MongoDB, Cassandra, Couchbase, Redis, Elasticsearch |
| **Protocol clients** | HTTP Client, gRPC |
| **Messaging** | Kafka (standalone `stove-kafka` only) |
| **Mocking** | WireMock, gRPC Mock |

**Excluded:** Spring Kafka (tied to single Spring app context), Bridge, Tracing, Dashboard (single-instance only)

## Backward Compatibility

- **Zero breaking changes.** Default (unnamed) systems use `activeSystems` exactly as before.
- Keyed systems are additive — stored in `keyedSystems`, only accessed through new overloads.
- `providedApplication()` is opt-in. Existing `springBoot()`/`ktor()` starters unchanged.
- `StateStorageFactory.createWithKey()` has a default implementation that delegates to `invoke()`.
- `SystemNotRegisteredException` gains an optional `detail` parameter with a default.

## Tests

| Test | What it covers |
|------|---------------|
| `KeyedSystemTest` | Keyed registration, lookup, coexistence with defaults, lifecycle participation, config contribution |
| `ProvidedApplicationUnderTestTest` | No-op start/stop, health check failure with retries, Stove lifecycle integration |
| `BridgeSystemGuardTest` | Guard throws before init, works after init |
| `StateStorageKeyTest` | Key-aware lock file paths, different keys produce different paths, backward compat |
| `SystemKeyTest` | Key identity, display name fallback |
| `BridgeSystemTest` (updated) | Existing tests updated to initialize context before `using()` |

All 295 core tests pass. Full compilation succeeds across all modules.

## Documentation

- `docs/Components/19-provided-application.md` — configure, health check, limitations, complete example
- `docs/Components/20-multiple-systems.md` — define keys, configure, write tests, supported systems, reporting
- `docs/Components/index.md` — updated tables, grid cards, and detailed doc links
- `mkdocs.yml` — nav entries added

## Test plan

- [ ] Verify `compileKotlin` and `compileTestKotlin` pass for all modules
- [ ] Verify `:lib:stove:test` passes (295 tests)
- [ ] Verify keyed system registration stores and retrieves independently
- [ ] Verify `providedApplication()` no-ops start/stop correctly
- [ ] Verify health check retries and fails with clear error on unreachable URL
- [ ] Verify `BridgeSystem.using<T>()` throws clear error when context not initialized
- [ ] Verify keyed systems produce distinct `reportSystemName` values
- [ ] Verify keyed systems produce distinct lock file paths via `StateStorage`
- [ ] Verify Spring Kafka has no keyed DSL (reverted)
- [ ] Verify documentation renders correctly in mkdocs
