### PR TITLE
feat(kafka): add publishTombstone and publishRaw to standalone and spring starters

### DIFF
--- a/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/ExampleTest.kt
+++ b/examples/spring-example/src/test/kotlin/com/stove/spring/example/e2e/ExampleTest.kt
@@ -41,6 +41,26 @@ class ExampleTest :
       }
     }
 
+    test("tombstone and raw bytes should be published as-is") {
+      stove {
+        kafka {
+          val key = "tombstone-key-${System.currentTimeMillis()}"
+          val topic = "tombstone.and.raw"
+
+          publishTombstone(topic, key = key)
+          peekPublishedMessages(atLeastIn = 10.seconds, topic = topic) {
+            it.key == key && it.value.isEmpty()
+          }
+
+          val poisonPill = "{not-valid-json!!".toByteArray()
+          publishRaw(topic, poisonPill, key = key.some())
+          peekPublishedMessages(atLeastIn = 10.seconds, topic = topic) {
+            it.key == key && it.value.contentEquals(poisonPill)
+          }
+        }
+      }
+    }
+
     test("should create new product when send product create request from api for the allowed supplier") {
       stove {
         val productCreateRequest = ProductCreateRequest(1L, name = "product name", 99L)

--- a/lib/stove-kafka/ROADMAP.md
+++ b/lib/stove-kafka/ROADMAP.md
@@ -12,7 +12,7 @@ Make stove-kafka the strongest Kafka e2e-testing surface on the JVM by improving
 
 ## Priority order
 
-Current sequence: **D1 (event-driven foundation) ✅ → D2 (observer isolation and wire compatibility) ✅ + B0 (partition correctness) ✅ → C (diagnostics) → B1 (raw/tombstone publishing) → A (assertions, deferred — discuss before starting)**. Semantic observation envelopes and asynchronous batching were reviewed and deliberately not adopted; the existing JVM/Go unary protocol remains the single contract. E-theme differentiators (chaos, schema registry, record & replay) are later bets, picked by audience.
+Current sequence: **D1 (event-driven foundation) ✅ → D2 (observer isolation and wire compatibility) ✅ + B0 (partition correctness) ✅ → B1 (raw/tombstone publishing) ✅ → C (diagnostics) → A (assertions, deferred — discuss before starting)**. Semantic observation envelopes and asynchronous batching were reviewed and deliberately not adopted; the existing JVM/Go unary protocol remains the single contract. E-theme differentiators (chaos, schema registry, record & replay) are later bets, picked by audience.
 
 ---
 
@@ -79,13 +79,17 @@ The duplicate Caffeine stores, polling loop, deserialization helpers, assertion 
 | Consumer-group lag panel | ⬜ | Live `Admin`-fed panel: group state, per-partition lag, rebalance events on the timeline. Assertion API can follow once the data proves useful. |
 | Cross-run trend analytics | ⬜ | `~/.stove-dashboard.db` persists across sessions: track assertion latency vs. timeout per test per run; flag assertions trending toward their timeout (flakiness early warning). |
 
-## Theme B — Publishing fidelity 🚧
+## Theme B — Publishing fidelity ✅
 
 | Item | Status | Notes |
 |---|---|---|
 | Fix `partition: Int = 0` default | ✅ | `publish` now uses the ABI-safe `PARTITION_BY_KEY = -1` sentinel and constructs a record with no explicit partition, allowing Kafka's configured partitioner to decide. Explicit non-negative partitions remain supported and invalid negative values fail early. |
-| `publishTombstone(topic, key)` | ⬜ | Null-value publishing for compacted-topic deletion logic — currently untestable. |
-| `publishRaw(topic, bytes)` | ⬜ | Poison-pill/malformed payloads to make "deserialization failure lands in DLT" a one-liner. |
+| `publishTombstone(topic, key)` | ✅ | Publishes a null-value record for the (mandatory) key. `StoveKafkaValueSerializer` maps null → null so Kafka stores a genuine tombstone, not empty bytes; the bridge observes it as an empty payload, so `peekPublishedMessages` can assert on it. `StoveKafkaValueDeserializer` is now null-safe for consuming tombstones. |
+| `publishRaw(topic, bytes)` | ✅ | Sends bytes to the wire unchanged: `StoveKafkaValueSerializer` passes `ByteArray` through, mirroring the bridge's observation-side passthrough, so observed evidence equals wire bytes. Poison-pill/DLT scenarios are a one-liner. Both new methods share `publish`'s record construction (headers, trace injection, partition sentinel, reporting). Custom value serializers must handle null/`ByteArray` to use these. |
+
+B1 verification: 64 Kafka tests pass in all three modes (container, embedded, provided), including tombstone and raw-bytes round-trips through publish-observation (`peekPublishedMessages`) and an ad-hoc consumer; `apiCheck` passes with additive-only API changes (the serializer/deserializer nullability changes don't alter JVM descriptors) and `spotlessCheck` passes.
+
+B1 parity in `starters/spring/stove-spring-kafka`: same `publishTombstone`/`publishRaw` surface. Tombstones go through the application's own `KafkaTemplate` (so key bytes match regular `publish`; standard serializers map null → null), while raw bytes use a dedicated Stove-owned producer (String keys, `ByteArraySerializer` values) because the application's value serializer would re-encode them. The observation path (`serializeIfNotYet`, `toMetadata`) is now null-safe, recording tombstones as empty payloads like the standalone bridge. Because the typed `shouldBe*` assertions require deserialization, the starter also gained `peekPublished/Consumed/FailedMessages` over the raw observed `MessageProperties` — the assertion surface for tombstone/poison-pill evidence. Verified with starter unit tests plus a spring-example e2e round-trip; both starter API dumps changed additively only.
 
 ## Theme A — Assertion power ⏸ deferred (discuss before starting)
 

--- a/lib/stove-kafka/api/stove-kafka.api
+++ b/lib/stove-kafka/api/stove-kafka.api
@@ -277,6 +277,10 @@ public final class com/trendyol/stove/kafka/KafkaSystem : com/trendyol/stove/rep
 	public static synthetic fun peekPublishedMessages-rnQQ1Ag$default (Lcom/trendyol/stove/kafka/KafkaSystem;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun publish (Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun publish$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun publishRaw (Ljava/lang/String;[BLarrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun publishRaw$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;[BLarrow/core/Option;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun publishTombstone (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun publishTombstone$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILarrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun report (Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeConsumedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
+++ b/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
@@ -336,21 +336,97 @@ class KafkaSystem(
     headers: Map<String, String> = mapOf(),
     partition: Int = PARTITION_BY_KEY,
     testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    action = "Publish to '$topic'",
+    input = Some(message),
+    topic = topic,
+    value = message,
+    key = key.getOrNull(),
+    headers = headers,
+    partition = partition,
+    testCase = testCase
+  )
+
+  /**
+   * Publishes a tombstone — a record with a null value — for [key] to [topic].
+   *
+   * Compacted topics treat a null value as a deletion marker for the key, so this is the way to
+   * exercise an application's compaction/deletion handling. The key is mandatory because a
+   * tombstone without a key deletes nothing.
+   *
+   * Requires a value serializer that maps null to null; the default [StoveKafkaValueSerializer] does.
+   */
+  suspend fun publishTombstone(
+    topic: String,
+    key: String,
+    headers: Map<String, String> = mapOf(),
+    partition: Int = PARTITION_BY_KEY,
+    testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    action = "Publish tombstone to '$topic'",
+    input = None,
+    topic = topic,
+    value = null,
+    key = key,
+    headers = headers,
+    partition = partition,
+    testCase = testCase
+  )
+
+  /**
+   * Publishes [message] to [topic] byte-for-byte, bypassing serialization.
+   *
+   * Intended for malformed/poison-pill payloads — e.g. asserting that a message the application
+   * cannot deserialize lands in the dead-letter topic.
+   *
+   * Requires a value serializer that passes [ByteArray] through unchanged; the default
+   * [StoveKafkaValueSerializer] does.
+   */
+  suspend fun publishRaw(
+    topic: String,
+    message: ByteArray,
+    key: Option<String> = None,
+    headers: Map<String, String> = mapOf(),
+    partition: Int = PARTITION_BY_KEY,
+    testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    action = "Publish raw bytes to '$topic'",
+    input = Some(String(message, Charsets.UTF_8)),
+    topic = topic,
+    value = message,
+    key = key.getOrNull(),
+    headers = headers,
+    partition = partition,
+    testCase = testCase,
+    extraMetadata = mapOf("sizeBytes" to message.size)
+  )
+
+  private suspend fun publishRecord(
+    action: String,
+    input: Option<Any>,
+    topic: String,
+    value: Any?,
+    key: String?,
+    headers: Map<String, String>,
+    partition: Int,
+    testCase: Option<String>,
+    extraMetadata: Map<String, Any> = emptyMap()
   ): KafkaSystem {
     require(partition == PARTITION_BY_KEY || partition >= 0) {
       "partition must be non-negative or PARTITION_BY_KEY"
     }
     report(
-      action = "Publish to '$topic'",
-      input = Some(message),
+      action = action,
+      input = input,
       metadata = buildMap {
-        key.onSome { put("key", it) }
+        key?.let { put("key", it) }
         put("headers", headers)
         put("partition", partition.takeUnless { it == PARTITION_BY_KEY } ?: "partitioner")
+        putAll(extraMetadata)
       }
     ) {
       val selectedPartition = partition.takeUnless { it == PARTITION_BY_KEY }
-      val record = ProducerRecord<String, Any>(topic, selectedPartition, key.getOrNull(), message)
+      val record = ProducerRecord<String, Any>(topic, selectedPartition, key, value)
       headers.forEach { (k, v) -> record.headers().add(k, v.toByteArray()) }
       testCase.map { record.headers().add("testCase", it.toByteArray()) }
       injectTraceHeaders(record)

--- a/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/SerDe.kt
+++ b/lib/stove-kafka/src/main/kotlin/com/trendyol/stove/kafka/SerDe.kt
@@ -7,8 +7,8 @@ import org.apache.kafka.common.serialization.*
 class StoveKafkaValueDeserializer<T : Any> : Deserializer<T> {
   override fun deserialize(
     topic: String,
-    data: ByteArray
-  ): T = stoveSerdeRef.deserialize(data, Any::class.java) as T
+    data: ByteArray?
+  ): T? = data?.let { stoveSerdeRef.deserialize(it, Any::class.java) as T }
 }
 
 class StoveKafkaValueSerializer<T : Any>(
@@ -16,6 +16,14 @@ class StoveKafkaValueSerializer<T : Any>(
 ) : Serializer<T> {
   override fun serialize(
     topic: String,
-    data: T
-  ): ByteArray = serde.serialize(data)
+    data: T?
+  ): ByteArray? = when (data) {
+    // Tombstones serialize to null so Kafka stores a null value, not empty bytes.
+    null -> null
+
+    // Raw payloads go to the wire byte-for-byte, matching the bridge's observation path.
+    is ByteArray -> data
+
+    else -> serde.serialize(data)
+  }
 }

--- a/lib/stove-kafka/src/test/kotlin/com/trendyol/stove/kafka/tests/KafkaSystemTests.kt
+++ b/lib/stove-kafka/src/test/kotlin/com/trendyol/stove/kafka/tests/KafkaSystemTests.kt
@@ -9,11 +9,12 @@ import io.github.nomisRev.kafka.createTopic
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.*
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.*
 import org.apache.kafka.common.utils.Utils
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -96,6 +97,75 @@ class KafkaSystemTests :
           }
 
           consumedPartition shouldBe 1
+        }
+      }
+    }
+
+    test("publishTombstone publishes a null value under the given key") {
+      stove {
+        kafka {
+          val key = randomString()
+          val topic = randomString()
+
+          adminOperations {
+            createTopic(NewTopic(topic, 1, 1))
+          }
+
+          publishTombstone(topic, key = key)
+
+          peekPublishedMessages(topic = topic) {
+            it.key == key && it.value.isEmpty()
+          }
+
+          var consumedKey: String? = null
+          var consumedValue: Any? = "sentinel"
+          consumer<String, Any>(
+            topic = topic,
+            readOnly = false,
+            keyDeserializer = StringDeserializer(),
+            keepConsumingAtLeastFor = 6.seconds,
+            pollTimeout = 250.milliseconds
+          ) { record ->
+            consumedKey = record.key()
+            consumedValue = record.value()
+          }
+
+          consumedKey shouldBe key
+          consumedValue shouldBe null
+        }
+      }
+    }
+
+    test("publishRaw publishes the given bytes unchanged") {
+      stove {
+        kafka {
+          val key = randomString()
+          val topic = randomString()
+          val poisonPill = "{not-valid-json!!".toByteArray()
+
+          adminOperations {
+            createTopic(NewTopic(topic, 1, 1))
+          }
+
+          publishRaw(topic, poisonPill, key = key.some())
+
+          peekPublishedMessages(topic = topic) {
+            it.key == key && it.value.contentEquals(poisonPill)
+          }
+
+          var consumed: ByteArray? = null
+          consumer<String, ByteArray>(
+            topic = topic,
+            readOnly = false,
+            keyDeserializer = StringDeserializer(),
+            valueDeserializer = ByteArrayDeserializer(),
+            keepConsumingAtLeastFor = 6.seconds,
+            pollTimeout = 250.milliseconds
+          ) { record ->
+            consumed = record.value()
+          }
+
+          consumed.shouldNotBeNull().contentEquals(poisonPill) shouldBe true
         }
       }
     }

--- a/starters/spring/stove-spring-kafka/api/stove-spring-kafka.api
+++ b/starters/spring/stove-spring-kafka/api/stove-spring-kafka.api
@@ -104,8 +104,18 @@ public final class com/trendyol/stove/kafka/KafkaSystem : com/trendyol/stove/rep
 	public fun getReporter ()Lcom/trendyol/stove/reporting/StoveReporter;
 	public fun getStove ()Lcom/trendyol/stove/system/Stove;
 	public final fun pause ()Lcom/trendyol/stove/kafka/KafkaSystem;
+	public final fun peekConsumedMessages-rnQQ1Ag (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun peekConsumedMessages-rnQQ1Ag$default (Lcom/trendyol/stove/kafka/KafkaSystem;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun peekFailedMessages-rnQQ1Ag (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun peekFailedMessages-rnQQ1Ag$default (Lcom/trendyol/stove/kafka/KafkaSystem;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun peekPublishedMessages-rnQQ1Ag (JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun peekPublishedMessages-rnQQ1Ag$default (Lcom/trendyol/stove/kafka/KafkaSystem;JLjava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun publish (Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun publish$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/Object;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun publishRaw (Ljava/lang/String;[BLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun publishRaw$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;[BLarrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun publishTombstone (Ljava/lang/String;Ljava/lang/String;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun publishTombstone$default (Lcom/trendyol/stove/kafka/KafkaSystem;Ljava/lang/String;Ljava/lang/String;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun report (Ljava/lang/String;Larrow/core/Option;Larrow/core/Option;Ljava/util/Map;Larrow/core/Option;Larrow/core/Option;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun shouldBeConsumedInternal-dWUq8MI (Lkotlin/reflect/KClass;JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/starters/spring/stove-spring-kafka/build.gradle.kts
+++ b/starters/spring/stove-spring-kafka/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
 
 dependencies {
   testImplementation(libs.kotest.runner.junit6)
+  testImplementation(libs.kafka)
 }

--- a/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/Extensions.kt
+++ b/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/Extensions.kt
@@ -9,13 +9,13 @@ import org.apache.kafka.clients.producer.ProducerRecord
 
 internal fun <K, V> ProducerRecord<K, V>.toMetadata(): MessageMetadata = MessageMetadata(
   this.topic(),
-  this.key().toString(),
+  this.key()?.toString() ?: "",
   this.headers().associate { h -> Pair(h.key(), String(h.value())) }
 )
 
 internal fun <K, V> ConsumerRecord<K, V>.toMetadata(): MessageMetadata = MessageMetadata(
   this.topic(),
-  this.key().toString(),
+  this.key()?.toString() ?: "",
   this.headers().associate { h -> Pair(h.key(), String(h.value())) }
 )
 
@@ -72,7 +72,11 @@ private fun <V> serializeIfNotYet(
   value: V,
   serde: StoveSerde<Any, ByteArray>
 ): ByteArray = when (value) {
+  // Tombstones are observed as empty payloads, matching the standalone bridge's behavior.
+  null -> byteArrayOf()
+
   is ByteArray -> value
+
   else -> serde.serialize(value as Any)
 }
 

--- a/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
+++ b/starters/spring/stove-spring-kafka/src/main/kotlin/com/trendyol/stove/kafka/KafkaSystem.kt
@@ -10,9 +10,11 @@ import com.trendyol.stove.system.*
 import com.trendyol.stove.system.abstractions.*
 import com.trendyol.stove.tracing.TraceContext
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 import org.apache.kafka.clients.admin.*
 import org.apache.kafka.clients.producer.*
 import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.serialization.*
 import org.slf4j.*
 import org.springframework.beans.factory.*
 import org.springframework.context.ApplicationContext
@@ -37,6 +39,24 @@ class KafkaSystem(
   private lateinit var exposedConfiguration: KafkaExposedConfiguration
   private lateinit var admin: Admin
   val getInterceptor: () -> TestSystemKafkaInterceptor<Any, Any> = { applicationContext.getBean() }
+
+  // The application's value serializer would re-encode raw bytes, so publishRaw uses a
+  // Stove-owned producer that writes ByteArray values to the wire unchanged.
+  private val rawKafkaTemplate = lazy {
+    val producerFactory = DefaultKafkaProducerFactory<Any, Any>(
+      buildMap {
+        putAll(context.options.properties)
+        put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, exposedConfiguration.bootstrapServers)
+        put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+        put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer::class.java)
+        put(ProducerConfig.CLIENT_ID_CONFIG, "stove-kafka-raw-producer")
+      }
+    )
+    KafkaTemplate(producerFactory).also {
+      it.setProducerListener(getInterceptor())
+      it.setCloseTimeout(1.seconds.toJavaDuration())
+    }
+  }
 
   override fun snapshot(): SystemSnapshot {
     val currentTestId = reporter.currentTestId()
@@ -118,28 +138,109 @@ class KafkaSystem(
     headers: Map<String, String> = mapOf(),
     serde: Option<StoveSerde<Any, *>> = None,
     testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    template = kafkaTemplate,
+    action = "Publish to '$topic'",
+    input = Some(message),
+    topic = topic,
+    value = message,
+    key = key.getOrNull(),
+    partition = partition,
+    headers = headers,
+    testCase = testCase
+  )
+
+  /**
+   * Publishes a tombstone — a record with a null value — for [key] to [topic].
+   *
+   * Compacted topics treat a null value as a deletion marker for the key, so this is the way to
+   * exercise an application's compaction/deletion handling. The key is mandatory because a
+   * tombstone without a key deletes nothing.
+   *
+   * Sent through the application's KafkaTemplate, so key bytes match regular [publish] calls.
+   * Requires a value serializer that maps null to null; Kafka's and Spring's standard serializers do.
+   */
+  suspend fun publishTombstone(
+    topic: String,
+    key: String,
+    partition: Option<Int> = None,
+    headers: Map<String, String> = mapOf(),
+    testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    template = kafkaTemplate,
+    action = "Publish tombstone to '$topic'",
+    input = None,
+    topic = topic,
+    value = null,
+    key = key,
+    partition = partition,
+    headers = headers,
+    testCase = testCase
+  )
+
+  /**
+   * Publishes [message] to [topic] byte-for-byte, bypassing serialization.
+   *
+   * Intended for malformed/poison-pill payloads — e.g. asserting that a message the application
+   * cannot deserialize is handled by its error path.
+   *
+   * Sent through a dedicated Stove-owned producer (String keys, ByteArray values), because the
+   * application's own value serializer would re-encode the bytes.
+   */
+  suspend fun publishRaw(
+    topic: String,
+    message: ByteArray,
+    key: Option<String> = None,
+    partition: Option<Int> = None,
+    headers: Map<String, String> = mapOf(),
+    testCase: Option<String> = None
+  ): KafkaSystem = publishRecord(
+    template = rawKafkaTemplate.value,
+    action = "Publish raw bytes to '$topic'",
+    input = Some(String(message, Charsets.UTF_8)),
+    topic = topic,
+    value = message,
+    key = key.getOrNull(),
+    partition = partition,
+    headers = headers,
+    testCase = testCase,
+    extraMetadata = mapOf("sizeBytes" to message.size)
+  )
+
+  private suspend fun publishRecord(
+    template: KafkaTemplate<Any, Any>,
+    action: String,
+    input: Option<Any>,
+    topic: String,
+    value: Any?,
+    key: String?,
+    partition: Option<Int>,
+    headers: Map<String, String>,
+    testCase: Option<String>,
+    extraMetadata: Map<String, Any> = emptyMap()
   ): KafkaSystem {
     report(
-      action = "Publish to '$topic'",
-      input = Some(message),
-      metadata = mapOf(
-        "key" to (key.getOrNull() ?: ""),
-        "headers" to headers,
-        "partition" to (partition.getOrNull()?.toString() ?: "")
-      )
+      action = action,
+      input = input,
+      metadata = buildMap {
+        put("key", key ?: "")
+        put("headers", headers)
+        put("partition", partition.getOrNull()?.toString() ?: "")
+        putAll(extraMetadata)
+      }
     ) {
       val record = ProducerRecord<String, Any>(
         topic,
         partition.getOrNull(),
-        key.getOrNull(),
-        message,
+        key,
+        value,
         headers
           .toMutableMap()
           .addTestCase(testCase)
           .addTraceContext(TraceContext.current())
           .map { RecordHeader(it.key, it.value.toByteArray()) }
       )
-      context.options.ops.send(kafkaTemplate, record)
+      context.options.ops.send(template, record)
     }
     return this
   }
@@ -148,6 +249,62 @@ class KafkaSystem(
    * Admin operations for Kafka.
    */
   suspend fun adminOperations(block: suspend Admin.() -> Unit) = block(admin)
+
+  /**
+   * Waits until a published message on [topic] matches [condition] and returns it.
+   *
+   * Works on the raw observed message, so it can assert payloads the typed assertions cannot
+   * deserialize — tombstones (empty [MessageProperties.value]) and [publishRaw] bytes.
+   */
+  suspend fun peekPublishedMessages(
+    atLeastIn: Duration = 5.seconds,
+    topic: String,
+    condition: (MessageProperties) -> Boolean
+  ): MessageProperties = withTimeout(atLeastIn) {
+    getInterceptor()
+      .getStore()
+      .core
+      .publishedRecords()
+      .mapNotNull { it.source as? StoveMessage.Published }
+      .filter { it.topic == topic }
+      .first { condition(it) }
+  }
+
+  /**
+   * Waits until a consumed message on [topic] matches [condition] and returns it.
+   */
+  suspend fun peekConsumedMessages(
+    atLeastIn: Duration = 5.seconds,
+    topic: String,
+    condition: (MessageProperties) -> Boolean
+  ): MessageProperties = withTimeout(atLeastIn) {
+    getInterceptor()
+      .getStore()
+      .core
+      .consumedRecords()
+      .mapNotNull { it.source as? StoveMessage.Consumed }
+      .filter { it.topic == topic }
+      .first { condition(it) }
+  }
+
+  /**
+   * Waits until a failed message on [topic] matches [condition] and returns it.
+   *
+   * Useful for poison-pill scenarios where the payload cannot be deserialized to any type.
+   */
+  suspend fun peekFailedMessages(
+    atLeastIn: Duration = 5.seconds,
+    topic: String,
+    condition: (MessageProperties) -> Boolean
+  ): MessageProperties = withTimeout(atLeastIn) {
+    getInterceptor()
+      .getStore()
+      .core
+      .failedRecords()
+      .mapNotNull { it.source as? StoveMessage.Failed }
+      .filter { it.topic == topic }
+      .first { condition(it) }
+  }
 
   /**
    * Asserts that a message is consumed.
@@ -278,6 +435,7 @@ class KafkaSystem(
   override fun close(): Unit = runBlocking {
     Try {
       context.options.cleanup(admin)
+      if (rawKafkaTemplate.isInitialized()) rawKafkaTemplate.value.destroy()
       kafkaTemplate.destroy()
       executeWithReuseCheck { stop() }
     }.recover {

--- a/starters/spring/stove-spring-kafka/src/test/kotlin/com/trendyol/stove/kafka/ExtensionsTests.kt
+++ b/starters/spring/stove-spring-kafka/src/test/kotlin/com/trendyol/stove/kafka/ExtensionsTests.kt
@@ -1,11 +1,49 @@
 package com.trendyol.stove.kafka
 
 import arrow.core.*
+import com.trendyol.stove.serialization.StoveSerde
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
 
 class ExtensionsTests :
   FunSpec({
+    val serde = StoveSerde.jackson.anyByteArraySerde()
+
+    test("toStoveMessage observes a tombstone producer record as an empty payload") {
+      val record = ProducerRecord<String, Any?>("topic", null, "key-1", null)
+
+      val message = record.toStoveMessage(serde)
+
+      message.value.size shouldBe 0
+      message.key shouldBe "key-1"
+      message.topic shouldBe "topic"
+    }
+
+    test("toStoveMessage observes a tombstone consumer record as an empty payload") {
+      val record = ConsumerRecord<String, Any?>("topic", 0, 42L, "key-1", null)
+
+      val message = record.toStoveMessage(serde)
+
+      message.value.size shouldBe 0
+      message.offset shouldBe 42L
+    }
+
+    test("toStoveMessage passes raw ByteArray values through unchanged") {
+      val poisonPill = "{not-valid-json!!".toByteArray()
+      val record = ProducerRecord<String, Any?>("topic", null, "key-1", poisonPill)
+
+      val message = record.toStoveMessage(serde)
+
+      message.value.contentEquals(poisonPill) shouldBe true
+    }
+
+    test("toMetadata tolerates records without a key") {
+      val record = ProducerRecord<String, Any?>("topic", null, null, "value")
+
+      record.toMetadata().key shouldBe ""
+    }
 
     test("addTestCase should add testCase to map when not present") {
       val map = mutableMapOf<String, String>("existingKey" to "existingValue")


### PR DESCRIPTION
Standalone lib/stove-kafka (roadmap B1):
- publishTombstone(topic, key) publishes a null-value record for compacted-topic deletion logic; publishRaw(topic, bytes) sends poison-pill payloads to the wire byte-for-byte
- StoveKafkaValueSerializer maps null -> null (genuine tombstone) and passes ByteArray through unchanged, matching the bridge's observation-side serialization; StoveKafkaValueDeserializer is null-safe for consuming tombstones
- both methods share publish's record construction (headers, trace injection, partition sentinel, reporting)

Spring starter stove-spring-kafka:
- same publishTombstone/publishRaw surface; tombstones go through the application's KafkaTemplate so key bytes match regular publish calls, raw bytes use a dedicated Stove-owned producer (String keys, ByteArraySerializer values) because the application's value serializer would re-encode them
- new peekPublished/Consumed/FailedMessages over MessageProperties: the typed shouldBe* assertions require deserialization, so they can never match tombstones or poison pills
- observation path made null-safe: serializeIfNotYet records tombstones as empty payloads instead of throwing, toMetadata tolerates null keys

Verified: 64 standalone Kafka tests pass in container, embedded, and provided modes; starter unit tests 27/27; spring-example e2e 32/32 with a new tombstone/raw round-trip; spring-4x-example 3/3; apiCheck (additive-only) and spotlessCheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing Kafka tombstone messages for keyed deletions.
  * Added raw byte publishing that preserves payloads exactly, including non-JSON data.
  * Added message inspection APIs for published, consumed, and failed records.
  * Improved handling of null keys and tombstone messages in message metadata and observations.

* **Tests**
  * Added coverage for tombstone publishing, raw byte preservation, and related message inspection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->