### PR TITLE
ci: publish rolling snapshot container images

### DIFF
--- a/.github/workflows/gradle-publish-snapshot.yml
+++ b/.github/workflows/gradle-publish-snapshot.yml
@@ -36,11 +36,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Publish the server dev channel (rolling `next` prerelease + `stove-next`
-  # Homebrew formula) versioned to match the Maven snapshot above —
-  # github.run_number inside the called workflow is this run's number.
+  # Homebrew formula, plus a container image) versioned to match the Maven
+  # snapshot above — github.run_number inside the called workflow is this run's number.
   publish-server-next:
     needs: publish
     permissions:
       contents: read
+      packages: write
     uses: ./.github/workflows/stove-server-next.yml
     secrets: inherit

--- a/.github/workflows/stove-server-image.yml
+++ b/.github/workflows/stove-server-image.yml
@@ -15,6 +15,17 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: 'Image version; snapshot versions also update the snapshot tag'
+        required: true
+        type: string
+      publish_latest:
+        description: 'Also move latest (stable semantic versions only)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -35,6 +46,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       stable: ${{ steps.version.outputs.stable }}
+      snapshot: ${{ steps.version.outputs.snapshot }}
       major: ${{ steps.version.outputs.major }}
       major_minor: ${{ steps.version.outputs.major_minor }}
       publish_latest: ${{ steps.version.outputs.publish_latest }}
@@ -48,10 +60,10 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            raw_version="${GITHUB_REF_NAME#v}"
-          elif [[ -n "${INPUT_VERSION}" ]]; then
+          if [[ -n "${INPUT_VERSION}" ]]; then
             raw_version="${INPUT_VERSION#v}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            raw_version="${GITHUB_REF_NAME#v}"
           else
             raw_version="$(sed -n 's/^version=//p' gradle.properties)"
           fi
@@ -62,12 +74,15 @@ jobs:
           fi
 
           stable=false
+          snapshot=false
           major=""
           major_minor=""
           if [[ "${raw_version}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             stable=true
             major="${BASH_REMATCH[1]}"
             major_minor="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          elif [[ "${raw_version}" =~ -[Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt]$ ]]; then
+            snapshot=true
           fi
 
           publish_latest=false
@@ -79,6 +94,7 @@ jobs:
           {
             echo "version=${raw_version}"
             echo "stable=${stable}"
+            echo "snapshot=${snapshot}"
             echo "major=${major}"
             echo "major_minor=${major_minor}"
             echo "publish_latest=${publish_latest}"
@@ -121,6 +137,7 @@ jobs:
             type=raw,value=${{ needs.prepare.outputs.major_minor }},enable=${{ needs.prepare.outputs.stable }}
             type=raw,value=${{ needs.prepare.outputs.major }},enable=${{ needs.prepare.outputs.stable }}
             type=raw,value=latest,enable=${{ needs.prepare.outputs.publish_latest }}
+            type=raw,value=snapshot,enable=${{ needs.prepare.outputs.snapshot }}
           labels: |
             org.opencontainers.image.title=Stove Server
             org.opencontainers.image.description=Dashboard, API, MCP server, and event ingestion for Stove test runs
@@ -215,6 +232,7 @@ jobs:
             type=raw,value=${{ needs.prepare.outputs.major_minor }},enable=${{ needs.prepare.outputs.stable }}
             type=raw,value=${{ needs.prepare.outputs.major }},enable=${{ needs.prepare.outputs.stable }}
             type=raw,value=latest,enable=${{ needs.prepare.outputs.publish_latest }}
+            type=raw,value=snapshot,enable=${{ needs.prepare.outputs.snapshot }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/stove-server-next.yml
+++ b/.github/workflows/stove-server-next.yml
@@ -1,8 +1,9 @@
 name: Stove Server Next
 
 # Publishes the server dev channel: builds binaries versioned like the Maven
-# snapshot, updates the rolling `next` prerelease in place with them, and
-# updates the `stove-next` formula in the Homebrew tap.
+# snapshot, updates the rolling `next` prerelease in place with them,
+# updates the `stove-next` formula in the Homebrew tap, and publishes the
+# matching container image with a rolling `snapshot` tag.
 #
 # The `next` prerelease lives on the tap repo (homebrew-trendyol-tap), not
 # here — Stove's release list stays purely `v*` releases. Everything that
@@ -55,6 +56,15 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Resolved next version: ${VERSION}"
+
+  publish-image:
+    needs: resolve-version
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/stove-server-image.yml
+    with:
+      version: ${{ needs.resolve-version.outputs.version }}
 
   build:
     needs: resolve-version

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ docker run -d --name stove -p 4040:4040 -p 4041:4041 \
 # http://localhost:4040
 ```
 
+Container tags: `ghcr.io/trendyol/stove-server:latest` follows stable releases, while `:snapshot` follows snapshot publications. Each snapshot also has a versioned tag such as `:1.0.0.558-SNAPSHOT` for selecting a specific build.
+
 For shared or multi-pod deployments, use one PostgreSQL database for every replica and load-balance both ports; no session affinity, Redis, or message broker is required. PostgreSQL coordinates ordered, idempotent ingestion, shared retention, and durable cross-pod live updates. Production settings can be mounted as TOML or JSON, with the PostgreSQL URL read from a separate secret file. See the [Dashboard deployment guide](https://trendyol.github.io/stove/Components/18-dashboard/#configuration-files-and-secrets).
 
 For local PostgreSQL development, run `just postgres-up` from `server/stove-server`; the Compose stack builds Stove and starts a persistent PostgreSQL 18 instance. The dedicated `/admin` page includes a native SQLite/PostgreSQL schema browser and SQL workbench running inside the Stove process. It has direct database write access and no built-in authentication, so expose it only on a trusted network.

--- a/docs/Components/18-dashboard.md
+++ b/docs/Components/18-dashboard.md
@@ -114,6 +114,10 @@ CLI arguments and `STOVE_*` environment variables override the configuration fil
 
 The image serves the dashboard, REST API, and MCP on port `4040`, and receives test events over gRPC on port `4041`. It runs as a non-root user and supports Linux AMD64 and ARM64.
 
+Use `ghcr.io/trendyol/stove-server:latest` to follow stable releases or `ghcr.io/trendyol/stove-server:snapshot` to follow development snapshots. Publishing a Maven snapshot also publishes the matching server image with both its versioned tag (for example, `:1.0.0.558-SNAPSHOT`) and `:snapshot`. Snapshot publications never update `:latest`.
+
+Manual container builds whose version ends in `-SNAPSHOT` (case-insensitive) also update `:snapshot`. Other prereleases, such as `0.28.0-beta.1`, receive only their versioned tag. Choose a versioned tag to select a specific build.
+
 For a local or single-host installation, persist SQLite at `/data`:
 
 ```bash


### PR DESCRIPTION
Snapshot publications currently update the Maven artifacts, server binaries, and Homebrew dev channel without publishing a matching container image. This change calls the reusable container workflow from Stove Server Next using the same resolved version. Each snapshot publishes both its versioned image tag (for example, `1.0.0.558-SNAPSHOT`) and the rolling `snapshot` tag.

Manual image builds ending in `-SNAPSHOT` also update `snapshot`, case-insensitively. Stable releases retain the existing `latest`, major, and minor alias behavior; snapshots never enable `latest`. Documentation describes the available tags.

Validation:
- Executed the workflow's version-resolution script for 14 cases covering stable releases, snapshot capitalization, explicit and default versions, tag pushes, other prereleases, and invalid input.
- Verified both image metadata steps gate the snapshot and latest aliases correctly.
- Actionlint passed with its unsupported pre-existing `concurrency.queue` key warning excluded; whitespace checks passed.

No publishing workflow was dispatched during validation. The first snapshot publication after merge will build and publish the new image tags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development snapshot releases now publish matching Dashboard and server container images.
  - Snapshot images are available through both the `snapshot` tag and version-specific tags.
  - Stable releases continue to use the `latest` tag, while prerelease builds retain version-specific tags without updating `latest`.

- **Documentation**
  - Added guidance describing container image tags and how stable, snapshot, and prerelease versions are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->