### PR TITLE
Correlate retried assertions in dashboard reports

### DIFF
--- a/lib/stove-dashboard/src/main/kotlin/com/trendyol/stove/dashboard/DashboardSystem.kt
+++ b/lib/stove-dashboard/src/main/kotlin/com/trendyol/stove/dashboard/DashboardSystem.kt
@@ -34,6 +34,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -70,11 +71,10 @@ class DashboardSystem(
   private val testFailures = ConcurrentHashMap<String, String>()
   private val failureSnapshotTaken = ConcurrentHashMap.newKeySet<String>()
   private var mockDiagnosticListenersRegistered = false
+  private val acceptingEvents = AtomicBoolean(false)
 
   override suspend fun run() {
     emitter = DashboardEmitter(options.cliHost, options.cliPort)
-    stove.addReportListener(this)
-    registerSpanListener()
     startTime = Instant.now()
     emitter.tryEmit(
       dashboardEvent {
@@ -90,6 +90,9 @@ class DashboardSystem(
           .build()
       }
     )
+    acceptingEvents.set(true)
+    stove.addReportListener(this)
+    registerSpanListener()
     registerMockDiagnosticListeners()
   }
 
@@ -98,61 +101,75 @@ class DashboardSystem(
   }
 
   override fun onTestStarted(ctx: StoveTestContext) {
-    totalTests++
-    testStartTimes[ctx.testId] = Instant.now()
-    emitter.tryEmit(
-      dashboardEvent {
-        testStarted = TestStartedEvent.newBuilder()
-          .setTestId(ctx.testId)
-          .setTestName(ctx.testName)
-          .setSpecName(ctx.specName ?: "")
-          .setTimestamp(now())
-          .addAllTestPath(ctx.testPath)
-          .build()
-      }
-    )
+    lifecycleLock.withLock {
+      if (!acceptingEvents.get()) return
+      totalTests++
+      testStartTimes[ctx.testId] = Instant.now()
+      emitter.tryEmit(
+        dashboardEvent {
+          testStarted = TestStartedEvent.newBuilder()
+            .setTestId(ctx.testId)
+            .setTestName(ctx.testName)
+            .setSpecName(ctx.specName ?: "")
+            .setTimestamp(now())
+            .addAllTestPath(ctx.testPath)
+            .build()
+        }
+      )
+    }
   }
 
   override fun onTestFailed(testId: String, error: String) {
-    testFailures[testId] = error
+    lifecycleLock.withLock {
+      if (!acceptingEvents.get() || !testStartTimes.containsKey(testId)) return
+      testFailures[testId] = error
+    }
   }
 
   override fun onTestEnded(testId: String) {
     lifecycleLock.withLock {
+      if (!acceptingEvents.get()) return
       finishTestIfOpen(testId)
     }
   }
 
   override fun onEntryRecorded(entry: ReportEntry) {
-    emitter.tryEmit(
-      dashboardEvent {
-        entryRecorded = EntryRecordedEvent.newBuilder()
-          .setTestId(entry.testId)
-          .setTimestamp(now())
-          .setSystem(entry.system)
-          .setAction(entry.action)
-          .setResult(entry.result.name)
-          .setInput(entry.input.getOrElse { "" }.toString())
-          .setOutput(entry.output.getOrElse { "" }.toString())
-          .putAllMetadata(entry.metadata.mapValues { it.value.toString() })
-          .setExpected(entry.expected.getOrElse { "" }.toString())
-          .setActual(entry.actual.getOrElse { "" }.toString())
-          .setError(entry.error.getOrElse { "" })
-          .setTraceId(entry.traceId.getOrElse { "" })
-          .build()
+    val shouldCaptureFailureSnapshot = lifecycleLock.withLock {
+      if (!acceptingEvents.get() || !testStartTimes.containsKey(entry.testId)) {
+        return@withLock false
       }
-    )
-    if (entry.isFailed) {
-      testFailures.putIfAbsent(entry.testId, entry.error.getOrElse { "Assertion failed" })
-      // State at the moment of failure genuinely differs from state at test end
-      // (stubs get consumed, cleanup runs); capture the failing system once per test.
-      if (failureSnapshotTaken.add(entry.testId)) {
-        emitSnapshots(entry.testId, trigger = TRIGGER_FAILURE) { it.reportSystemName == entry.system }
+      emitter.tryEmit(
+        dashboardEvent {
+          entryRecorded = EntryRecordedEvent.newBuilder()
+            .setTestId(entry.testId)
+            .setTimestamp(entry.timestamp.toTimestamp())
+            .setSystem(entry.system)
+            .setAction(entry.action)
+            .setResult(entry.result.name)
+            .setInput(entry.input.getOrElse { "" }.toString())
+            .setOutput(entry.output.getOrElse { "" }.toString())
+            .putAllMetadata(entry.metadata.mapValues { it.value.toString() })
+            .setExpected(entry.expected.getOrElse { "" }.toString())
+            .setActual(entry.actual.getOrElse { "" }.toString())
+            .setError(entry.error.getOrElse { "" })
+            .setTraceId(entry.traceId.getOrElse { "" })
+            .build()
+        }
+      )
+      entry.isFailed && failureSnapshotTaken.add(entry.testId)
+    }
+    if (shouldCaptureFailureSnapshot) {
+      // Entry failures are attempt-level diagnostics. The test framework's terminal
+      // callback is the only authority for the test status, so an `eventually` retry
+      // can fail here and still finish as a passed test.
+      emitSnapshots(entry.testId, trigger = TRIGGER_FAILURE) {
+        it.reportSystemName == entry.system
       }
     }
   }
 
   override fun onInteraction(interaction: MockInteraction) {
+    if (!acceptingEvents.get()) return
     emitter.tryEmit(
       dashboardEvent {
         mockInteraction = MockInteractionEvent.newBuilder()
@@ -185,6 +202,7 @@ class DashboardSystem(
   }
 
   override fun onWarning(warning: MockWarning) {
+    if (!acceptingEvents.get()) return
     emitter.tryEmit(
       dashboardEvent {
         mockWarning = MockWarningEvent.newBuilder()
@@ -208,6 +226,7 @@ class DashboardSystem(
   }
 
   override fun onSpanRecorded(span: SpanInfo) {
+    if (!acceptingEvents.get()) return
     emitter.tryEmit(
       dashboardEvent {
         spanRecorded = SpanRecordedEvent.newBuilder()
@@ -236,7 +255,8 @@ class DashboardSystem(
 
   override fun close() {
     lifecycleLock.withLock {
-      if (!::emitter.isInitialized) return
+      if (!::emitter.isInitialized || !acceptingEvents.compareAndSet(true, false)) return
+      stove.removeReportListener(this)
       removeMockDiagnosticListeners()
       finalizeOpenTests()
       val duration = Duration.between(startTime, Instant.now()).toMillis()
@@ -251,7 +271,6 @@ class DashboardSystem(
             .build()
         }
       )
-      stove.removeReportListener(this)
       emitter.close()
     }
   }
@@ -260,36 +279,41 @@ class DashboardSystem(
     val stillRunning = testStartTimes.keys.toList()
     stillRunning.forEach { testId ->
       logger.debug("Finalizing still-running test {} during dashboard shutdown", testId)
-      finishTestIfOpen(testId)
+      finishTestIfOpen(testId, interrupted = true)
     }
   }
 
-  private fun finishTestIfOpen(testId: String) {
+  private fun finishTestIfOpen(testId: String, interrupted: Boolean = false) {
     val startedAt = testStartTimes.remove(testId) ?: run {
       logger.debug("Ignoring duplicate or late test end for {}", testId)
       return
     }
 
+    val failure = testFailures.remove(testId)
     emitSnapshots(testId, trigger = TRIGGER_TEST_END)
     failureSnapshotTaken.remove(testId)
     val durationMs = Duration.between(startedAt, Instant.now()).toMillis()
-    val failure = testFailures.remove(testId)
-    val status = if (failure != null) "FAILED" else "PASSED"
+    val status = when {
+      failure != null -> "FAILED"
+      interrupted -> "ERROR"
+      else -> "PASSED"
+    }
+    val error = failure ?: if (interrupted) "Test ended before the framework reported an outcome" else ""
     emitter.tryEmit(
       dashboardEvent {
         testEnded = TestEndedEvent.newBuilder()
           .setTestId(testId)
           .setStatus(status)
           .setDurationMs(durationMs)
-          .setError(failure ?: "")
+          .setError(error)
           .setTimestamp(now())
           .build()
       }
     )
-    if (failure != null) {
-      failedTests++
-    } else {
+    if (status == "PASSED") {
       passedTests++
+    } else {
+      failedTests++
     }
   }
 

--- a/lib/stove-dashboard/src/test/kotlin/com/trendyol/stove/dashboard/DashboardSystemTest.kt
+++ b/lib/stove-dashboard/src/test/kotlin/com/trendyol/stove/dashboard/DashboardSystemTest.kt
@@ -98,8 +98,110 @@ class DashboardSystemTest : FunSpec({
       system.stop()
       delay(1000.milliseconds)
 
-      received.any { it.hasTestEnded() && it.testEnded.testId == "test-still-running" } shouldBe true
-      received.first { it.hasRunEnded() }.runEnded.totalTests shouldBe 1
+      received.single {
+        it.hasTestEnded() && it.testEnded.testId == "test-still-running"
+      }.testEnded.status shouldBe "ERROR"
+      received.first { it.hasRunEnded() }.runEnded.let {
+        it.totalTests shouldBe 1
+        it.passed shouldBe 0
+        it.failed shouldBe 1
+      }
+    } finally {
+      server.shutdownNow()
+    }
+  }
+
+  test("eventually-style attempts all reach the CLI while final test status stays passed") {
+    val received = CopyOnWriteArrayList<DashboardEvent>()
+    val server = startMockServer(received, port = 0)
+
+    try {
+      val stove = Stove()
+      stove.getOrRegister(PostgreSqlSnapshotSystem(stove))
+      val system = DashboardSystem(
+        stove,
+        DashboardSystemOptions(appName = "test-api", cliPort = server.port)
+      )
+
+      system.run()
+      delay(200.milliseconds)
+
+      stove.startTest(StoveTestContext("test-eventually", "eventually passes", "MySpec"))
+      repeat(4) { attempt ->
+        stove.recordReport(
+          ReportEntry.failure("PostgreSQL", "test-eventually", "Query", "not ready: $attempt")
+        )
+      }
+      stove.recordReport(ReportEntry.success("PostgreSQL", "test-eventually", "Query"))
+      stove.endTest()
+      stove.recordReport(
+        ReportEntry.failure("PostgreSQL", "test-eventually", "Query", "late callback")
+      )
+
+      delay(300.milliseconds)
+      system.stop()
+
+      val entries = received.filter {
+        it.hasEntryRecorded() && it.entryRecorded.testId == "test-eventually"
+      }
+      entries.size shouldBe 5
+      entries.take(4).all { it.entryRecorded.result == "FAILED" } shouldBe true
+      entries.last().entryRecorded.result shouldBe "PASSED"
+      received.single {
+        it.hasTestEnded() && it.testEnded.testId == "test-eventually"
+      }.testEnded.status shouldBe "PASSED"
+      received.count {
+        it.hasSnapshot() &&
+          it.snapshot.testId == "test-eventually" &&
+          it.snapshot.trigger == "FAILURE"
+      } shouldBe 1
+      received.single { it.hasRunEnded() }.runEnded.failed shouldBe 0
+    } finally {
+      server.shutdownNow()
+    }
+  }
+
+  test("exhausted attempts all reach the CLI and final test failure remains authoritative") {
+    val received = CopyOnWriteArrayList<DashboardEvent>()
+    val server = startMockServer(received, port = 0)
+
+    try {
+      val stove = Stove()
+      stove.getOrRegister(PostgreSqlSnapshotSystem(stove))
+      val system = DashboardSystem(
+        stove,
+        DashboardSystemOptions(appName = "test-api", cliPort = server.port)
+      )
+
+      system.run()
+      delay(200.milliseconds)
+
+      stove.startTest(StoveTestContext("test-exhausted", "eventually fails", "MySpec"))
+      repeat(5) { attempt ->
+        stove.recordReport(
+          ReportEntry.failure("PostgreSQL", "test-exhausted", "Query", "not ready: $attempt")
+        )
+      }
+      system.onTestFailed("test-exhausted", "eventually timed out")
+      stove.endTest()
+
+      delay(300.milliseconds)
+      system.stop()
+
+      val entries = received.filter {
+        it.hasEntryRecorded() && it.entryRecorded.testId == "test-exhausted"
+      }
+      entries.size shouldBe 5
+      entries.all { it.entryRecorded.result == "FAILED" } shouldBe true
+      received.single {
+        it.hasTestEnded() && it.testEnded.testId == "test-exhausted"
+      }.testEnded.status shouldBe "FAILED"
+      received.count {
+        it.hasSnapshot() &&
+          it.snapshot.testId == "test-exhausted" &&
+          it.snapshot.trigger == "FAILURE"
+      } shouldBe 1
+      received.single { it.hasRunEnded() }.runEnded.failed shouldBe 1
     } finally {
       server.shutdownNow()
     }
@@ -288,6 +390,21 @@ private class BlockingSnapshotSystem(
   fun releaseSnapshots() {
     releaseSnapshots.countDown()
   }
+
+  override fun close() = Unit
+}
+
+private class PostgreSqlSnapshotSystem(
+  override val stove: Stove
+) : PluggedSystem,
+  Reports {
+  override val reportSystemName: String = "PostgreSQL"
+
+  override fun snapshot(): SystemSnapshot = SystemSnapshot(
+    system = reportSystemName,
+    state = mapOf("ready" to true),
+    summary = "PostgreSQL state"
+  )
 
   override fun close() = Unit
 }

--- a/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
+++ b/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
@@ -680,7 +680,7 @@ class GrpcMockSystem internal constructor(
       ReportEntry.success(
         system = reportSystemName,
         testId = reporter.currentTestId(),
-        action = "Validate: All gRPC requests matched registered stubs"
+        action = "Validate: All gRPC requests should match registered stubs"
       )
     )
   }

--- a/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
+++ b/lib/stove-grpc-mock/src/main/kotlin/com/trendyol/stove/testing/grpcmock/GrpcMockSystem.kt
@@ -677,10 +677,12 @@ class GrpcMockSystem internal constructor(
     }
 
     reporter.record(
-      ReportEntry.success(
+      ReportEntry.action(
         system = reportSystemName,
         testId = reporter.currentTestId(),
-        action = "Validate: All gRPC requests should match registered stubs"
+        action = "Validate: All gRPC requests should match registered stubs",
+        passed = true,
+        expected = "0 unmatched requests".some()
       )
     )
   }

--- a/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockReportConstants.kt
+++ b/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockReportConstants.kt
@@ -39,7 +39,6 @@ internal object WireMockReportActions {
   fun registerDynamicStub(method: String, url: String): String = "Register stub: $method $url (dynamic response)"
 
   const val VALIDATE_ALL_REQUESTS_SHOULD_MATCH = "Validate: All requests should match registered stubs"
-  const val VALIDATE_ALL_REQUESTS_MATCHED = "Validate: All requests matched registered stubs"
   const val VERIFY_REQUEST_WAS_CALLED = "Verify request was called"
   const val VERIFY_REQUEST_WAS_NOT_CALLED = "Verify request was not called"
 }

--- a/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
+++ b/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
@@ -36,7 +36,6 @@ import com.trendyol.stove.system.abstractions.*
 import com.trendyol.stove.wiremock.WireMockHeaders.APPLICATION_JSON
 import com.trendyol.stove.wiremock.WireMockHeaders.APPLICATION_JSON_UTF8
 import com.trendyol.stove.wiremock.WireMockHeaders.CONTENT_TYPE
-import com.trendyol.stove.wiremock.WireMockReportActions.VALIDATE_ALL_REQUESTS_MATCHED
 import com.trendyol.stove.wiremock.WireMockReportActions.VALIDATE_ALL_REQUESTS_SHOULD_MATCH
 import com.trendyol.stove.wiremock.WireMockReportMetadataKeys.RESPONSE_HEADERS
 import com.trendyol.stove.wiremock.WireMockReportMetadataKeys.STATUS_CODE
@@ -1293,7 +1292,7 @@ class WireMockSystem(
         ReportEntry.success(
           system = reportSystemName,
           testId = reporter.currentTestId(),
-          action = VALIDATE_ALL_REQUESTS_MATCHED
+          action = VALIDATE_ALL_REQUESTS_SHOULD_MATCH
         )
       )
     }

--- a/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
+++ b/lib/stove-wiremock/src/main/kotlin/com/trendyol/stove/wiremock/WireMockSystem.kt
@@ -1289,10 +1289,12 @@ class WireMockSystem(
       throw error
     } else {
       reporter.record(
-        ReportEntry.success(
+        ReportEntry.action(
           system = reportSystemName,
           testId = reporter.currentTestId(),
-          action = VALIDATE_ALL_REQUESTS_SHOULD_MATCH
+          action = VALIDATE_ALL_REQUESTS_SHOULD_MATCH,
+          passed = true,
+          expected = WireMockValidationMessages.EXPECTED_NO_UNMATCHED_REQUESTS.some()
         )
       )
     }

--- a/lib/stove/src/main/kotlin/com/trendyol/stove/messaging/kafka/KafkaAssertionReporting.kt
+++ b/lib/stove/src/main/kotlin/com/trendyol/stove/messaging/kafka/KafkaAssertionReporting.kt
@@ -27,12 +27,14 @@ suspend fun <T : Any> runKafkaAssertion(
 
   if (failure == null) {
     reporter.record(
-      ReportEntry.success(
+      ReportEntry.action(
         system = systemName,
         testId = reporter.currentTestId(),
         action = "$assertionName<$typeName>",
+        passed = true,
         output = matchedMessage.toOption(),
-        metadata = mapOf("timeout" to timeout.toString())
+        metadata = mapOf("timeout" to timeout.toString()),
+        expected = expected.some()
       )
     )
   } else {

--- a/tools/stove-cli/spa/src/api/live-cache.ts
+++ b/tools/stove-cli/spa/src/api/live-cache.ts
@@ -449,7 +449,7 @@ function updateCachedTests(
 }
 
 function appendEntries(entries: Entry[] | undefined, incoming: Entry): Entry[] {
-  if (entries?.some((entry) => entry.id === incoming.id)) {
+  if (incoming.id !== 0 && entries?.some((entry) => entry.id === incoming.id)) {
     return entries;
   }
 

--- a/tools/stove-cli/spa/src/api/live-cache.ts
+++ b/tools/stove-cli/spa/src/api/live-cache.ts
@@ -141,6 +141,9 @@ export function applyLiveDashboardEvent(queryClient: QueryClient, event: LiveDas
         actual: event.payload.actual,
         error: event.payload.error,
         trace_id: event.payload.trace_id,
+        assertion_id: event.payload.assertion_id,
+        attempt_count: event.payload.attempt_count,
+        failure_count: event.payload.failure_count,
       };
 
       queryClient.setQueryData<Entry[]>(
@@ -449,9 +452,32 @@ function appendEntries(entries: Entry[] | undefined, incoming: Entry): Entry[] {
   if (entries?.some((entry) => entry.id === incoming.id)) {
     return entries;
   }
-  return [...(entries ?? []), incoming].sort((left, right) =>
-    left.timestamp.localeCompare(right.timestamp),
+
+  const existing = entries ?? [];
+  const assertionIndex = existing.findIndex(
+    (entry) => entry.assertion_id === incoming.assertion_id,
   );
+  if (assertionIndex < 0) {
+    return [...existing, incoming].sort((left, right) =>
+      left.timestamp.localeCompare(right.timestamp),
+    );
+  }
+
+  const previous = existing[assertionIndex];
+  const latest =
+    incoming.attempt_count > previous.attempt_count ||
+    (incoming.attempt_count === previous.attempt_count && incoming.timestamp > previous.timestamp)
+      ? incoming
+      : previous;
+  const correlated = {
+    ...latest,
+    id: previous.id,
+    attempt_count: Math.max(previous.attempt_count, incoming.attempt_count),
+    failure_count: Math.max(previous.failure_count, incoming.failure_count),
+  };
+  return existing
+    .map((entry, index) => (index === assertionIndex ? correlated : entry))
+    .sort((left, right) => left.timestamp.localeCompare(right.timestamp));
 }
 
 function appendSpan(spans: Span[] | undefined, incoming: Span): Span[] {
@@ -545,20 +571,28 @@ function mergeTests(persisted: Test[], cached: Test[]): Test[] {
 }
 
 function mergeEntries(persisted: Entry[], cached: Entry[]): Entry[] {
-  return mergeEvidenceRecords(
-    persisted,
-    cached,
-    (entry) =>
-      [
-        entry.run_id,
-        entry.test_id,
-        entry.timestamp,
-        entry.system,
-        entry.action,
-        entry.result,
-        entry.trace_id,
-      ].join("\u0000"),
-    (left, right) => left.timestamp.localeCompare(right.timestamp),
+  const byAssertion = new Map(persisted.map((entry) => [entry.assertion_id, entry]));
+  for (const live of cached) {
+    const stored = byAssertion.get(live.assertion_id);
+    if (!stored) {
+      byAssertion.set(live.assertion_id, live);
+      continue;
+    }
+
+    const latest =
+      live.attempt_count > stored.attempt_count ||
+      (live.attempt_count === stored.attempt_count && live.timestamp > stored.timestamp)
+        ? live
+        : stored;
+    byAssertion.set(live.assertion_id, {
+      ...latest,
+      id: stored.id,
+      attempt_count: Math.max(stored.attempt_count, live.attempt_count),
+      failure_count: Math.max(stored.failure_count, live.failure_count),
+    });
+  }
+  return [...byAssertion.values()].sort((left, right) =>
+    left.timestamp.localeCompare(right.timestamp),
   );
 }
 

--- a/tools/stove-cli/spa/src/api/types.ts
+++ b/tools/stove-cli/spa/src/api/types.ts
@@ -72,6 +72,9 @@ export interface Entry {
   actual: string | null;
   error: string | null;
   trace_id: string | null;
+  assertion_id: string;
+  attempt_count: number;
+  failure_count: number;
 }
 
 export interface Span {
@@ -189,6 +192,9 @@ export interface LiveEntryRecordedPayload {
   actual: string | null;
   error: string | null;
   trace_id: string | null;
+  assertion_id: string;
+  attempt_count: number;
+  failure_count: number;
 }
 
 export interface LiveSpanRecordedPayload {

--- a/tools/stove-cli/spa/src/components/EntryDetails.tsx
+++ b/tools/stove-cli/spa/src/components/EntryDetails.tsx
@@ -4,6 +4,12 @@ import { Detail } from "./Detail";
 export function EntryDetails({ entry }: { entry: Entry }) {
   return (
     <>
+      {entry.attempt_count > 1 && (
+        <Detail
+          label="Retry history"
+          value={`${entry.attempt_count} attempts, ${entry.failure_count} failed`}
+        />
+      )}
       {entry.input && <Detail label="Input" value={entry.input} />}
       {entry.output && <Detail label="Output" value={entry.output} color="var(--stove-green)" />}
       {entry.expected && <Detail label="Expected" value={entry.expected} />}

--- a/tools/stove-cli/spa/src/components/EntryRow.tsx
+++ b/tools/stove-cli/spa/src/components/EntryRow.tsx
@@ -32,6 +32,11 @@ export function EntryRow({ entry }: EntryRowProps) {
         <ResultIcon result={entry.result} />
         <SysBadge system={entry.system} />
         <span className="truncate font-medium text-[var(--stove-text)]">{entry.action}</span>
+        {entry.attempt_count > 1 && (
+          <span className="text-xs text-[var(--stove-amber)]">
+            {entry.attempt_count} attempts · {entry.failure_count} failed
+          </span>
+        )}
         <span className="ml-auto text-[var(--stove-text-muted)]">
           {expanded ? "Hide" : "Details"}
         </span>

--- a/tools/stove-cli/spa/src/components/EvidenceWorkbench.tsx
+++ b/tools/stove-cli/spa/src/components/EvidenceWorkbench.tsx
@@ -181,6 +181,11 @@ function EvidenceRow({
         <strong>{entry.action}</strong>
         <span>{entry.system}</span>
       </span>
+      {entry.attempt_count > 1 && (
+        <span className="ledger-attempt-stamp">
+          {entry.attempt_count} attempts · {entry.failure_count} failed
+        </span>
+      )}
       {entry.trace_id && <span className="ledger-trace-stamp">trace</span>}
       <span className={`ledger-result is-${issue ? "issue" : "success"}`}>{entry.result}</span>
       <Icon name="chevron" className="h-4 w-4" />
@@ -263,6 +268,11 @@ function EvidenceInspector({
 
         <div className="inspector-status-line">
           <span className={isEntryIssue(entry) ? "is-issue" : "is-success"}>{entry.result}</span>
+          {entry.attempt_count > 1 && (
+            <span>
+              {entry.attempt_count} attempts · {entry.failure_count} failed
+            </span>
+          )}
           {entry.trace_id && (
             <button type="button" onClick={onOpenTrace}>
               Open trace

--- a/tools/stove-cli/spa/src/index.css
+++ b/tools/stove-cli/spa/src/index.css
@@ -1867,6 +1867,17 @@ button {
   text-transform: uppercase;
 }
 
+.ledger-attempt-stamp {
+  border: 1px solid color-mix(in srgb, var(--stove-amber) 30%, var(--stove-border));
+  border-radius: 999px;
+  background: var(--stove-amber-bg);
+  padding: 3px 6px;
+  color: var(--stove-amber);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  white-space: nowrap;
+}
+
 .ledger-result {
   justify-self: end;
   border-radius: 999px;

--- a/tools/stove-cli/spa/test/live-cache.test.mjs
+++ b/tools/stove-cli/spa/test/live-cache.test.mjs
@@ -54,6 +54,9 @@ test("applyLiveDashboardEvent updates run, test, and detail caches from live SSE
       actual: null,
       error: null,
       trace_id: "trace-1",
+      assertion_id: "assertion-health",
+      attempt_count: 1,
+      failure_count: 0,
     },
   });
 
@@ -207,6 +210,62 @@ test("applyLiveDashboardEvent updates run, test, and detail caches from live SSE
   assert.equal(testWarnings.length, 1);
   assert.equal(testWarnings[0].kind, "UNUSED_STUB");
   assert.equal(runWarnings.length, 0);
+});
+
+test("live assertion retries collapse to the latest attempt and retain failure history", () => {
+  const queryClient = new QueryClient();
+  const queryKey = ["entries", "run-retry", "test-retry"];
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const failed = attempt < 5;
+    applyLiveDashboardEvent(queryClient, {
+      seq: attempt,
+      run_id: "run-retry",
+      event_type: "entry_recorded",
+      payload: {
+        id: -attempt,
+        test_id: "test-retry",
+        timestamp: `2024-06-01T10:00:0${attempt}Z`,
+        system: "PostgreSQL",
+        action: "Query",
+        result: failed ? "FAILED" : "PASSED",
+        input: "select * from products",
+        output: null,
+        metadata: "{}",
+        expected: "one row",
+        actual: failed ? "no rows" : "one row",
+        error: failed ? `not ready on attempt ${attempt}` : null,
+        trace_id: null,
+        assertion_id: "assertion-products",
+        attempt_count: attempt,
+        failure_count: failed ? attempt : attempt - 1,
+      },
+    });
+  }
+
+  const liveEntries = queryClient.getQueryData(queryKey);
+  assert.equal(liveEntries.length, 1);
+  assert.equal(liveEntries[0].result, "PASSED");
+  assert.equal(liveEntries[0].attempt_count, 5);
+  assert.equal(liveEntries[0].failure_count, 4);
+  assert.equal(liveEntries[0].actual, "one row");
+
+  const reconciled = reconcileDashboardData(queryClient, queryKey, [
+    {
+      ...liveEntries[0],
+      id: 42,
+      timestamp: "2024-06-01T10:00:04Z",
+      result: "FAILED",
+      actual: "no rows",
+      error: "not ready on attempt 4",
+      attempt_count: 4,
+      failure_count: 4,
+    },
+  ]);
+  assert.equal(reconciled.length, 1);
+  assert.equal(reconciled[0].result, "PASSED");
+  assert.equal(reconciled[0].attempt_count, 5);
+  assert.equal(reconciled[0].failure_count, 4);
 });
 
 test("live test data survives a stale persisted response", () => {

--- a/tools/stove-cli/spa/test/live-cache.test.mjs
+++ b/tools/stove-cli/spa/test/live-cache.test.mjs
@@ -223,7 +223,7 @@ test("live assertion retries collapse to the latest attempt and retain failure h
       run_id: "run-retry",
       event_type: "entry_recorded",
       payload: {
-        id: -attempt,
+        id: 0,
         test_id: "test-retry",
         timestamp: `2024-06-01T10:00:0${attempt}Z`,
         system: "PostgreSQL",
@@ -243,16 +243,43 @@ test("live assertion retries collapse to the latest attempt and retain failure h
     });
   }
 
+  applyLiveDashboardEvent(queryClient, {
+    seq: 6,
+    run_id: "run-retry",
+    event_type: "entry_recorded",
+    payload: {
+      id: 0,
+      test_id: "test-retry",
+      timestamp: "2024-06-01T10:00:06Z",
+      system: "PostgreSQL",
+      action: "Query",
+      result: "PASSED",
+      input: "select * from orders",
+      output: null,
+      metadata: "{}",
+      expected: "one row",
+      actual: "one row",
+      error: null,
+      trace_id: null,
+      assertion_id: "assertion-orders",
+      attempt_count: 1,
+      failure_count: 0,
+    },
+  });
+
   const liveEntries = queryClient.getQueryData(queryKey);
-  assert.equal(liveEntries.length, 1);
-  assert.equal(liveEntries[0].result, "PASSED");
-  assert.equal(liveEntries[0].attempt_count, 5);
-  assert.equal(liveEntries[0].failure_count, 4);
-  assert.equal(liveEntries[0].actual, "one row");
+  assert.equal(liveEntries.length, 2);
+  const retriedEntry = liveEntries.find(
+    (entry) => entry.assertion_id === "assertion-products",
+  );
+  assert.equal(retriedEntry.result, "PASSED");
+  assert.equal(retriedEntry.attempt_count, 5);
+  assert.equal(retriedEntry.failure_count, 4);
+  assert.equal(retriedEntry.actual, "one row");
 
   const reconciled = reconcileDashboardData(queryClient, queryKey, [
     {
-      ...liveEntries[0],
+      ...retriedEntry,
       id: 42,
       timestamp: "2024-06-01T10:00:04Z",
       result: "FAILED",
@@ -262,10 +289,13 @@ test("live assertion retries collapse to the latest attempt and retain failure h
       failure_count: 4,
     },
   ]);
-  assert.equal(reconciled.length, 1);
-  assert.equal(reconciled[0].result, "PASSED");
-  assert.equal(reconciled[0].attempt_count, 5);
-  assert.equal(reconciled[0].failure_count, 4);
+  assert.equal(reconciled.length, 2);
+  const reconciledRetry = reconciled.find(
+    (entry) => entry.assertion_id === "assertion-products",
+  );
+  assert.equal(reconciledRetry.result, "PASSED");
+  assert.equal(reconciledRetry.attempt_count, 5);
+  assert.equal(reconciledRetry.failure_count, 4);
 });
 
 test("live test data survives a stale persisted response", () => {

--- a/tools/stove-cli/src/grpc/service/preparers.rs
+++ b/tools/stove-cli/src/grpc/service/preparers.rs
@@ -24,12 +24,14 @@ use crate::storage::models::NewEntry;
 use crate::storage::models::NewMockInteraction;
 use crate::storage::models::NewMockWarning;
 use crate::storage::models::NewSpan;
+use uuid::Uuid;
 
 use super::convert::PreparedDashboardEvent;
 use super::convert::extract_test_id;
 use super::convert::format_timestamp;
 use super::convert::non_empty;
 use super::convert::run_status;
+use super::state::AssertionAttempts;
 use super::state::LiveState;
 use super::state::ensure_run_known;
 use super::state::ensure_test_known;
@@ -140,6 +142,7 @@ pub(super) fn prepare_test_ended(
 ) -> AppResult<PreparedDashboardEvent> {
   ensure_test_known(state, run_id, &event.test_id)?;
   let ended_at = format_timestamp(event.timestamp.as_ref());
+  state.end_test(run_id, &event.test_id);
   Ok(PreparedDashboardEvent {
     live: live_event(
       run_id,
@@ -179,6 +182,27 @@ pub(super) fn prepare_entry_recorded(
 
   let metadata = serde_json::to_string(&event.metadata)?;
   let timestamp = format_timestamp(event.timestamp.as_ref());
+  let correlation_id = assertion_correlation_key(event)?;
+  let occurrence_id = Uuid::new_v4().to_string();
+  let correlated_attempts = state.record_assertion_attempt(
+    run_id,
+    &event.test_id,
+    &correlation_id,
+    &occurrence_id,
+    matches!(event.result.as_str(), "FAILED" | "ERROR"),
+  );
+  // A passing entry with no preceding failed attempt is a standalone operation,
+  // not a retry. Give it a unique ID so repeated successful calls stay visible.
+  let (assertion_id, attempts) = match correlated_attempts {
+    Some(correlated) => correlated,
+    None => (
+      occurrence_id,
+      AssertionAttempts {
+        attempt_count: 1,
+        failure_count: 0,
+      },
+    ),
+  };
   let entry = NewEntry {
     run_id: run_id.to_string(),
     test_id: event.test_id.clone(),
@@ -193,6 +217,7 @@ pub(super) fn prepare_entry_recorded(
     actual: event.actual.clone(),
     error: event.error.clone(),
     trace_id: event.trace_id.clone(),
+    assertion_id: assertion_id.clone(),
   };
 
   Ok(PreparedDashboardEvent {
@@ -213,11 +238,26 @@ pub(super) fn prepare_entry_recorded(
         actual: non_empty(&event.actual),
         error: non_empty(&event.error),
         trace_id: non_empty(&event.trace_id),
+        assertion_id,
+        attempt_count: attempts.attempt_count,
+        failure_count: attempts.failure_count,
       }),
     ),
     persisted: PersistedDashboardEvent::EntryRecorded(entry),
     flush: FlushBehavior::Deferred,
   })
+}
+
+/// The current reporting protocol does not carry a call-site identity, so the CLI
+/// derives a best-effort correlation signature from the assertion's semantic
+/// action and input. Outcome fields are deliberately excluded.
+fn assertion_correlation_key(event: &proto::EntryRecordedEvent) -> AppResult<String> {
+  Ok(serde_json::to_string(&[
+    &event.test_id,
+    &event.system,
+    &event.action,
+    &event.input,
+  ])?)
 }
 
 pub(super) fn prepare_span_recorded(

--- a/tools/stove-cli/src/grpc/service/preparers.rs
+++ b/tools/stove-cli/src/grpc/service/preparers.rs
@@ -250,13 +250,14 @@ pub(super) fn prepare_entry_recorded(
 
 /// The current reporting protocol does not carry a call-site identity, so the CLI
 /// derives a best-effort correlation signature from the assertion's semantic
-/// action and input. Outcome fields are deliberately excluded.
+/// action, input, and expectation. Result-specific fields are deliberately excluded.
 fn assertion_correlation_key(event: &proto::EntryRecordedEvent) -> AppResult<String> {
   Ok(serde_json::to_string(&[
     &event.test_id,
     &event.system,
     &event.action,
     &event.input,
+    &event.expected,
   ])?)
 }
 

--- a/tools/stove-cli/src/grpc/service/state.rs
+++ b/tools/stove-cli/src/grpc/service/state.rs
@@ -27,9 +27,39 @@ pub(super) struct LiveState {
   pub(super) runs: HashSet<String>,
   pub(super) tests: HashSet<(String, String)>,
   pub(super) traces: HashMap<(String, String), String>,
+  assertion_attempts: HashMap<(String, String, String), AssertionSequence>,
 }
 
 impl LiveState {
+  pub(super) fn record_assertion_attempt(
+    &mut self,
+    run_id: &str,
+    test_id: &str,
+    correlation_id: &str,
+    new_assertion_id: &str,
+    failed: bool,
+  ) -> Option<(String, AssertionAttempts)> {
+    let key = (
+      run_id.to_string(),
+      test_id.to_string(),
+      correlation_id.to_string(),
+    );
+    if failed {
+      let attempts = self
+        .assertion_attempts
+        .entry(key)
+        .or_insert_with(|| AssertionSequence::new(new_assertion_id));
+      attempts.counts.attempt_count += 1;
+      attempts.counts.failure_count += 1;
+      return Some((attempts.assertion_id.clone(), attempts.counts));
+    }
+
+    self.assertion_attempts.remove(&key).map(|mut attempts| {
+      attempts.counts.attempt_count += 1;
+      (attempts.assertion_id, attempts.counts)
+    })
+  }
+
   pub(super) fn clear_run(&mut self, run_id: &str) {
     self.runs.remove(run_id);
     self
@@ -38,7 +68,41 @@ impl LiveState {
     self
       .traces
       .retain(|(known_run_id, _), _| known_run_id != run_id);
+    self
+      .assertion_attempts
+      .retain(|(known_run_id, _, _), _| known_run_id != run_id);
   }
+
+  pub(super) fn end_test(&mut self, run_id: &str, test_id: &str) {
+    self
+      .tests
+      .remove(&(run_id.to_string(), test_id.to_string()));
+    self
+      .assertion_attempts
+      .retain(|(known_run_id, known_test_id, _), _| {
+        known_run_id != run_id || known_test_id != test_id
+      });
+  }
+}
+
+struct AssertionSequence {
+  assertion_id: String,
+  counts: AssertionAttempts,
+}
+
+impl AssertionSequence {
+  fn new(assertion_id: &str) -> Self {
+    Self {
+      assertion_id: assertion_id.to_string(),
+      counts: AssertionAttempts::default(),
+    }
+  }
+}
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct AssertionAttempts {
+  pub(super) attempt_count: i64,
+  pub(super) failure_count: i64,
 }
 
 pub(super) fn ensure_run_known(state: &LiveState, run_id: &str) -> AppResult<()> {
@@ -62,5 +126,46 @@ pub(super) fn ensure_test_known(state: &LiveState, run_id: &str, test_id: &str) 
     Err(AppError::InvalidEvent(format!(
       "received event for unknown test `{test_id}` in run `{run_id}`"
     )))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::LiveState;
+
+  #[test]
+  fn retry_sequences_share_an_id_until_the_first_success() {
+    let mut state = LiveState::default();
+
+    assert!(
+      state
+        .record_assertion_attempt("run", "test", "signature", "pass-1", false)
+        .is_none(),
+      "standalone successes must remain distinct dashboard entries"
+    );
+
+    let (first_id, first) = state
+      .record_assertion_attempt("run", "test", "signature", "retry-1", true)
+      .unwrap();
+    let (second_id, second) = state
+      .record_assertion_attempt("run", "test", "signature", "ignored", true)
+      .unwrap();
+    let (final_id, final_attempt) = state
+      .record_assertion_attempt("run", "test", "signature", "ignored", false)
+      .unwrap();
+
+    assert_eq!(first_id, "retry-1");
+    assert_eq!(second_id, first_id);
+    assert_eq!(final_id, first_id);
+    assert_eq!(first.attempt_count, 1);
+    assert_eq!(second.attempt_count, 2);
+    assert_eq!(final_attempt.attempt_count, 3);
+    assert_eq!(final_attempt.failure_count, 2);
+
+    let (next_id, next) = state
+      .record_assertion_attempt("run", "test", "signature", "retry-2", true)
+      .unwrap();
+    assert_eq!(next_id, "retry-2");
+    assert_eq!(next.attempt_count, 1);
   }
 }

--- a/tools/stove-cli/src/grpc/service/tests.rs
+++ b/tools/stove-cli/src/grpc/service/tests.rs
@@ -140,27 +140,34 @@ async fn process_full_lifecycle() {
     })
     .unwrap();
 
-  svc
-    .process_event(&proto::DashboardEvent {
-      run_id: "run-1".to_string(),
-      event: Some(proto::dashboard_event::Event::EntryRecorded(
-        proto::EntryRecordedEvent {
-          test_id: "test-1".to_string(),
-          timestamp: Some(ts(1_704_067_202)),
-          system: "HTTP".to_string(),
-          action: "GET /api".to_string(),
-          result: "PASSED".to_string(),
-          input: String::new(),
-          output: String::new(),
-          metadata: std::collections::HashMap::default(),
-          expected: String::new(),
-          actual: String::new(),
-          error: String::new(),
-          trace_id: String::new(),
-        },
-      )),
-    })
-    .unwrap();
+  for attempt in 1_i64..=5 {
+    let failed = attempt < 5;
+    svc
+      .process_event(&proto::DashboardEvent {
+        run_id: "run-1".to_string(),
+        event: Some(proto::dashboard_event::Event::EntryRecorded(
+          proto::EntryRecordedEvent {
+            test_id: "test-1".to_string(),
+            timestamp: Some(ts(1_704_067_201 + attempt)),
+            system: "HTTP".to_string(),
+            action: "GET /api".to_string(),
+            result: if failed { "FAILED" } else { "PASSED" }.to_string(),
+            input: String::new(),
+            output: String::new(),
+            metadata: std::collections::HashMap::default(),
+            expected: "200".to_string(),
+            actual: if failed { "503" } else { "200" }.to_string(),
+            error: if failed {
+              format!("not ready on attempt {attempt}")
+            } else {
+              String::new()
+            },
+            trace_id: String::new(),
+          },
+        )),
+      })
+      .unwrap();
+  }
 
   svc
     .process_event(&proto::DashboardEvent {
@@ -171,7 +178,7 @@ async fn process_full_lifecycle() {
           status: "PASSED".to_string(),
           duration_ms: 500,
           error: String::new(),
-          timestamp: Some(ts(1_704_067_203)),
+          timestamp: Some(ts(1_704_067_207)),
         },
       )),
     })
@@ -204,4 +211,11 @@ async fn process_full_lifecycle() {
 
   let entries = svc.repository.get_entries("run-1", "test-1").unwrap();
   assert_eq!(entries.len(), 1);
+  assert_eq!(
+    entries[0].result,
+    crate::storage::models::TestStatus::Passed
+  );
+  assert_eq!(entries[0].attempt_count, 5);
+  assert_eq!(entries[0].failure_count, 4);
+  assert_eq!(entries[0].actual.as_deref(), Some("200"));
 }

--- a/tools/stove-cli/src/grpc/service/tests.rs
+++ b/tools/stove-cli/src/grpc/service/tests.rs
@@ -219,3 +219,69 @@ async fn process_full_lifecycle() {
   assert_eq!(entries[0].failure_count, 4);
   assert_eq!(entries[0].actual.as_deref(), Some("200"));
 }
+
+#[tokio::test]
+async fn assertions_with_distinct_expectations_do_not_share_retry_identity() {
+  let svc = test_service();
+
+  svc
+    .process_event(&proto::DashboardEvent {
+      run_id: "run-expectations".to_string(),
+      event: Some(proto::dashboard_event::Event::RunStarted(
+        proto::RunStartedEvent {
+          timestamp: Some(ts(1_704_067_200)),
+          app_name: "test-app".to_string(),
+          systems: vec!["HTTP".to_string()],
+          stove_version: String::new(),
+        },
+      )),
+    })
+    .unwrap();
+  svc
+    .process_event(&proto::DashboardEvent {
+      run_id: "run-expectations".to_string(),
+      event: Some(proto::dashboard_event::Event::TestStarted(
+        proto::TestStartedEvent {
+          test_id: "test-expectations".to_string(),
+          test_name: "checks two statuses".to_string(),
+          spec_name: "ExpectationSpec".to_string(),
+          timestamp: Some(ts(1_704_067_201)),
+          test_path: vec![],
+        },
+      )),
+    })
+    .unwrap();
+
+  for (offset, expected) in ["200", "201"].into_iter().enumerate() {
+    svc
+      .process_event(&proto::DashboardEvent {
+        run_id: "run-expectations".to_string(),
+        event: Some(proto::dashboard_event::Event::EntryRecorded(
+          proto::EntryRecordedEvent {
+            test_id: "test-expectations".to_string(),
+            timestamp: Some(ts(1_704_067_202 + i64::try_from(offset).unwrap())),
+            system: "HTTP".to_string(),
+            action: "GET /api".to_string(),
+            result: "FAILED".to_string(),
+            input: String::new(),
+            output: String::new(),
+            metadata: std::collections::HashMap::default(),
+            expected: expected.to_string(),
+            actual: "503".to_string(),
+            error: format!("expected {expected}"),
+            trace_id: String::new(),
+          },
+        )),
+      })
+      .unwrap();
+  }
+
+  svc.flush_pending().await.unwrap();
+
+  let entries = svc
+    .repository
+    .get_entries("run-expectations", "test-expectations")
+    .unwrap();
+  assert_eq!(entries.len(), 2);
+  assert_ne!(entries[0].assertion_id, entries[1].assertion_id);
+}

--- a/tools/stove-cli/src/http/routes/tests.rs
+++ b/tools/stove-cli/src/http/routes/tests.rs
@@ -20,6 +20,14 @@ pub async fn get_entries(
   Ok(Json(entries))
 }
 
+pub async fn get_raw_entries(
+  State(state): State<AppState>,
+  Path((run_id, test_id)): Path<(String, String)>,
+) -> Result<Json<Vec<Entry>>, crate::error::AppError> {
+  let entries = state.repository.get_raw_entries(&run_id, &test_id)?;
+  Ok(Json(entries))
+}
+
 pub async fn get_snapshots(
   State(state): State<AppState>,
   Path((run_id, test_id)): Path<(String, String)>,

--- a/tools/stove-cli/src/http/server.rs
+++ b/tools/stove-cli/src/http/server.rs
@@ -44,6 +44,10 @@ pub fn create_router_with_ingestor(
       get(super::routes::get_entries),
     )
     .route(
+      "/runs/{run_id}/tests/{test_id}/entries/raw",
+      get(super::routes::get_raw_entries),
+    )
+    .route(
       "/runs/{run_id}/tests/{test_id}/spans",
       get(super::routes::get_test_spans),
     )

--- a/tools/stove-cli/src/ingest.rs
+++ b/tools/stove-cli/src/ingest.rs
@@ -154,6 +154,9 @@ pub struct LiveEntryRecordedPayload {
   pub actual: Option<String>,
   pub error: Option<String>,
   pub trace_id: Option<String>,
+  pub assertion_id: String,
+  pub attempt_count: i64,
+  pub failure_count: i64,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/tools/stove-cli/src/mcp/analysis/common.rs
+++ b/tools/stove-cli/src/mcp/analysis/common.rs
@@ -265,7 +265,7 @@ pub(super) fn correlated_test_for_trace(
     .into_iter()
     .find(|test| {
       repository
-        .get_entries(&run.id, &test.id)
+        .get_raw_entries(&run.id, &test.id)
         .is_ok_and(|entries| {
           entries
             .iter()

--- a/tools/stove-cli/src/mcp/analysis/evidence.rs
+++ b/tools/stove-cli/src/mcp/analysis/evidence.rs
@@ -26,6 +26,9 @@ pub(super) fn entry_preview(entry: &Entry, max_chars: usize) -> Value {
     "actual": preview_field(entry.actual.as_deref(), max_chars),
     "error": clip_opt(entry.error.as_deref(), max_chars),
     "trace_id": entry.trace_id,
+    "assertion_id": entry.assertion_id,
+    "attempt_count": entry.attempt_count,
+    "failure_count": entry.failure_count,
     "raw_tool_call": tool_call(ToolName::RawEvidence, tool_args([
       (ArgName::Kind, json!(RawEvidenceKind::Entry.as_str())),
       (ArgName::Id, json!(entry.id)),

--- a/tools/stove-cli/src/mcp/analysis/raw_evidence.rs
+++ b/tools/stove-cli/src/mcp/analysis/raw_evidence.rs
@@ -36,7 +36,7 @@ impl Analyzer {
           .ok_or_else(|| "raw entry lookup requires run_id and test_id".to_string())?;
         let entry = self
           .repository
-          .get_entries(run_id, test_id)
+          .get_raw_entries(run_id, test_id)
           .map_err(display_error)?
           .into_iter()
           .find(|entry| entry.id == args.id)

--- a/tools/stove-cli/src/storage/database.rs
+++ b/tools/stove-cli/src/storage/database.rs
@@ -163,6 +163,7 @@ static IN_MEMORY_DB_COUNTER: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::storage::repository::Repository;
   use tempfile::TempDir;
 
   #[test]
@@ -202,7 +203,7 @@ mod tests {
   }
 
   #[test]
-  fn open_upgrades_v1_database_with_run_stove_version_column() {
+  fn open_upgrades_v1_database_and_preserves_legacy_entries() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("stove-v1.db");
     let conn = Connection::open(&path).unwrap();
@@ -221,6 +222,21 @@ mod tests {
       .execute(
         "INSERT INTO schema_migrations (version, name) VALUES (?1, ?2)",
         rusqlite::params![1_i64, "V1__initial_schema"],
+      )
+      .unwrap();
+    conn
+      .execute_batch(
+        "INSERT INTO runs (id, app_name, started_at)
+           VALUES ('legacy-run', 'legacy-app', '2024-01-01T00:00:00Z');
+         INSERT INTO tests (id, run_id, test_name, spec_name, started_at)
+           VALUES ('legacy-test', 'legacy-run', 'legacy test', 'LegacySpec',
+                   '2024-01-01T00:00:01Z');
+         INSERT INTO entries (
+           run_id, test_id, timestamp, system, action, result, input
+         ) VALUES (
+           'legacy-run', 'legacy-test', '2024-01-01T00:00:02Z',
+           'HTTP', 'GET /legacy', 'PASSED', '/legacy'
+         );",
       )
       .unwrap();
     drop(conn);
@@ -248,9 +264,28 @@ mod tests {
         row.get(0)
       })
       .unwrap();
+    let stored_assertion_id: String = db
+      .conn()
+      .query_row(
+        "SELECT assertion_id FROM entries WHERE run_id = 'legacy-run'",
+        [],
+        |row| row.get(0),
+      )
+      .unwrap();
 
     assert_eq!(stove_version_columns, 1);
     assert_eq!(assertion_id_columns, 1);
     assert_eq!(schema_version, i64::try_from(MIGRATIONS.len()).unwrap());
+    assert_eq!(stored_assertion_id, "");
+
+    let repository = Repository::new(db);
+    let entries = repository.get_entries("legacy-run", "legacy-test").unwrap();
+    let raw_entries = repository
+      .get_raw_entries("legacy-run", "legacy-test")
+      .unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(raw_entries.len(), 1);
+    assert_eq!(entries[0].assertion_id, format!("legacy:{}", entries[0].id));
+    assert_eq!(raw_entries[0].assertion_id, entries[0].assertion_id);
   }
 }

--- a/tools/stove-cli/src/storage/database.rs
+++ b/tools/stove-cli/src/storage/database.rs
@@ -27,6 +27,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
     "V5__mock_interaction_metadata",
     include_str!("migrations/V5__mock_interaction_metadata.sql"),
   ),
+  (
+    "V6__entry_assertion_correlation",
+    include_str!("migrations/V6__entry_assertion_correlation.sql"),
+  ),
 ];
 
 /// `SQLite` database wrapper with WAL mode and versioned schema migrations.
@@ -230,6 +234,14 @@ mod tests {
         |row| row.get(0),
       )
       .unwrap();
+    let assertion_id_columns: i64 = db
+      .conn()
+      .query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('entries') WHERE name = 'assertion_id'",
+        [],
+        |row| row.get(0),
+      )
+      .unwrap();
     let schema_version: i64 = db
       .conn()
       .query_row("SELECT MAX(version) FROM schema_migrations", [], |row| {
@@ -238,6 +250,7 @@ mod tests {
       .unwrap();
 
     assert_eq!(stove_version_columns, 1);
+    assert_eq!(assertion_id_columns, 1);
     assert_eq!(schema_version, i64::try_from(MIGRATIONS.len()).unwrap());
   }
 }

--- a/tools/stove-cli/src/storage/migrations/V6__entry_assertion_correlation.sql
+++ b/tools/stove-cli/src/storage/migrations/V6__entry_assertion_correlation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE entries ADD COLUMN assertion_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_entries_run_test_assertion
+    ON entries(run_id, test_id, assertion_id);

--- a/tools/stove-cli/src/storage/models.rs
+++ b/tools/stove-cli/src/storage/models.rs
@@ -133,6 +133,10 @@ pub struct Entry {
   pub actual: Option<String>,
   pub error: Option<String>,
   pub trace_id: Option<String>,
+  /// Best-effort identity shared by repeated invocations of the same assertion.
+  pub assertion_id: String,
+  pub attempt_count: i64,
+  pub failure_count: i64,
 }
 
 /// A span in a distributed trace.
@@ -234,6 +238,7 @@ pub struct NewEntry {
   pub actual: String,
   pub error: String,
   pub trace_id: String,
+  pub assertion_id: String,
 }
 
 /// Data required to save a new mock interaction.

--- a/tools/stove-cli/src/storage/repository/mod.rs
+++ b/tools/stove-cli/src/storage/repository/mod.rs
@@ -41,6 +41,9 @@ use crate::storage::models::Snapshot;
 use crate::storage::models::Span;
 use crate::storage::models::Test;
 
+const NORMALIZED_ASSERTION_ID_SQL: &str =
+  "CASE WHEN assertion_id = '' THEN 'legacy:' || id ELSE assertion_id END";
+
 pub struct Repository {
   write_db: Arc<Mutex<Database>>,
   read_db: Arc<Mutex<Database>>,
@@ -126,14 +129,11 @@ impl Repository {
 
   pub fn get_entries(&self, run_id: &str, test_id: &str) -> Result<Vec<Entry>> {
     let db = self.lock_read_db();
-    let mut stmt = db.conn().prepare(
+    let sql = format!(
       "WITH correlated AS (
          SELECT id, run_id, test_id, timestamp, system, action, result, input, output,
                 metadata, expected, actual, error, trace_id,
-                CASE
-                  WHEN assertion_id = '' THEN 'legacy:' || id
-                  ELSE assertion_id
-                END AS assertion_id
+                {NORMALIZED_ASSERTION_ID_SQL} AS assertion_id
            FROM entries
           WHERE run_id = ?1 AND test_id = ?2
        ),
@@ -153,8 +153,9 @@ impl Repository {
               attempt_count, failure_count
          FROM ranked
         WHERE attempt_rank = 1
-        ORDER BY timestamp, id",
-    )?;
+        ORDER BY timestamp, id"
+    );
+    let mut stmt = db.conn().prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params![run_id, test_id], entry_from_row)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
   }
@@ -162,19 +163,17 @@ impl Repository {
   /// Return the append-only entry history without assertion correlation.
   pub fn get_raw_entries(&self, run_id: &str, test_id: &str) -> Result<Vec<Entry>> {
     let db = self.lock_read_db();
-    let mut stmt = db.conn().prepare(
+    let sql = format!(
       "SELECT id, run_id, test_id, timestamp, system, action, result, input, output,
               metadata, expected, actual, error, trace_id,
-              CASE
-                WHEN assertion_id = '' THEN 'legacy:' || id
-                ELSE assertion_id
-              END AS assertion_id,
+              {NORMALIZED_ASSERTION_ID_SQL} AS assertion_id,
               1 AS attempt_count,
               CASE WHEN result IN ('FAILED', 'ERROR') THEN 1 ELSE 0 END AS failure_count
          FROM entries
         WHERE run_id = ?1 AND test_id = ?2
-        ORDER BY timestamp, id",
-    )?;
+        ORDER BY timestamp, id"
+    );
+    let mut stmt = db.conn().prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params![run_id, test_id], entry_from_row)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
   }

--- a/tools/stove-cli/src/storage/repository/mod.rs
+++ b/tools/stove-cli/src/storage/repository/mod.rs
@@ -127,8 +127,54 @@ impl Repository {
   pub fn get_entries(&self, run_id: &str, test_id: &str) -> Result<Vec<Entry>> {
     let db = self.lock_read_db();
     let mut stmt = db.conn().prepare(
-            "SELECT id, run_id, test_id, timestamp, system, action, result, input, output, metadata, expected, actual, error, trace_id FROM entries WHERE run_id = ?1 AND test_id = ?2 ORDER BY timestamp",
-        )?;
+      "WITH correlated AS (
+         SELECT id, run_id, test_id, timestamp, system, action, result, input, output,
+                metadata, expected, actual, error, trace_id,
+                CASE
+                  WHEN assertion_id = '' THEN 'legacy:' || id
+                  ELSE assertion_id
+                END AS assertion_id
+           FROM entries
+          WHERE run_id = ?1 AND test_id = ?2
+       ),
+       ranked AS (
+         SELECT *,
+                COUNT(*) OVER (PARTITION BY assertion_id) AS attempt_count,
+                SUM(CASE WHEN result IN ('FAILED', 'ERROR') THEN 1 ELSE 0 END)
+                  OVER (PARTITION BY assertion_id) AS failure_count,
+                ROW_NUMBER() OVER (
+                  PARTITION BY assertion_id
+                  ORDER BY id DESC
+                ) AS attempt_rank
+           FROM correlated
+       )
+       SELECT id, run_id, test_id, timestamp, system, action, result, input, output,
+              metadata, expected, actual, error, trace_id, assertion_id,
+              attempt_count, failure_count
+         FROM ranked
+        WHERE attempt_rank = 1
+        ORDER BY timestamp, id",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![run_id, test_id], entry_from_row)?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+  }
+
+  /// Return the append-only entry history without assertion correlation.
+  pub fn get_raw_entries(&self, run_id: &str, test_id: &str) -> Result<Vec<Entry>> {
+    let db = self.lock_read_db();
+    let mut stmt = db.conn().prepare(
+      "SELECT id, run_id, test_id, timestamp, system, action, result, input, output,
+              metadata, expected, actual, error, trace_id,
+              CASE
+                WHEN assertion_id = '' THEN 'legacy:' || id
+                ELSE assertion_id
+              END AS assertion_id,
+              1 AS attempt_count,
+              CASE WHEN result IN ('FAILED', 'ERROR') THEN 1 ELSE 0 END AS failure_count
+         FROM entries
+        WHERE run_id = ?1 AND test_id = ?2
+        ORDER BY timestamp, id",
+    )?;
     let rows = stmt.query_map(rusqlite::params![run_id, test_id], entry_from_row)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
   }

--- a/tools/stove-cli/src/storage/repository/sql.rs
+++ b/tools/stove-cli/src/storage/repository/sql.rs
@@ -86,6 +86,9 @@ pub(super) fn entry_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Entry>
     actual: row.get(11)?,
     error: row.get(12)?,
     trace_id: row.get(13)?,
+    assertion_id: row.get(14)?,
+    attempt_count: row.get(15)?,
+    failure_count: row.get(16)?,
   })
 }
 

--- a/tools/stove-cli/src/storage/repository/tests.rs
+++ b/tools/stove-cli/src/storage/repository/tests.rs
@@ -58,6 +58,7 @@ fn full_event_lifecycle() {
       actual: String::new(),
       error: String::new(),
       trace_id: String::new(),
+      assertion_id: "assertion-post-products".into(),
     })
     .unwrap();
 
@@ -151,6 +152,9 @@ fn full_event_lifecycle() {
       actual: None,
       error: None,
       trace_id: None,
+      assertion_id: "assertion-post-products".into(),
+      attempt_count: 1,
+      failure_count: 0,
     }]
   );
 
@@ -200,6 +204,67 @@ fn full_event_lifecycle() {
       total_runs: 1,
     }]
   );
+}
+
+#[test]
+fn entries_return_latest_assertion_attempt_with_retry_counts() {
+  let repo = test_repo();
+  repo
+    .save_run_start("run-1", "product-api", "2024-01-01T00:00:00Z", &[])
+    .unwrap();
+  repo
+    .save_test_start(
+      "run-1",
+      "test-1",
+      "eventually creates product",
+      "ProductSpec",
+      &[],
+      "2024-01-01T00:00:01Z",
+    )
+    .unwrap();
+
+  for attempt in 1..=5 {
+    let failed = attempt < 5;
+    repo
+      .save_entry(&NewEntry {
+        run_id: "run-1".into(),
+        test_id: "test-1".into(),
+        timestamp: format!("2024-01-01T00:00:0{}Z", attempt + 1),
+        system: "PostgreSQL".into(),
+        action: "Query".into(),
+        result: if failed { "FAILED" } else { "PASSED" }.into(),
+        input: "select * from products".into(),
+        output: String::new(),
+        metadata: "{}".into(),
+        expected: "one row".into(),
+        actual: if failed { "no rows" } else { "one row" }.into(),
+        error: if failed {
+          format!("not ready on attempt {attempt}")
+        } else {
+          String::new()
+        },
+        trace_id: String::new(),
+        assertion_id: "assertion-query-products".into(),
+      })
+      .unwrap();
+  }
+
+  let raw_entries = repo.get_raw_entries("run-1", "test-1").unwrap();
+  assert_eq!(
+    raw_entries.len(),
+    5,
+    "every attempt must remain available in the audit log"
+  );
+  assert_eq!(raw_entries[0].failure_count, 1);
+  assert_eq!(raw_entries[4].failure_count, 0);
+
+  let entries = repo.get_entries("run-1", "test-1").unwrap();
+  assert_eq!(entries.len(), 1);
+  assert_eq!(entries[0].result, TestStatus::Passed);
+  assert_eq!(entries[0].attempt_count, 5);
+  assert_eq!(entries[0].failure_count, 4);
+  assert_eq!(entries[0].actual.as_deref(), Some("one row"));
+  assert_eq!(entries[0].error, None);
 }
 
 #[test]

--- a/tools/stove-cli/src/storage/repository/writes.rs
+++ b/tools/stove-cli/src/storage/repository/writes.rs
@@ -339,7 +339,7 @@ fn save_test_end_on(
 
 fn save_entry_on(conn: &rusqlite::Connection, entry: &NewEntry) -> Result<()> {
   conn.execute(
-    "INSERT INTO entries (run_id, test_id, timestamp, system, action, result, input, output, metadata, expected, actual, error, trace_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+    "INSERT INTO entries (run_id, test_id, timestamp, system, action, result, input, output, metadata, expected, actual, error, trace_id, assertion_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
     rusqlite::params![
       entry.run_id,
       entry.test_id,
@@ -353,7 +353,8 @@ fn save_entry_on(conn: &rusqlite::Connection, entry: &NewEntry) -> Result<()> {
       non_empty(&entry.expected),
       non_empty(&entry.actual),
       non_empty(&entry.error),
-      non_empty(&entry.trace_id)
+      non_empty(&entry.trace_id),
+      entry.assertion_id
     ],
   )?;
   Ok(())

--- a/tools/stove-cli/tests/api_e2e.rs
+++ b/tools/stove-cli/tests/api_e2e.rs
@@ -917,6 +917,37 @@ async fn get_entries_returns_empty_for_unknown_test() {
   assert_eq!(body, Value::Array(vec![]));
 }
 
+#[tokio::test]
+async fn raw_entries_preserve_attempts_hidden_by_the_correlated_view() {
+  let server = TestServer::start().await;
+  server.seed_run("run-retry", "product-api");
+  server.seed_test(
+    "run-retry",
+    "test-retry",
+    "eventually creates a product",
+    "ProductSpec",
+  );
+  server.seed_entry("run-retry", "test-retry", "PostgreSQL", "Query", "FAILED");
+  server.seed_entry("run-retry", "test-retry", "PostgreSQL", "Query", "PASSED");
+
+  let correlated = server
+    .get_json("/runs/run-retry/tests/test-retry/entries")
+    .await;
+  let correlated = correlated.as_array().unwrap();
+  assert_eq!(correlated.len(), 1);
+  assert_eq!(correlated[0]["result"], "PASSED");
+  assert_eq!(correlated[0]["attempt_count"], 2);
+  assert_eq!(correlated[0]["failure_count"], 1);
+
+  let raw = server
+    .get_json("/runs/run-retry/tests/test-retry/entries/raw")
+    .await;
+  let raw = raw.as_array().unwrap();
+  assert_eq!(raw.len(), 2);
+  assert_eq!(raw[0]["result"], "FAILED");
+  assert_eq!(raw[1]["result"], "PASSED");
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/v1/runs/:run_id/tests/:test_id/spans
 // ---------------------------------------------------------------------------

--- a/tools/stove-cli/tests/common/mod.rs
+++ b/tools/stove-cli/tests/common/mod.rs
@@ -250,6 +250,7 @@ impl TestServer {
         actual: actual.into(),
         error: error.into(),
         trace_id: trace_id.into(),
+        assertion_id: format!("{test_id}\u{0}{system}\u{0}{action}\u{0}{input}\u{0}{expected}"),
       })
       .unwrap();
   }


### PR DESCRIPTION
## What changed

- Keep failed Stove report entries as attempt-level diagnostics while using the test framework's terminal callback as the test result authority.
- Correlate retry sequences in stove-cli with an assertion ID, retain every raw attempt, and return the latest attempt with attempt/failure counts from the regular entries API.
- Add a raw entries endpoint for full evidence history and preserve raw evidence in MCP analysis.
- Reconcile correlated live and persisted entries in the SPA and display retry counts.
- Harden dashboard lifecycle handling against late events, duplicate shutdown, and unfinished tests.
- Align WireMock and gRPC validation action names so successful retry attempts correlate with preceding failures.

## Why

Kotest `eventually { ... }` can invoke the same Stove assertion several times. Earlier failed attempts were treated as both independent dashboard records and terminal test failures, even when a later attempt succeeded and Kotest passed the test.

The reporting protocol does not currently carry a call-site or retry-scope identity, so stove-cli applies best-effort correlation using the test, system, action, and input. Raw attempts remain available for diagnostics.

## Impact

A retry sequence such as four failures followed by a success appears as one successful dashboard assertion with `5 attempts · 4 failed`, while the complete append-only attempt history remains accessible. Exhausted retries still fail when the test framework reports the terminal failure.

## Validation

- JVM pre-commit checks: Spotless, Detekt, and API checks
- Dashboard, WireMock, and gRPC module checks
- Rust formatting, Clippy with warnings denied, unit tests, API E2E tests, and MCP E2E tests
- SPA type checking, Biome, unit tests, and production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added assertion retry tracking for test entries (attempts and failed attempts) across the dashboard UI.
  * Added “Retry history” and attempt/failed stamps in entry and evidence views.
  * Introduced a raw entries API endpoint (`/entries/raw`) to show every attempt; consolidated views now show the latest attempt with aggregated retry counts.
  * Improved live dashboard caching to reconcile repeated assertion attempts correctly.

* **Bug Fixes**
  * Prevented dashboard event handling during shutdown and finalized still-running tests as interrupted with accurate final statuses.
  * Improved retried-test failure/snapshot reporting consistency.
  * Updated gRPC/WireMock validation success messaging for clearer request-matching expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->