### PR TITLE
fix(deps): pin rusqlite to 0.39.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
   "branchPrefix": "renovate/",
   "packageRules": [
     {
+      "description": "Keep rusqlite at 0.39.0 until refinery-core supports a newer version",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["rusqlite"],
+      "allowedVersions": "=0.39.0"
+    },
+    {
       "allowedVersions": "!/M/",
       "matchPackageNames": [
         "/io.kotest:kotest.*/"

--- a/server/stove-server/Cargo.toml
+++ b/server/stove-server/Cargo.toml
@@ -56,7 +56,7 @@ pq-sys = { version = "0.7", default-features = false, optional = true }
 openssl-sys = { version = "0.9", optional = true }
 refinery = { version = "0.9", default-features = false, features = ["postgres", "rusqlite-bundled"] }
 # Keep this compatible with refinery-core's rusqlite dependency.
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "=0.39.0", features = ["bundled"] }
 postgres = "0.19"
 postgres-native-tls = "0.5"
 native-tls = "0.2"


### PR DESCRIPTION
Pin rusqlite to exactly 0.39.0 in Cargo and Renovate so automated updates cannot reintroduce the SQLite linkage conflict fixed in #1352. Refinery-core 0.9.2 supports rusqlite only through 0.39; revisit the pin when it supports a newer version.

Validation: locked offline dependency resolution confirms the server and Refinery share rusqlite 0.39.0; Renovate configuration validation, Rust formatting, and Clippy with warnings denied all pass. The lockfile is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pinned the `rusqlite` dependency to version 0.39.0.
  - Configured dependency update management to prevent `rusqlite` from being upgraded beyond version 0.39.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->