### PR TITLE
fix(stove-cli): publish self-contained PostgreSQL binaries

### DIFF
--- a/.github/workflows/stove-cli-next.yml
+++ b/.github/workflows/stove-cli-next.yml
@@ -109,10 +109,13 @@ jobs:
           restore-keys: cargo-release-${{ matrix.target }}-
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --features vendored-postgres --target ${{ matrix.target }}
         env:
           SKIP_SPA_BUILD: "1"
           STOVE_VERSION: ${{ needs.resolve-version.outputs.version }}
+
+      - name: Verify standalone release binary
+        run: ./scripts/verify-release-linkage.sh "target/${{ matrix.target }}/release/stove"
 
       - name: Package tarball
         env:

--- a/.github/workflows/stove-cli-release.yml
+++ b/.github/workflows/stove-cli-release.yml
@@ -101,9 +101,12 @@ jobs:
           restore-keys: cargo-release-${{ matrix.target }}-
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --features vendored-postgres --target ${{ matrix.target }}
         env:
           SKIP_SPA_BUILD: "1"
+
+      - name: Verify standalone release binary
+        run: ./scripts/verify-release-linkage.sh "target/${{ matrix.target }}/release/stove"
 
       - name: Package tarball
         env:

--- a/tools/stove-cli/Cargo.lock
+++ b/tools/stove-cli/Cargo.lock
@@ -1907,6 +1907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1923,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2141,6 +2151,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pq-src"
+version = "0.3.11+libpq-18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb5bfbe0c3445d371dd8acf7d6c912ece8baf2f61f7c571af85a1d7687c2d0f"
+dependencies = [
+ "cc",
+ "openssl-sys",
+]
+
+[[package]]
 name = "pq-sys"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2168,7 @@ checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
 dependencies = [
  "libc",
  "pkg-config",
+ "pq-src",
  "vcpkg",
 ]
 
@@ -2982,8 +3003,10 @@ dependencies = [
  "fallible-iterator 0.2.0",
  "mime_guess",
  "native-tls",
+ "openssl-sys",
  "postgres",
  "postgres-native-tls",
+ "pq-sys",
  "prost",
  "prost-types",
  "refinery",

--- a/tools/stove-cli/Cargo.toml
+++ b/tools/stove-cli/Cargo.toml
@@ -20,6 +20,15 @@ path = "acceptance-tests/cli_acceptance.rs"
 name = "load"
 path = "acceptance-tests/load.rs"
 
+[features]
+default = []
+vendored-postgres = [
+  "dep:openssl-sys",
+  "dep:pq-sys",
+  "openssl-sys/vendored",
+  "pq-sys/bundled",
+]
+
 [dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -39,6 +48,10 @@ tokio-stream = "0.1"
 
 # Database
 diesel = { version = "2.3", default-features = false, features = ["postgres", "sqlite", "serde_json", "returning_clauses_for_sqlite_3_35", "32-column-tables"] }
+# Publishing enables `vendored-postgres` so release archives do not depend on
+# a system-installed libpq/OpenSSL. Normal development builds stay fast.
+pq-sys = { version = "0.7", default-features = false, optional = true }
+openssl-sys = { version = "0.9", optional = true }
 refinery = { version = "0.9", default-features = false, features = ["postgres", "rusqlite-bundled"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"

--- a/tools/stove-cli/scripts/verify-release-linkage.sh
+++ b/tools/stove-cli/scripts/verify-release-linkage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -eu
+
+BINARY_PATH="${1:?usage: verify-release-linkage.sh <binary>}"
+
+case "$(uname -s)" in
+  Darwin)
+    LINKED_LIBRARIES="$(otool -L "$BINARY_PATH")"
+    ;;
+  Linux)
+    LINKED_LIBRARIES="$(ldd "$BINARY_PATH")"
+    ;;
+  *)
+    echo "Unsupported release verification platform: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+printf '%s\n' "$LINKED_LIBRARIES"
+
+if printf '%s\n' "$LINKED_LIBRARIES" | grep -Eiq '(^|[/[:space:]])lib(pq|ssl|crypto)([.][^/[:space:]]*)?([[:space:]]|$)'; then
+  echo "Release binary depends on a non-system PostgreSQL/OpenSSL library" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- bundle `libpq` and its OpenSSL support into Stove CLI release binaries
- keep PostgreSQL TLS support without requiring Homebrew/system libraries
- reject stable and `next` artifacts that dynamically link `libpq`, `libssl`, or `libcrypto`

## Root cause
Diesel's PostgreSQL feature links through `pq-sys`. The publishing runners did not provide `libpq`, so the Apple ARM link failed with `ld: library 'pq' not found`. Installing `libpq` only in CI would still produce release archives with an undeclared runtime dependency.

## Validation
- `cargo clippy --locked -- -D warnings`
- release build: `aarch64-apple-darwin`
- release build: `x86_64-apple-darwin`
- linkage verification passed for both macOS artifacts
- both binaries execute and report `stove 0.26.0`
- both publishing workflow files parse as valid YAML


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now package PostgreSQL and OpenSSL dependencies within the standalone Stove CLI binary, reducing reliance on libraries installed on the host system.
  * Added automated checks across supported release platforms to detect unintended links to non-system PostgreSQL or OpenSSL libraries.
  * Release binaries are now built with locked dependency versions for more consistent and reproducible results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->